### PR TITLE
test: cover logged-out onboarding

### DIFF
--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -67,6 +67,13 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('FIRST CONTACT / SETUP REQUIRED')).toBeVisible()
     await expect(page.getByText('Grok CLI is missing or cannot run.')).toBeVisible()
 
+    await fs.writeFile(path.join(grokHome, 'e2e-cli-ready'), 'unauthenticated\n')
+    await page.getByRole('button', { name: /Recheck setup/ }).click()
+
+    await expect(page.getByText('FIRST CONTACT / SETUP REQUIRED')).toBeVisible()
+    await expect(page.getByText('Grok Build e2e')).toBeVisible()
+    await expect(page.getByText('Authentication is required.')).toBeVisible()
+
     await fs.writeFile(path.join(grokHome, 'e2e-cli-ready'), 'ready\n')
     await page.getByRole('button', { name: /Recheck setup/ }).click()
 

--- a/scripts/fake-grok-e2e.mjs
+++ b/scripts/fake-grok-e2e.mjs
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { Readable, Writable } from 'node:stream'
 import * as acp from '@agentclientprotocol/sdk'
 
 const args = process.argv.slice(2)
 const readyMarker = path.join(process.env.GROK_HOME || '', 'e2e-cli-ready')
+const setupMode = existsSync(readyMarker) ? readFileSync(readyMarker, 'utf8').trim() : 'missing'
 
 if (args[0] === 'version') {
-  if (!existsSync(readyMarker)) process.exit(1)
+  if (setupMode === 'missing') process.exit(1)
   console.log('Grok Build e2e')
   process.exit(0)
 }
 
 if (args[0] === 'models') {
-  if (!existsSync(readyMarker)) process.exit(1)
+  if (setupMode !== 'ready') process.exit(1)
   console.log('grok-e2e')
   process.exit(0)
 }

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -71,12 +71,12 @@ try {
   ])
   await fs.writeFile(path.join(installDirectory, 'package.json'), '{"private":true,"type":"module"}\n')
   await fs.writeFile(fakeGrok, `#!/usr/bin/env node
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 const marker = path.join(process.env.GROK_HOME || '', 'package-cli-ready')
-if (!existsSync(marker)) process.exit(1)
-if (process.argv[2] === 'version') console.log('Grok Build package-smoke')
-else if (process.argv[2] === 'models') console.log('grok-package-smoke')
+const mode = existsSync(marker) ? readFileSync(marker, 'utf8').trim() : 'missing'
+if (process.argv[2] === 'version' && mode !== 'missing') console.log('Grok Build package-smoke')
+else if (process.argv[2] === 'models' && mode === 'ready') console.log('grok-package-smoke')
 else process.exit(1)
 `)
   await fs.chmod(fakeGrok, 0o755)
@@ -162,6 +162,18 @@ else process.exit(1)
   ) {
     throw new Error(`unexpected setup diagnostics: ${JSON.stringify(setup)}`)
   }
+  await fs.writeFile(readyMarker, 'unauthenticated\n')
+  const loggedOutResponse = await fetch(`http://127.0.0.1:${port}/api/setup?refresh=1`)
+  const loggedOutSetup = await loggedOutResponse.json()
+  if (
+    !loggedOutResponse.ok
+    || loggedOutSetup.ready
+    || loggedOutSetup.checks?.find((check) => check.id === 'cli')?.state !== 'ready'
+    || loggedOutSetup.checks?.find((check) => check.id === 'auth')?.state !== 'action'
+  ) {
+    throw new Error(`packaged onboarding did not identify logged-out CLI: ${JSON.stringify(loggedOutSetup)}`)
+  }
+
   await fs.writeFile(readyMarker, 'ready\n')
   const readyResponse = await fetch(`http://127.0.0.1:${port}/api/setup?refresh=1`)
   const readySetup = await readyResponse.json()
@@ -201,6 +213,7 @@ else process.exit(1)
   console.log(`✓ Production server   health check passed on ${process.platform}`)
   console.log(`✓ Browser security    CSP and frame protection headers confirmed`)
   console.log(`✓ First-run failure   missing CLI returned actionable diagnostics`)
+  console.log(`✓ First-run logged out installed CLI requested account authentication`)
   console.log(`✓ First-run ready     CLI and account checks transitioned to ready`)
   console.log(`✓ Live registration   new CLI session discovered by the packaged server`)
 } finally {


### PR DESCRIPTION
Adds the missing installed-but-unauthenticated state to the clean package smoke test and Chromium launch journey. Production package contents are unchanged.\n\nVerified locally:\n- npm run test:package\n- npm run test:e2e\n- npm run verify