### PR TITLE
theme: default to Event Horizon

### DIFF
--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -61,6 +61,13 @@ async function registerLiveSession() {
 }
 
 test.describe.serial('public launch path', () => {
+  test('defaults a fresh browser to the Event Horizon theme', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'event-horizon')
+    expect(await page.evaluate(() => localStorage.getItem('grok-ui-theme'))).toBe('event-horizon')
+  })
+
   test('guides a clean installation through missing CLI and ready states', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByRole('heading', { name: /Zero to live/ })).toBeVisible()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,8 @@ const NAV_ITEMS: NavItem[] = [
 
 type ThemeId = 'operator' | 'event-horizon'
 
+const DEFAULT_THEME: ThemeId = 'event-horizon'
+
 const THEMES: Array<{
   id: ThemeId
   name: string
@@ -97,9 +99,10 @@ const THEMES: Array<{
 
 function storedTheme(): ThemeId {
   try {
-    return localStorage.getItem('grok-ui-theme') === 'event-horizon' ? 'event-horizon' : 'operator'
+    const stored = localStorage.getItem('grok-ui-theme')
+    return stored === 'operator' || stored === 'event-horizon' ? stored : DEFAULT_THEME
   } catch {
-    return 'operator'
+    return DEFAULT_THEME
   }
 }
 


### PR DESCRIPTION
## What changed
- make the red Event Horizon visual system the default for fresh browsers
- preserve an explicitly saved Operator or Event Horizon preference
- add a browser test proving the fresh-install default

## Verification
- `npm run verify`
- `npm run test:e2e` (6 journeys passed)