### PR TITLE
release: prepare v0.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ coverage/
 test-results/
 playwright-report/
 .grok-ui/
+
+# Local demo-production project, raw captures, and rendered media.
+videos/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.1 — 2026-07-25
+
+- Made Event Horizon the default visual system for first-time launches.
+- Updated the application, repository artwork, and package assets to use the
+  current red Grok command mark.
+- Added a production browser journey for logged-out onboarding and recovery.
+- Added a sanitized 24-second public demo covering live session arrival,
+  Control, Changes, Overview, Activity, and theme switching.
+
 ## 0.5.0 — 2026-07-24
 
 - Added the installable `grok-ui` executable with browser auto-open, help,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ and move through your complete local history without leaving the browser.
 
 <img src="docs/grok-ui-dashboard.png" width="900" alt="Grok UI Event Horizon dashboard with live runtime telemetry"/>
 
-[**Quickstart**](#quickstart) · [**What it does**](#what-it-does) · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
+[**Watch the 24-second demo**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
+· [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
+· [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 
 </div>
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,13 +19,13 @@ attaches the verified package to a GitHub release.
 
 ## npm publication
 
-The unscoped `grok-ui` package name was available when packaging was added.
-Registry availability must be checked again immediately before the first
-publication:
+The public package is published as
+[`grok-ui`](https://www.npmjs.com/package/grok-ui). Verify the tagged version,
+registry identity, and current authentication immediately before publication:
 
 ```bash
-npm view grok-ui
-npm login
+npm view grok-ui version
+npm whoami
 npm publish
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",


### PR DESCRIPTION
## What changed

- bumps the package and lockfile to 0.5.1
- documents the Event Horizon default, current red command mark, and logged-out onboarding coverage
- links the sanitized 24-second demo from the README
- keeps local demo-production captures and rendered media out of Git history
- updates npm publication guidance for the established public package

## Why

The public npm package was one release behind the branding and default-theme experience shown in the launch demo. This patch aligns the installable artifact, repository onboarding, and release assets before the public announcement.

## Verification

- `npm run verify`
- `npm run test:package`
- `npm audit --omit=dev --audit-level=high`
- release artifact privacy scan: passed
- isolated packaged live registration: passed