### PR TITLE
release: ship Workflow Command Center in v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.7.0 — 2026-07-25
+
+- Added a cross-session Workflow Command Center powered by Grok Build workflow
+  telemetry.
+- Added live run status, objectives, phase progression, agent rosters, budget
+  usage, latest events, result summaries, and parent-workbench navigation.
+- Added run filters and safe Pause, Resume, and Stop controls, with failed-run
+  recovery enabled only when Grok reports a recoverable display handle.
+- Added persisted workflow snapshots with controls disabled after server
+  restarts, and extended Privacy Mode to workflow content.
+- Added controller, workflow-state, workbench, and browser coverage for live
+  workflow behavior and responsive dashboard presentation.
+
 ## 0.6.0 — 2026-07-25
 
 - Added confirmed cancellation states for dashboard-managed Grok turns.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ required.
 
 </td>
 </tr>
+<tr>
+<td colspan="2" valign="top">
+
+**⌁ Cross-session workflow command field**
+
+Grok Build v0.2.112+ workflow updates become one live run field: phase
+progression, agent roster, budget use, failures, results, and safe Pause,
+Resume, or Stop controls. Failed runs expose recovery only when Grok reports
+that the current process can resume them.
+
+</td>
+</tr>
 </table>
 
 ## Architecture
@@ -159,6 +171,27 @@ cancels pending permissions, preserves final tool updates, surfaces a retry when
 Grok does not confirm, and leaves the lane ready to resume. Rename and archive
 actions are local Grok UI overlays; Grok’s own session files are never rewritten.
 
+## Workflow runs
+
+The Runs view listens for Grok’s structured `workflow_updated` notifications on
+UI-managed ACP sessions and aggregates them across the command field. Each run
+can show:
+
+- current status, objective, phase progression, and latest event
+- per-agent state and current work detail
+- active, used, reserved, and total agent allocation
+- pause context and final result summary
+- Pause, Resume, and Stop controls when the run state supports them
+
+Controls use Grok’s documented `/workflow pause|resume|stop <display-name>`
+commands and accept only validated display handles. Persisted snapshots remain
+visible after a dashboard restart, but their controls are disabled because Grok
+only resumes failed or paused workflows inside the process that owns them.
+
+Grok UI intentionally does not scrape the terminal dashboard or imply visibility
+into historical CLI-only workflow runs. A run appears after a UI-managed session
+emits its first workflow update.
+
 ## Themes
 
 Two complete visual systems ship with the dashboard:
@@ -229,6 +262,7 @@ npm run serve     # Serve an existing production build without rebuilding
 ```text
 server/
   grok-controller.ts      ACP lifecycle, prompts, approvals, cancellation
+  workflow-state.ts       workflow notification projection and safe controls
   live-monitor.ts         active process and runtime event projection
   grok-store.ts           historical metadata aggregation
   session-reader.ts       bounded conversation and tool timeline
@@ -237,6 +271,7 @@ server/
   security.ts             local and remote access gate
 src/
   views/ControlView.tsx   command deck and approval queue
+  views/WorkflowsView.tsx cross-session workflow command field
   views/ChangesView.tsx   live repository change workbench
   views/SessionWorkbench.tsx
                             session timeline and operations

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -134,6 +134,44 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('20')).toBeVisible()
   })
 
+  test('surfaces workflow telemetry and recovers a failed run across sessions', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: /Control/ }).click()
+
+    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.getByLabel('WORKSPACE').fill(workspace)
+    await page.getByLabel('INSTRUCTION').fill('Start workflow fixture')
+    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+
+    await page.getByRole('button', { name: /Runs/ }).click()
+    await expect(page.getByRole('heading', { name: /Every run/ })).toBeVisible()
+    await expect(page.getByText('release-check').first()).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Recovery point available')).toBeVisible()
+    await expect(page.getByText('Verify release')).toBeVisible()
+    await expect(page.getByText('Verifier').first()).toBeVisible()
+    await expect(page.getByText('4 / 8')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Resume run' }).click()
+    await expect(page.getByText('Release verified and ready to ship.')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('.workflow-mission-head').getByText('completed')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Resume', exact: true })).toBeDisabled()
+
+    const snapshot = await (await page.request.get('/api/control')).json()
+    expect(snapshot.workflows).toHaveLength(1)
+    expect(snapshot.workflows[0]).toMatchObject({
+      displayName: 'release-check',
+      status: 'completed',
+      agentsUsed: 5,
+      resultSummary: 'Release verified and ready to ship.',
+    })
+
+    await page.getByRole('button', { name: 'Privacy' }).click()
+    const privateBody = await page.locator('body').innerText()
+    expect(privateBody).not.toContain('release-check')
+    expect(privateBody).not.toContain('Ship a verified release')
+    expect(privateBody).not.toContain('Release verified and ready to ship.')
+  })
+
   test('cancels cleanly while a permission decision is pending', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('button', { name: /Control/ }).click()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/scripts/fake-grok-e2e.mjs
+++ b/scripts/fake-grok-e2e.mjs
@@ -44,6 +44,52 @@ function waitForCancellation(sessionId) {
   return new Promise((resolve) => cancelWaiters.set(sessionId, resolve))
 }
 
+async function notifyWorkflow(client, sessionId, status, overrides = {}) {
+  const completed = status === 'completed'
+  const failed = status === 'failed'
+  await client.notify('x.ai/session_notification', {
+    sessionId,
+    update: {
+      sessionUpdate: 'workflow_updated',
+      run_id: 'workflow-run-1',
+      display_name: 'release-check',
+      objective: 'Ship a verified release across every implementation lane.',
+      foreground: false,
+      status,
+      phases: [
+        { id: 'plan', name: 'Plan release', status: 'completed' },
+        { id: 'build', name: 'Build artifact', status: completed ? 'completed' : 'completed' },
+        { id: 'verify', name: 'Verify release', status: completed ? 'completed' : failed ? 'failed' : 'in_progress' },
+      ],
+      current_phase: 'verify',
+      agent_budget: 8,
+      agents_used: completed ? 5 : 4,
+      agents_reserved: 0,
+      agent_usage_incomplete: false,
+      active_agents: status === 'running' ? 1 : 0,
+      current_agent_label: status === 'running' ? 'Verifier' : '',
+      agents: [
+        { id: 'builder', label: 'Builder', status: 'completed', detail: 'Artifact assembled' },
+        {
+          id: 'verifier',
+          label: 'Verifier',
+          status: completed ? 'completed' : failed ? 'failed' : 'running',
+          detail: completed ? 'Release checks passed' : failed ? 'Fixture check failed' : 'Re-running release checks',
+        },
+      ],
+      last_event: completed ? 'workflow_completed' : failed ? 'workflow_failed' : 'workflow_resumed',
+      last_event_detail: completed
+        ? 'All release verification lanes passed.'
+        : failed
+          ? 'Verification lane reported a recoverable failure.'
+          : 'Failed workflow resumed from the verification phase.',
+      last_event_timestamp: new Date().toISOString(),
+      result_summary: completed ? 'Release verified and ready to ship.' : '',
+      ...overrides,
+    },
+  })
+}
+
 const stream = acp.ndJsonStream(
   Writable.toWeb(process.stdout),
   Readable.toWeb(process.stdin),
@@ -79,6 +125,28 @@ const agent = acp.agent({ name: 'grok-e2e' })
         content: { type: 'text', text: 'E2E agent received the command.' },
       },
     })
+    if (instruction.includes('Start workflow fixture')) {
+      await notifyWorkflow(client, params.sessionId, 'failed')
+      return {
+        stopReason: 'end_turn',
+        usage: { inputTokens: 10, outputTokens: 6, totalTokens: 16 },
+      }
+    }
+    if (instruction === '/workflow resume release-check') {
+      await notifyWorkflow(client, params.sessionId, 'running')
+      await notifyWorkflow(client, params.sessionId, 'completed')
+      await client.notify(acp.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'Workflow release-check resumed and completed.' },
+        },
+      })
+      return {
+        stopReason: 'end_turn',
+        usage: { inputTokens: 4, outputTokens: 5, totalTokens: 9 },
+      }
+    }
     if (instruction.includes('long-running cancellation') || instruction.includes('ignored cancellation')) {
       if (instruction.includes('ignored cancellation')) ignoredCancellationSessions.add(params.sessionId)
       await client.notify(acp.methods.client.session.update, {

--- a/server/grok-controller.test.ts
+++ b/server/grok-controller.test.ts
@@ -57,3 +57,42 @@ describe('GrokController cancellation', () => {
     expect(controller.snapshot().sessions[0].error).toContain('did not confirm')
   })
 })
+
+describe('GrokController workflows', () => {
+  it('collects cross-session telemetry and resumes a failed run through Grok', async () => {
+    process.env.GROK_BIN = fakeGrok
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-workflow-'))
+    cleanup.push(workspace)
+    const controller = new GrokController()
+    controllers.push(controller)
+
+    const created = await controller.createSession({
+      cwd: workspace,
+      prompt: 'Start workflow fixture',
+    })
+    await waitFor(() => controller.snapshot().workflows[0]?.status === 'failed', 5_000)
+
+    expect(controller.snapshot().workflows[0]).toMatchObject({
+      id: 'workflow-run-1',
+      sessionId: created.id,
+      displayName: 'release-check',
+      status: 'failed',
+      currentPhase: 'verify',
+      agentBudget: 8,
+      agentsUsed: 4,
+      canResume: true,
+    })
+
+    await waitFor(() => controller.snapshot().sessions[0]?.state === 'idle', 5_000)
+    await controller.controlWorkflow(created.id, 'workflow-run-1', 'resume')
+    await waitFor(() => controller.snapshot().workflows[0]?.status === 'completed', 5_000)
+
+    expect(controller.snapshot().workflows[0]).toMatchObject({
+      status: 'completed',
+      resultSummary: 'Release verified and ready to ship.',
+      agentsUsed: 5,
+      canResume: false,
+    })
+    expect(controller.snapshot().sessions[0]?.lastPrompt).toBe('/workflow resume release-check')
+  })
+})

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -13,9 +13,11 @@ import type {
   ControlSession,
   ControlSnapshot,
   LiveFeedItem,
+  WorkflowControlAction,
 } from './types.js'
 import { SessionStateStore } from './session-state.js'
 import { APP_VERSION } from './app-version.js'
+import { parseWorkflowNotification, workflowControlCommand } from './workflow-state.js'
 
 interface NewControlSession {
   cwd: string
@@ -70,6 +72,7 @@ function sessionSeed(id: string, cwd: string, prompt: string, model = ''): Contr
     costAmount: 0,
     costCurrency: '',
     feed: [],
+    workflows: [],
   }
 }
 
@@ -169,6 +172,9 @@ export class GrokController extends EventEmitter {
       agentVersion: this.agentVersion,
       error: this.error,
       sessions: [...this.sessions.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+      workflows: [...this.sessions.values()]
+        .flatMap((session) => session.workflows)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
       permissions: [...this.permissions.values()]
         .map((item) => item.public)
         .sort((a, b) => a.createdAt.localeCompare(b.createdAt)),
@@ -328,6 +334,31 @@ export class GrokController extends EventEmitter {
     }
   }
 
+  async controlWorkflow(
+    sessionId: string,
+    workflowId: string,
+    action: WorkflowControlAction,
+  ): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error('Managed session was not found.')
+    const workflow = session.workflows.find((item) => item.id === workflowId)
+    if (!workflow) throw new Error('Workflow run was not found.')
+    const allowed = action === 'pause'
+      ? workflow.canPause
+      : action === 'resume'
+        ? workflow.canResume
+        : workflow.canStop
+    if (!allowed) throw new Error(`This workflow cannot ${action} from its current state.`)
+    if (['starting', 'working', 'attention', 'stopping'].includes(session.state)) {
+      throw new Error('Wait for the parent session turn to settle before controlling this workflow.')
+    }
+    await this.promptSession({
+      sessionId,
+      cwd: session.cwd,
+      prompt: workflowControlCommand(action, workflow.controlHandle),
+    })
+  }
+
   resolvePermission(permissionId: string, optionId?: string): boolean {
     const pending = this.permissions.get(permissionId)
     if (!pending) return false
@@ -381,6 +412,9 @@ export class GrokController extends EventEmitter {
           this.requestPermission(params))
         .onNotification(acp.methods.client.session.update, ({ params }) => {
           this.sessionUpdate(params)
+        })
+        .onNotification('x.ai/session_notification', (params: unknown) => params, ({ params }) => {
+          this.workflowUpdate(params)
         })
       const connection = app.connect(stream)
       this.connection = connection
@@ -592,6 +626,25 @@ export class GrokController extends EventEmitter {
       }
     }
     this.sessions.set(params.sessionId, next)
+    this.emitSnapshot()
+  }
+
+  private workflowUpdate(params: unknown) {
+    const initial = parseWorkflowNotification(params)
+    if (!initial) return
+    const session = this.sessions.get(initial.sessionId)
+    if (!session) return
+    const existing = session.workflows.find((workflow) => workflow.id === initial.run.id)
+    const parsed = existing ? parseWorkflowNotification(params, existing) : initial
+    if (!parsed) return
+    const workflows = session.workflows.some((workflow) => workflow.id === parsed.run.id)
+      ? session.workflows.map((workflow) => workflow.id === parsed.run.id ? parsed.run : workflow)
+      : [parsed.run, ...session.workflows]
+    this.sessions.set(session.id, {
+      ...session,
+      updatedAt: parsed.run.updatedAt,
+      workflows: workflows.slice(0, 80),
+    })
     this.emitSnapshot()
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -126,6 +126,19 @@ app.post('/api/control/sessions/:id/cancel', async (request, response) => {
   }
 })
 
+app.post('/api/control/sessions/:sessionId/workflows/:workflowId', async (request, response) => {
+  try {
+    const action = request.body?.action
+    if (action !== 'pause' && action !== 'resume' && action !== 'stop') {
+      throw new Error('Workflow action must be pause, resume, or stop.')
+    }
+    await controller.controlWorkflow(request.params.sessionId, request.params.workflowId, action)
+    response.status(202).json({ accepted: true })
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to control workflow.' })
+  }
+})
+
 app.post('/api/control/permissions/:id', (request, response) => {
   const optionId = typeof request.body?.optionId === 'string' ? request.body.optionId : undefined
   if (!controller.resolvePermission(request.params.id, optionId)) {

--- a/server/session-state.ts
+++ b/server/session-state.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { ControlSession, SessionRow } from './types.js'
+import type { ControlSession, SessionRow, WorkflowRun } from './types.js'
+import { interruptRestoredWorkflow } from './workflow-state.js'
 
 export interface SessionAnnotation {
   title?: string
@@ -54,6 +55,11 @@ function normalizeControlSession(value: unknown): ControlSession | null {
     costAmount: Number(item.costAmount) || 0,
     costCurrency: typeof item.costCurrency === 'string' ? item.costCurrency : '',
     feed: Array.isArray(item.feed) ? item.feed.slice(-120) : [],
+    workflows: Array.isArray(item.workflows)
+      ? item.workflows
+        .filter((workflow) => workflow && typeof workflow === 'object')
+        .map((workflow) => interruptRestoredWorkflow(workflow as WorkflowRun))
+      : [],
   }
 }
 
@@ -116,6 +122,11 @@ export class SessionStateStore {
     return this.state.managedSessions.map((session) => ({
       ...session,
       feed: [...session.feed],
+      workflows: session.workflows.map((workflow) => ({
+        ...workflow,
+        phases: workflow.phases.map((phase) => ({ ...phase })),
+        agents: workflow.agents.map((agent) => ({ ...agent })),
+      })),
     }))
   }
 
@@ -141,6 +152,11 @@ export class SessionStateStore {
     this.state.managedSessions = sessions.map((session) => ({
       ...session,
       feed: session.feed.slice(-120),
+      workflows: session.workflows.map((workflow) => ({
+        ...workflow,
+        phases: workflow.phases.map((phase) => ({ ...phase })),
+        agents: workflow.agents.map((agent) => ({ ...agent })),
+      })),
     }))
     await this.persist()
   }

--- a/server/session-workbench.test.ts
+++ b/server/session-workbench.test.ts
@@ -41,6 +41,33 @@ function managedSession(state: ControlSession['state'] = 'working'): ControlSess
     totalTokens: 200,
     costAmount: 0.02,
     costCurrency: 'USD',
+    workflows: [{
+      id: 'workflow-durable-1',
+      controlHandle: 'durable-run',
+      displayName: 'durable-run',
+      sessionId: 'session-durable-1',
+      objective: 'Complete durable work',
+      foreground: false,
+      status: 'running',
+      phases: [],
+      currentPhase: 'build',
+      agentBudget: 4,
+      agentsUsed: 2,
+      agentsReserved: 0,
+      usageIncomplete: false,
+      activeAgents: 1,
+      currentAgentLabel: 'Builder',
+      agents: [],
+      lastEvent: 'workflow_started',
+      lastEventDetail: '',
+      lastEventAt: '2026-07-24T10:01:00.000Z',
+      pauseMessage: '',
+      resultSummary: '',
+      updatedAt: '2026-07-24T10:01:00.000Z',
+      canPause: true,
+      canResume: false,
+      canStop: true,
+    }],
     feed: [{
       id: 'feed-1',
       type: 'assistant',
@@ -75,6 +102,12 @@ describe('Session workbench state', () => {
       totalTokens: 200,
     })
     expect(second.managedSessions()[0].feed[0].text).toBe('Persistent response')
+    expect(second.managedSessions()[0].workflows[0]).toMatchObject({
+      status: 'interrupted',
+      canPause: false,
+      canResume: false,
+      canStop: false,
+    })
     expect((await fs.stat(path.join(directory, 'state.json'))).mode & 0o777).toBe(0o600)
   })
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -145,6 +145,57 @@ export interface LiveSnapshot {
 
 export type ControlSessionState = 'starting' | 'idle' | 'working' | 'attention' | 'stopping' | 'cancelled' | 'failed'
 export type ControlCancellationStatus = 'none' | 'requested' | 'confirmed' | 'timed_out' | 'failed'
+export type WorkflowRunStatus =
+  | 'running'
+  | 'paused'
+  | 'failed'
+  | 'completed'
+  | 'cancelled'
+  | 'budget-limited'
+  | 'interrupted'
+  | 'unknown'
+export type WorkflowControlAction = 'pause' | 'resume' | 'stop'
+
+export interface WorkflowPhase {
+  id: string
+  label: string
+  status: string
+}
+
+export interface WorkflowAgent {
+  id: string
+  label: string
+  status: string
+  detail: string
+}
+
+export interface WorkflowRun {
+  id: string
+  controlHandle: string
+  displayName: string
+  sessionId: string
+  objective: string
+  foreground: boolean
+  status: WorkflowRunStatus
+  phases: WorkflowPhase[]
+  currentPhase: string
+  agentBudget: number
+  agentsUsed: number
+  agentsReserved: number
+  usageIncomplete: boolean
+  activeAgents: number
+  currentAgentLabel: string
+  agents: WorkflowAgent[]
+  lastEvent: string
+  lastEventDetail: string
+  lastEventAt: string
+  pauseMessage: string
+  resultSummary: string
+  updatedAt: string
+  canPause: boolean
+  canResume: boolean
+  canStop: boolean
+}
 
 export interface ControlSession {
   id: string
@@ -166,6 +217,7 @@ export interface ControlSession {
   costAmount: number
   costCurrency: string
   feed: LiveFeedItem[]
+  workflows: WorkflowRun[]
 }
 
 export interface ControlPermissionOption {
@@ -192,6 +244,7 @@ export interface ControlSnapshot {
   agentVersion: string
   error: string
   sessions: ControlSession[]
+  workflows: WorkflowRun[]
   permissions: ControlPermission[]
 }
 

--- a/server/workflow-state.test.ts
+++ b/server/workflow-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkflowNotification, workflowControlCommand } from './workflow-state.js'
+
+describe('workflow telemetry', () => {
+  it('normalizes Grok snake_case workflow updates and enables failed-run recovery', () => {
+    const parsed = parseWorkflowNotification({
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'workflow_updated',
+        run_id: 'run-1',
+        display_name: 'release-check',
+        objective: 'Verify the release',
+        status: 'failed',
+        phases: [
+          { id: 'plan', name: 'Plan', status: 'completed' },
+          { id: 'verify', name: 'Verify', status: 'failed' },
+        ],
+        current_phase: 'verify',
+        agent_budget: 8,
+        agents_used: 4,
+        active_agents: 0,
+        agents: [{ id: 'agent-1', label: 'Verifier', status: 'failed', detail: 'Check failed' }],
+        last_event: 'workflow_failed',
+        last_event_detail: 'Recoverable verification failure',
+        last_event_timestamp: '2026-07-25T12:00:00.000Z',
+      },
+    })
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.run).toMatchObject({
+      id: 'run-1',
+      controlHandle: 'release-check',
+      displayName: 'release-check',
+      sessionId: 'session-1',
+      status: 'failed',
+      currentPhase: 'verify',
+      agentBudget: 8,
+      agentsUsed: 4,
+      canPause: false,
+      canResume: true,
+      canStop: false,
+    })
+    expect(parsed?.run.phases[1]).toEqual({ id: 'verify', label: 'Verify', status: 'failed' })
+    expect(parsed?.run.agents[0]).toEqual({
+      id: 'agent-1',
+      label: 'Verifier',
+      status: 'failed',
+      detail: 'Check failed',
+    })
+  })
+
+  it('merges partial camelCase updates without losing the run roster', () => {
+    const first = parseWorkflowNotification({
+      session_id: 'session-2',
+      update: {
+        session_update: 'workflow_updated',
+        runId: 'run-2',
+        displayName: 'migration',
+        status: 'running',
+        phases: ['Plan', 'Execute'],
+        agents: ['Planner'],
+      },
+    })
+    const second = parseWorkflowNotification({
+      session_id: 'session-2',
+      update: {
+        session_update: 'workflow_updated',
+        runId: 'run-2',
+        status: 'completed',
+        resultSummary: 'Migration complete',
+      },
+    }, first?.run)
+
+    expect(second?.run).toMatchObject({
+      status: 'completed',
+      displayName: 'migration',
+      resultSummary: 'Migration complete',
+      canPause: false,
+      canResume: false,
+      canStop: false,
+    })
+    expect(second?.run.phases).toHaveLength(2)
+    expect(second?.run.agents).toHaveLength(1)
+  })
+
+  it('ignores unrelated notifications and refuses unsafe command handles', () => {
+    expect(parseWorkflowNotification({
+      sessionId: 'session-1',
+      update: { sessionUpdate: 'agent_message_chunk' },
+    })).toBeNull()
+    expect(workflowControlCommand('resume', 'release-check')).toBe('/workflow resume release-check')
+    expect(() => workflowControlCommand('resume', 'release check; rm -rf')).toThrow('safe control handle')
+  })
+})

--- a/server/workflow-state.ts
+++ b/server/workflow-state.ts
@@ -1,0 +1,193 @@
+import type {
+  WorkflowAgent,
+  WorkflowControlAction,
+  WorkflowPhase,
+  WorkflowRun,
+  WorkflowRunStatus,
+} from './types.js'
+
+type UnknownRecord = Record<string, unknown>
+
+const CONTROL_HANDLE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/
+
+function record(value: unknown): UnknownRecord {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : {}
+}
+
+function text(...values: unknown[]): string {
+  const value = values.find((item) => typeof item === 'string')
+  return typeof value === 'string' ? value : ''
+}
+
+function number(...values: unknown[]): number | undefined {
+  const value = values.find((item) => typeof item === 'number' || typeof item === 'string')
+  if (value === undefined || value === '') return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function boolean(...values: unknown[]): boolean | undefined {
+  const value = values.find((item) => typeof item === 'boolean')
+  return typeof value === 'boolean' ? value : undefined
+}
+
+function normalizeStatus(value: string): WorkflowRunStatus {
+  const normalized = value.toLowerCase().replaceAll('_', '-').replaceAll(' ', '-')
+  if (['running', 'active', 'in-progress', 'started', 'resumed'].includes(normalized)) return 'running'
+  if (['paused', 'pause', 'waiting'].includes(normalized)) return 'paused'
+  if (['failed', 'failure', 'error'].includes(normalized)) return 'failed'
+  if (['completed', 'complete', 'succeeded', 'success', 'done'].includes(normalized)) return 'completed'
+  if (['cancelled', 'canceled', 'stopped', 'stop'].includes(normalized)) return 'cancelled'
+  if (['budget-limited', 'budget-exhausted', 'agent-budget-exceeded'].includes(normalized)) return 'budget-limited'
+  if (['interrupted', 'aborted'].includes(normalized)) return 'interrupted'
+  return 'unknown'
+}
+
+function deriveStatus(update: UnknownRecord, existing?: WorkflowRun): WorkflowRunStatus {
+  const explicit = normalizeStatus(text(
+    update.status,
+    update.state,
+    update.outcome,
+    update.run_status,
+    update.runStatus,
+  ))
+  if (explicit !== 'unknown') return explicit
+
+  const event = text(update.last_event, update.lastEvent, update.event).toLowerCase()
+  if (event.includes('budget')) return 'budget-limited'
+  if (event.includes('fail') || event.includes('error')) return 'failed'
+  if (event.includes('pause')) return 'paused'
+  if (event.includes('complete') || event.includes('success') || event.includes('finish')) return 'completed'
+  if (event.includes('cancel') || event.includes('stop')) return 'cancelled'
+  if (event.includes('resume') || event.includes('start') || event.includes('progress')) return 'running'
+  if (text(update.pause_message, update.pauseMessage)) return 'paused'
+  if (text(update.result_summary, update.resultSummary)) return 'completed'
+  return existing?.status || 'running'
+}
+
+function normalizePhases(value: unknown, existing: WorkflowPhase[]): WorkflowPhase[] {
+  if (!Array.isArray(value)) return existing
+  return value.map((item, index) => {
+    if (typeof item === 'string') {
+      return { id: item || `phase-${index + 1}`, label: item || `Phase ${index + 1}`, status: 'pending' }
+    }
+    const phase = record(item)
+    const label = text(phase.label, phase.name, phase.title, phase.id) || `Phase ${index + 1}`
+    return {
+      id: text(phase.id, phase.phase_id, phase.phaseId, phase.name) || `phase-${index + 1}`,
+      label,
+      status: text(phase.status, phase.state) || 'pending',
+    }
+  })
+}
+
+function normalizeAgents(value: unknown, existing: WorkflowAgent[]): WorkflowAgent[] {
+  if (!Array.isArray(value)) return existing
+  return value.map((item, index) => {
+    if (typeof item === 'string') {
+      return { id: item || `agent-${index + 1}`, label: item || `Agent ${index + 1}`, status: 'unknown', detail: '' }
+    }
+    const agent = record(item)
+    const label = text(agent.label, agent.name, agent.title, agent.id) || `Agent ${index + 1}`
+    return {
+      id: text(agent.id, agent.agent_id, agent.agentId, agent.name) || `agent-${index + 1}`,
+      label,
+      status: text(agent.status, agent.state) || 'unknown',
+      detail: text(agent.detail, agent.message, agent.current_task, agent.currentTask),
+    }
+  })
+}
+
+function controls(status: WorkflowRunStatus, controlHandle: string) {
+  const controllable = CONTROL_HANDLE.test(controlHandle)
+  return {
+    canPause: controllable && status === 'running',
+    canResume: controllable && (status === 'paused' || status === 'failed'),
+    canStop: controllable && (status === 'running' || status === 'paused'),
+  }
+}
+
+export function parseWorkflowNotification(
+  value: unknown,
+  existing?: WorkflowRun,
+): { sessionId: string; run: WorkflowRun } | null {
+  const envelope = record(value)
+  const params = Object.keys(record(envelope.params)).length ? record(envelope.params) : envelope
+  const updateEnvelope = Object.keys(record(params.update)).length ? record(params.update) : params
+  const eventType = text(
+    updateEnvelope.sessionUpdate,
+    updateEnvelope.session_update,
+    updateEnvelope.type,
+    params.sessionUpdate,
+    params.session_update,
+  )
+  if (eventType !== 'workflow_updated') return null
+
+  const nested = record(updateEnvelope.workflow)
+  const update = Object.keys(nested).length ? { ...updateEnvelope, ...nested } : updateEnvelope
+  const sessionId = text(params.sessionId, params.session_id, update.sessionId, update.session_id)
+    || existing?.sessionId
+    || ''
+  const runId = text(update.run_id, update.runId, update.id) || existing?.id || ''
+  if (!sessionId || !runId) return null
+
+  const timestamp = text(update.last_event_timestamp, update.lastEventTimestamp, update.updated_at, update.updatedAt)
+    || new Date().toISOString()
+  const explicitHandle = text(update.display_name, update.displayName, update.control_handle, update.controlHandle)
+  const controlHandle = explicitHandle || existing?.controlHandle || ''
+  const status = deriveStatus(update, existing)
+  const phasesValue = update.phases
+  const agentsValue = update.agents
+  const run: WorkflowRun = {
+    id: runId,
+    controlHandle,
+    displayName: explicitHandle || existing?.displayName || runId,
+    sessionId,
+    objective: text(update.objective) || existing?.objective || '',
+    foreground: boolean(update.foreground) ?? existing?.foreground ?? false,
+    status,
+    phases: normalizePhases(phasesValue, existing?.phases || []),
+    currentPhase: text(update.current_phase, update.currentPhase) || existing?.currentPhase || '',
+    agentBudget: number(update.agent_budget, update.agentBudget) ?? existing?.agentBudget ?? 0,
+    agentsUsed: number(update.agents_used, update.agentsUsed) ?? existing?.agentsUsed ?? 0,
+    agentsReserved: number(update.agents_reserved, update.agentsReserved) ?? existing?.agentsReserved ?? 0,
+    usageIncomplete: boolean(update.agent_usage_incomplete, update.agentUsageIncomplete)
+      ?? existing?.usageIncomplete
+      ?? false,
+    activeAgents: number(update.active_agents, update.activeAgents) ?? existing?.activeAgents ?? 0,
+    currentAgentLabel: text(update.current_agent_label, update.currentAgentLabel)
+      || existing?.currentAgentLabel
+      || '',
+    agents: normalizeAgents(agentsValue, existing?.agents || []),
+    lastEvent: text(update.last_event, update.lastEvent, update.event) || existing?.lastEvent || '',
+    lastEventDetail: text(update.last_event_detail, update.lastEventDetail)
+      || existing?.lastEventDetail
+      || '',
+    lastEventAt: text(update.last_event_timestamp, update.lastEventTimestamp)
+      || existing?.lastEventAt
+      || timestamp,
+    pauseMessage: text(update.pause_message, update.pauseMessage) || existing?.pauseMessage || '',
+    resultSummary: text(update.result_summary, update.resultSummary) || existing?.resultSummary || '',
+    updatedAt: timestamp,
+    ...controls(status, controlHandle),
+  }
+  return { sessionId, run }
+}
+
+export function workflowControlCommand(action: WorkflowControlAction, handle: string): string {
+  if (!['pause', 'resume', 'stop'].includes(action)) throw new Error('Unsupported workflow action.')
+  if (!CONTROL_HANDLE.test(handle)) throw new Error('Workflow does not expose a safe control handle.')
+  return `/workflow ${action} ${handle}`
+}
+
+export function interruptRestoredWorkflow(run: WorkflowRun): WorkflowRun {
+  return {
+    ...run,
+    status: run.status === 'running' || run.status === 'paused' ? 'interrupted' : run.status,
+    canPause: false,
+    canResume: false,
+    canStop: false,
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import {
   TerminalSquare,
   TimerReset,
   ToolCase,
+  Workflow,
   X,
   Zap,
   type LucideIcon,
@@ -50,6 +51,7 @@ import type {
 import { ChangesView } from './views/ChangesView'
 import { ControlView } from './views/ControlView'
 import { SessionWorkbench } from './views/SessionWorkbench'
+import { WorkflowsView } from './views/WorkflowsView'
 import { PrivacyProvider, usePrivacy } from './privacy'
 import packageJson from '../package.json'
 
@@ -64,13 +66,14 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { id: 'live', label: 'Live', eyebrow: 'Runtime', icon: Radio, shortcut: '1' },
   { id: 'control', label: 'Control', eyebrow: 'Operate', icon: Command, shortcut: '2' },
-  { id: 'changes', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '3' },
-  { id: 'overview', label: 'Overview', eyebrow: 'Command', icon: Gauge, shortcut: '4' },
-  { id: 'sessions', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '5' },
-  { id: 'activity', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '6' },
-  { id: 'library', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: '7' },
-  { id: 'memory', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: '8' },
-  { id: 'themes', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '9' },
+  { id: 'runs', label: 'Runs', eyebrow: 'Orchestrate', icon: Workflow, shortcut: '3' },
+  { id: 'changes', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '4' },
+  { id: 'overview', label: 'Overview', eyebrow: 'Command', icon: Gauge, shortcut: '5' },
+  { id: 'sessions', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '6' },
+  { id: 'activity', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '7' },
+  { id: 'library', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: '8' },
+  { id: 'memory', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: '9' },
+  { id: 'themes', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '0' },
 ]
 
 type ThemeId = 'operator' | 'event-horizon'
@@ -363,6 +366,14 @@ function App() {
                 onOpenSession={openSession}
               />
             )}
+            {view === 'runs' && (
+              <WorkflowsView
+                control={control}
+                connected={streamConnected}
+                onRefresh={refreshControl}
+                onOpenSession={openSession}
+              />
+            )}
             {view === 'changes' && (
               <ChangesView
                 data={data}
@@ -455,7 +466,7 @@ function ThemesView({
   return (
     <>
       <PageIntro
-        index="09"
+        index="10"
         eyebrow="Visual systems"
         title={<>Choose your<br /><em>command atmosphere.</em></>}
         description="Switch the entire dashboard aesthetic without changing your data, sessions, or workflow. Your selection stays active on this device."
@@ -546,7 +557,7 @@ function Sidebar({
                 className={`nav-item ${active === item.id ? 'is-active' : ''}`}
                 onClick={() => onNavigate(item.id)}
               >
-                <span className="nav-index">0{item.shortcut}</span>
+                <span className="nav-index">{item.shortcut === '0' ? '10' : `0${item.shortcut}`}</span>
                 <Icon size={17} strokeWidth={1.7} />
                 <span className="nav-copy">
                   <strong>{item.label}</strong>
@@ -1004,7 +1015,7 @@ function Overview({
   return (
     <>
       <PageIntro
-        index="04"
+        index="05"
         eyebrow="Local intelligence"
         title={<>Your Grok,<br /><em>at a glance.</em></>}
         description="A read-only flight recorder for every local Grok Build session, tool run, model, workspace, and durable memory."
@@ -1353,7 +1364,7 @@ function SessionsView({
   return (
     <>
       <PageIntro
-        index="05"
+        index="06"
         eyebrow="Conversation archive"
         title={<>Every run.<br /><em>Nothing buried.</em></>}
         description="Search local session metadata without sending conversation content anywhere."
@@ -1413,7 +1424,7 @@ function ActivityView({ data }: { data: DashboardPayload }) {
   return (
     <>
       <PageIntro
-        index="06"
+        index="07"
         eyebrow="Operational telemetry"
         title={<>The shape of<br /><em>the work.</em></>}
         description="A two-week read on agent velocity, tool intensity, code movement, and friction."
@@ -1507,7 +1518,7 @@ function LibraryView({
   return (
     <>
       <PageIntro
-        index="07"
+        index="08"
         eyebrow="Capability library"
         title={<>What Grok can<br /><em>reach for.</em></>}
         description="The local skills, agent profiles, and marketplace packages shaping every run."
@@ -1546,7 +1557,7 @@ function MemoryView({ data }: { data: DashboardPayload }) {
   return (
     <>
       <PageIntro
-        index="08"
+        index="09"
         eyebrow="Durable recall"
         title={<>Memory without<br /><em>the mystery.</em></>}
         description="A privacy-conscious inventory of Grok’s durable Markdown memory. Content stays on disk and is not rendered here."
@@ -1595,7 +1606,7 @@ function PageIntro({
 }) {
   return (
     <header className="page-intro">
-      <div className="intro-index">{index} / 09</div>
+      <div className="intro-index">{index} / 10</div>
       <div>
         <div className="kicker">{eyebrow}</div>
         <h1>{title}</h1>

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,7 @@ import type {
   SessionWorkbenchData,
   LiveSnapshot,
   SetupStatus,
+  WorkflowControlAction,
   WorkspaceDiff,
   WorkspaceSnapshot,
 } from './types'
@@ -81,6 +82,21 @@ export async function cancelControlSession(sessionId: string): Promise<void> {
   await json(await fetch(`/api/control/sessions/${encodeURIComponent(sessionId)}/cancel`, {
     method: 'POST',
   }), 'Unable to cancel session')
+}
+
+export async function controlWorkflow(
+  sessionId: string,
+  workflowId: string,
+  action: WorkflowControlAction,
+): Promise<void> {
+  await json(await fetch(
+    `/api/control/sessions/${encodeURIComponent(sessionId)}/workflows/${encodeURIComponent(workflowId)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    },
+  ), `Unable to ${action} workflow`)
 }
 
 export async function resolveControlPermission(permissionId: string, optionId?: string): Promise<void> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -6510,3 +6510,763 @@ kbd {
     padding: 18px 20px;
   }
 }
+
+/* Cross-session workflow command field */
+.workflow-summary-strip .live-summary-metric:last-child > strong {
+  font-size: clamp(22px, 2.5vw, 34px);
+}
+
+.workflow-empty {
+  min-height: 330px;
+  display: grid;
+  grid-template-columns: 180px minmax(0, 600px) auto;
+  align-items: center;
+  gap: clamp(28px, 5vw, 70px);
+  padding: clamp(28px, 5vw, 60px);
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(90deg, transparent 49.8%, rgba(255,255,255,.025) 50%, transparent 50.2%),
+    linear-gradient(transparent 49.8%, rgba(255,255,255,.025) 50%, transparent 50.2%),
+    rgba(13,15,12,.74);
+}
+
+.workflow-empty h2 {
+  margin: 13px 0 10px;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: clamp(28px, 3vw, 44px);
+  letter-spacing: -.045em;
+}
+
+.workflow-empty p {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.8;
+}
+
+.workflow-empty code {
+  color: var(--lime);
+}
+
+.workflow-empty small {
+  color: #62665d;
+  font-size: 8px;
+  line-height: 1.6;
+}
+
+.workflow-radar {
+  position: relative;
+  width: 150px;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--lime-soft), transparent 58%);
+}
+
+.workflow-radar::before,
+.workflow-radar::after,
+.workflow-radar span,
+.workflow-radar i,
+.workflow-radar b {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+}
+
+.workflow-radar::before { inset: 21px; border: 1px solid var(--line); }
+.workflow-radar::after { inset: 46px; border: 1px solid var(--line); }
+.workflow-radar span { width: 1px; height: 100%; background: var(--line); border-radius: 0; }
+.workflow-radar span:last-of-type { width: 100%; height: 1px; }
+.workflow-radar i { width: 6px; height: 6px; background: var(--lime); box-shadow: 0 0 18px var(--lime); }
+.workflow-radar b {
+  inset: 5px;
+  border: 1px solid color-mix(in srgb, var(--lime) 35%, transparent);
+  animation: workflow-scan 2.7s ease-out infinite;
+}
+
+@keyframes workflow-scan {
+  from { opacity: .85; transform: scale(.08); }
+  to { opacity: 0; transform: scale(1); }
+}
+
+.workflow-toolbar {
+  min-height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-filter {
+  display: flex;
+  align-items: stretch;
+  align-self: stretch;
+}
+
+.workflow-filter button {
+  min-width: 96px;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  color: var(--muted);
+  border: 0;
+  border-bottom: 1px solid transparent;
+  background: transparent;
+  font-size: 8px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.workflow-filter button:hover,
+.workflow-filter button.is-active {
+  color: var(--paper);
+}
+
+.workflow-filter button.is-active {
+  border-bottom-color: var(--lime);
+  background: linear-gradient(0deg, var(--lime-soft), transparent 75%);
+}
+
+.workflow-filter button span {
+  min-width: 19px;
+  padding: 2px 4px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  font-size: 7px;
+}
+
+.workflow-link-state {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.workflow-link-state i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--coral);
+}
+
+.workflow-link-state.is-live i {
+  background: var(--lime);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--lime) 65%, transparent);
+}
+
+.workflow-console {
+  min-height: 690px;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  border: 1px solid var(--line);
+  background: rgba(10,12,10,.8);
+}
+
+.workflow-run-list {
+  min-width: 0;
+  border-right: 1px solid var(--line);
+  background: rgba(255,255,255,.012);
+}
+
+.workflow-run-list > header {
+  height: 51px;
+  padding: 0 15px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #666a61;
+  border-bottom: 1px solid var(--line);
+  font-size: 8px;
+  letter-spacing: .14em;
+}
+
+.workflow-run-list > div > button {
+  width: 100%;
+  min-height: 92px;
+  padding: 13px 12px;
+  display: grid;
+  grid-template-columns: 26px 26px minmax(0, 1fr);
+  grid-template-rows: 1fr auto;
+  align-items: center;
+  gap: 5px 8px;
+  color: var(--muted);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-left: 2px solid transparent;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.workflow-run-list > div > button:hover {
+  background: rgba(255,255,255,.025);
+}
+
+.workflow-run-list > div > button.is-active {
+  color: var(--paper);
+  border-left-color: var(--lime);
+  background: linear-gradient(90deg, var(--lime-soft), transparent 88%);
+}
+
+.workflow-run-index {
+  color: #555950;
+  font-size: 7px;
+}
+
+.workflow-status-glyph {
+  width: 25px;
+  height: 25px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 50%;
+}
+
+.workflow-status-running,
+.workflow-status-completed { color: var(--lime); }
+.workflow-status-failed,
+.workflow-status-budget-limited { color: #ff8b79; }
+.workflow-status-paused { color: var(--amber); }
+
+.workflow-run-copy {
+  min-width: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.workflow-run-copy strong {
+  overflow: hidden;
+  color: var(--paper);
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 12px;
+  letter-spacing: -.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-run-copy small {
+  overflow: hidden;
+  color: #6d7168;
+  font-size: 7px;
+  line-height: 1.45;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-status-label {
+  grid-column: 2 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 7px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.workflow-mission {
+  min-width: 0;
+  background:
+    linear-gradient(90deg, transparent 49.9%, rgba(255,255,255,.014) 50%, transparent 50.1%) 0 0 / 72px 72px,
+    linear-gradient(transparent 49.9%, rgba(255,255,255,.014) 50%, transparent 50.1%) 0 0 / 72px 72px;
+}
+
+.workflow-mission-head {
+  min-height: 180px;
+  padding: 25px clamp(20px, 3vw, 38px);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 250px);
+  gap: 35px;
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-mission-head > div:first-child > .workflow-status-label {
+  margin-bottom: 13px;
+}
+
+.workflow-mission-head h2 {
+  margin: 0 0 8px;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: clamp(28px, 3.4vw, 49px);
+  line-height: .95;
+  letter-spacing: -.055em;
+}
+
+.workflow-mission-head p {
+  max-width: 670px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1.7;
+}
+
+.workflow-parent {
+  min-width: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 5px;
+  border-left: 1px solid var(--line);
+}
+
+.workflow-parent > span,
+.workflow-phase-panel header span,
+.workflow-agent-panel header span,
+.workflow-event-panel header span,
+.workflow-result > span,
+.workflow-controls > span {
+  color: #676b62;
+  font-size: 7px;
+  letter-spacing: .15em;
+  text-transform: uppercase;
+}
+
+.workflow-parent strong,
+.workflow-parent small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-parent strong { margin-top: 5px; color: var(--paper); font-size: 9px; }
+.workflow-parent small { color: var(--muted); font-size: 7px; }
+
+.workflow-parent button {
+  width: max-content;
+  margin-top: 8px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--lime);
+  border: 0;
+  background: transparent;
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.workflow-recovery {
+  min-height: 82px;
+  padding: 15px clamp(20px, 3vw, 38px);
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  color: #ffb3a7;
+  border-bottom: 1px solid color-mix(in srgb, var(--coral) 28%, transparent);
+  background: linear-gradient(90deg, var(--coral-soft), transparent 75%);
+}
+
+.workflow-recovery > span {
+  width: 31px;
+  height: 31px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--coral) 35%, transparent);
+  border-radius: 50%;
+}
+
+.workflow-recovery strong { color: var(--paper); font-size: 9px; }
+.workflow-recovery p { margin: 4px 0 0; color: #9e817a; font-size: 8px; }
+.workflow-recovery > small { color: #9e817a; font-size: 7px; }
+
+.workflow-primary-action {
+  min-height: 34px;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink);
+  border: 1px solid var(--lime);
+  background: var(--lime);
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.workflow-primary-action:disabled { opacity: .55; cursor: wait; }
+
+.workflow-phase-panel {
+  padding: 23px clamp(20px, 3vw, 38px) 27px;
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-phase-panel > header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.workflow-phase-panel header > div { display: grid; gap: 7px; }
+.workflow-phase-panel header strong { color: var(--paper); font-size: 10px; }
+.workflow-phase-panel header em {
+  color: var(--lime);
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 24px;
+  font-style: normal;
+}
+
+.workflow-progress-track {
+  height: 2px;
+  margin: 14px 0 22px;
+  background: var(--line);
+}
+
+.workflow-progress-track span {
+  display: block;
+  height: 100%;
+  background: var(--lime);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--lime) 42%, transparent);
+  transition: width .3s ease;
+}
+
+.workflow-phase-rail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+}
+
+.workflow-phase {
+  position: relative;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 20px 15px minmax(0, 1fr);
+  align-items: center;
+  gap: 5px;
+}
+
+.workflow-phase > i {
+  color: #5a5e55;
+  font-size: 7px;
+  font-style: normal;
+}
+
+.workflow-phase > span {
+  position: relative;
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  border: 1px solid #555950;
+  border-radius: 50%;
+  background: var(--ink);
+}
+
+.workflow-phase:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 30px;
+  right: -2px;
+  top: 50%;
+  height: 1px;
+  background: var(--line);
+}
+
+.workflow-phase > div {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+  padding: 5px 7px;
+  background: var(--ink);
+}
+
+.workflow-phase strong {
+  overflow: hidden;
+  color: var(--paper);
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-phase small {
+  color: #62665d;
+  font-size: 6px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.workflow-phase-completed > span,
+.workflow-phase-complete > span,
+.workflow-phase-succeeded > span {
+  border-color: var(--lime);
+  background: var(--lime);
+}
+
+.workflow-phase-failed > span {
+  border-color: var(--coral);
+  background: var(--coral);
+}
+
+.workflow-phase-in-progress > span,
+.workflow-phase-running > span {
+  border-color: var(--lime);
+  box-shadow: 0 0 10px var(--lime);
+}
+
+.workflow-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(230px, .7fr);
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-agent-panel {
+  min-width: 0;
+  border-right: 1px solid var(--line);
+}
+
+.workflow-agent-panel > header,
+.workflow-event-panel > header {
+  height: 45px;
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-agent-panel > header > div,
+.workflow-event-panel > header {
+  gap: 8px;
+}
+
+.workflow-agent-panel > header strong { color: var(--muted); font-size: 7px; font-weight: 400; }
+
+.workflow-agent-list > div {
+  min-height: 61px;
+  padding: 10px 17px;
+  display: grid;
+  grid-template-columns: 26px 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.workflow-agent-list > div:last-child { border-bottom: 0; }
+.workflow-agent-index { color: #555950; font-size: 7px; }
+
+.workflow-agent-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #656960;
+}
+
+.workflow-agent-dot.agent-running,
+.workflow-agent-dot.agent-in-progress,
+.workflow-agent-dot.agent-completed { background: var(--lime); }
+.workflow-agent-dot.agent-failed { background: var(--coral); }
+
+.workflow-agent-list > div > span:nth-child(3) {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.workflow-agent-list strong { color: var(--paper); font-size: 8px; }
+.workflow-agent-list small {
+  overflow: hidden;
+  color: #666a61;
+  font-size: 7px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-agent-list em {
+  color: var(--muted);
+  font-size: 6px;
+  font-style: normal;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.workflow-event-panel {
+  min-width: 0;
+  padding-bottom: 17px;
+}
+
+.workflow-event-panel > header {
+  justify-content: flex-start;
+  margin-bottom: 16px;
+}
+
+.workflow-event-panel > strong,
+.workflow-event-panel > p,
+.workflow-event-panel > time,
+.workflow-budget {
+  margin-left: 18px;
+  margin-right: 18px;
+}
+
+.workflow-event-panel > strong {
+  display: block;
+  color: var(--paper);
+  font-size: 9px;
+  text-transform: capitalize;
+}
+
+.workflow-event-panel > p {
+  min-height: 34px;
+  margin-top: 7px;
+  margin-bottom: 7px;
+  color: var(--muted);
+  font-size: 7px;
+  line-height: 1.55;
+}
+
+.workflow-event-panel > time { color: #5f635a; font-size: 7px; }
+
+.workflow-budget {
+  margin-top: 18px;
+  padding-top: 14px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 7px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 7px;
+}
+
+.workflow-budget > strong { color: var(--paper); }
+.workflow-budget > div { grid-column: 1 / -1; height: 2px; background: var(--line); }
+.workflow-budget > div i { display: block; height: 100%; background: var(--lime); }
+.workflow-budget > small { grid-column: 1 / -1; color: var(--amber); font-size: 6px; }
+
+.workflow-muted {
+  margin: 20px;
+  color: var(--muted);
+  font-size: 8px;
+}
+
+.workflow-result {
+  min-height: 62px;
+  padding: 14px clamp(20px, 3vw, 38px);
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(90deg, var(--lime-soft), transparent 65%);
+}
+
+.workflow-result p {
+  margin: 0;
+  color: var(--paper);
+  font-size: 8px;
+  line-height: 1.6;
+}
+
+.workflow-controls {
+  min-height: 64px;
+  padding: 11px clamp(20px, 3vw, 38px);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px 18px;
+}
+
+.workflow-controls > div { display: flex; gap: 7px; }
+
+.workflow-controls button {
+  min-width: 86px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--paper);
+  border: 1px solid var(--line-strong);
+  background: rgba(255,255,255,.025);
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.workflow-controls button:hover:not(:disabled) {
+  color: var(--lime);
+  border-color: var(--lime);
+}
+
+.workflow-controls button.is-danger:hover:not(:disabled) {
+  color: var(--coral);
+  border-color: var(--coral);
+}
+
+.workflow-controls button:disabled {
+  color: #52564e;
+  border-color: var(--line);
+  cursor: not-allowed;
+}
+
+.workflow-controls > p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #ff9f91;
+  font-size: 8px;
+}
+
+.workflow-filter-empty {
+  min-height: 240px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  font-size: 9px;
+}
+
+@media (max-width: 1050px) {
+  .workflow-console { grid-template-columns: 240px minmax(0, 1fr); }
+  .workflow-mission-head { grid-template-columns: 1fr; gap: 18px; }
+  .workflow-parent { padding-left: 0; padding-top: 14px; border-left: 0; border-top: 1px solid var(--line); }
+  .workflow-detail-grid { grid-template-columns: 1fr; }
+  .workflow-agent-panel { border-right: 0; border-bottom: 1px solid var(--line); }
+}
+
+@media (max-width: 900px) {
+  .workflow-empty { grid-template-columns: 130px minmax(0, 1fr); }
+  .workflow-empty > button { grid-column: 2; width: max-content; }
+  .workflow-radar { width: 120px; }
+  .mobile-bottom-nav { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+}
+
+@media (max-width: 680px) {
+  .workflow-summary-strip .live-summary-metric:last-child > strong { font-size: 23px; }
+  .workflow-toolbar { align-items: stretch; flex-direction: column; padding-top: 8px; }
+  .workflow-filter { overflow-x: auto; min-height: 46px; }
+  .workflow-filter button { min-width: 82px; padding: 0 9px; }
+  .workflow-link-state { padding: 0 4px 11px; }
+  .workflow-console { grid-template-columns: 1fr; }
+  .workflow-run-list { border-right: 0; border-bottom: 1px solid var(--line); }
+  .workflow-run-list > div { max-height: 235px; overflow-y: auto; }
+  .workflow-run-list > div > button { min-height: 75px; }
+  .workflow-mission-head { min-height: 0; padding: 22px 18px; }
+  .workflow-recovery { grid-template-columns: 30px minmax(0, 1fr); padding: 15px 18px; }
+  .workflow-recovery > button,
+  .workflow-recovery > small { grid-column: 2; width: max-content; }
+  .workflow-phase-panel { padding: 21px 18px 24px; }
+  .workflow-phase-rail { grid-template-columns: 1fr; gap: 8px; }
+  .workflow-phase:not(:last-child)::after { display: none; }
+  .workflow-agent-list > div { grid-template-columns: 23px 7px minmax(0, 1fr); }
+  .workflow-agent-list em { grid-column: 3; }
+  .workflow-result { grid-template-columns: 1fr; gap: 8px; padding: 16px 18px; }
+  .workflow-controls { grid-template-columns: 1fr; padding: 15px 18px; }
+  .workflow-controls > div { display: grid; grid-template-columns: repeat(3, 1fr); }
+  .workflow-controls button { min-width: 0; }
+  .workflow-empty { grid-template-columns: 1fr; justify-items: start; padding: 28px 20px; }
+  .workflow-empty > button { grid-column: 1; }
+  .workflow-radar { width: 100px; }
+  .mobile-bottom-nav { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+  .mobile-bottom-nav button { min-width: 0; padding-left: 0; padding-right: 0; }
+  .mobile-bottom-nav button svg { width: 15px; }
+  .mobile-bottom-nav button span { font-size: 5px; }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ViewId = 'live' | 'control' | 'changes' | 'overview' | 'sessions' | 'activity' | 'library' | 'memory' | 'themes'
+export type ViewId = 'live' | 'control' | 'runs' | 'changes' | 'overview' | 'sessions' | 'activity' | 'library' | 'memory' | 'themes'
 export type SessionStatus = 'live' | 'recent' | 'idle' | 'attention'
 
 export interface SessionRow {
@@ -146,6 +146,57 @@ export interface LiveSnapshot {
 
 export type ControlSessionState = 'starting' | 'idle' | 'working' | 'attention' | 'stopping' | 'cancelled' | 'failed'
 export type ControlCancellationStatus = 'none' | 'requested' | 'confirmed' | 'timed_out' | 'failed'
+export type WorkflowRunStatus =
+  | 'running'
+  | 'paused'
+  | 'failed'
+  | 'completed'
+  | 'cancelled'
+  | 'budget-limited'
+  | 'interrupted'
+  | 'unknown'
+export type WorkflowControlAction = 'pause' | 'resume' | 'stop'
+
+export interface WorkflowPhase {
+  id: string
+  label: string
+  status: string
+}
+
+export interface WorkflowAgent {
+  id: string
+  label: string
+  status: string
+  detail: string
+}
+
+export interface WorkflowRun {
+  id: string
+  controlHandle: string
+  displayName: string
+  sessionId: string
+  objective: string
+  foreground: boolean
+  status: WorkflowRunStatus
+  phases: WorkflowPhase[]
+  currentPhase: string
+  agentBudget: number
+  agentsUsed: number
+  agentsReserved: number
+  usageIncomplete: boolean
+  activeAgents: number
+  currentAgentLabel: string
+  agents: WorkflowAgent[]
+  lastEvent: string
+  lastEventDetail: string
+  lastEventAt: string
+  pauseMessage: string
+  resultSummary: string
+  updatedAt: string
+  canPause: boolean
+  canResume: boolean
+  canStop: boolean
+}
 
 export interface ControlSession {
   id: string
@@ -167,6 +218,7 @@ export interface ControlSession {
   costAmount: number
   costCurrency: string
   feed: LiveFeedItem[]
+  workflows: WorkflowRun[]
 }
 
 export interface ControlPermissionOption {
@@ -193,6 +245,7 @@ export interface ControlSnapshot {
   agentVersion: string
   error: string
   sessions: ControlSession[]
+  workflows: WorkflowRun[]
   permissions: ControlPermission[]
 }
 

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -92,7 +92,7 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
   return (
     <>
       <section className="page-intro changes-intro">
-        <div className="page-intro-index">03 / 09</div>
+        <div className="page-intro-index">04 / 10</div>
         <div className="page-intro-copy">
           <div className="kicker"><Braces size={14} /> Change surface</div>
           <h1>See the work.<br /><em>Before it lands.</em></h1>

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -165,7 +165,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
   return (
     <>
       <section className="page-intro command-intro">
-        <div className="page-intro-index">02 / 09</div>
+        <div className="page-intro-index">02 / 10</div>
         <div className="page-intro-copy">
           <div className="kicker"><Command size={14} /> Command deck</div>
           <h1>Don’t just watch.<br /><em>Run the room.</em></h1>

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -1,0 +1,360 @@
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  Bot,
+  CheckCircle2,
+  CircleStop,
+  Pause,
+  Play,
+  RefreshCw,
+  RotateCcw,
+  Satellite,
+  Workflow,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { controlWorkflow } from '../api'
+import { usePrivacy } from '../privacy'
+import type {
+  ControlSnapshot,
+  WorkflowControlAction,
+  WorkflowRun,
+  WorkflowRunStatus,
+} from '../types'
+
+type Filter = 'all' | 'active' | 'failed' | 'complete'
+
+function displayStatus(status: WorkflowRunStatus): string {
+  return status === 'budget-limited' ? 'budget limited' : status
+}
+
+function eventTime(input: string): string {
+  if (!input) return 'No event timestamp'
+  const date = new Date(input)
+  if (Number.isNaN(date.getTime())) return input
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function matchesFilter(run: WorkflowRun, filter: Filter): boolean {
+  if (filter === 'active') return run.status === 'running' || run.status === 'paused'
+  if (filter === 'failed') return run.status === 'failed' || run.status === 'budget-limited'
+  if (filter === 'complete') return run.status === 'completed' || run.status === 'cancelled'
+  return true
+}
+
+function phaseProgress(run: WorkflowRun): number {
+  if (!run.phases.length) return run.status === 'completed' ? 100 : 0
+  const finished = run.phases.filter((phase) =>
+    ['completed', 'complete', 'succeeded', 'success', 'done'].includes(phase.status.toLowerCase())).length
+  return Math.round((finished / run.phases.length) * 100)
+}
+
+function runKey(run: WorkflowRun): string {
+  return `${run.sessionId}:${run.id}`
+}
+
+function cssToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9-]+/g, '-')
+}
+
+function statusIcon(status: WorkflowRunStatus) {
+  if (status === 'failed' || status === 'budget-limited') return <AlertTriangle size={15} />
+  if (status === 'completed') return <CheckCircle2 size={15} />
+  if (status === 'paused') return <Pause size={15} />
+  if (status === 'cancelled' || status === 'interrupted') return <CircleStop size={15} />
+  return <Satellite size={15} />
+}
+
+export function WorkflowsView({
+  control,
+  connected,
+  onRefresh,
+  onOpenSession,
+}: {
+  control: ControlSnapshot | null
+  connected: boolean
+  onRefresh: () => Promise<void>
+  onOpenSession: (sessionId: string) => void
+}) {
+  const privacy = usePrivacy()
+  const runs = control?.workflows || []
+  const [filter, setFilter] = useState<Filter>('all')
+  const [selectedId, setSelectedId] = useState(runs[0] ? runKey(runs[0]) : '')
+  const [pendingAction, setPendingAction] = useState<WorkflowControlAction | ''>('')
+  const [error, setError] = useState('')
+
+  const filtered = useMemo(
+    () => runs.filter((run) => matchesFilter(run, filter)),
+    [filter, runs],
+  )
+
+  useEffect(() => {
+    if (!filtered.length) {
+      setSelectedId('')
+      return
+    }
+    if (!filtered.some((run) => runKey(run) === selectedId)) setSelectedId(runKey(filtered[0]))
+  }, [filtered, selectedId])
+
+  const selected = filtered.find((run) => runKey(run) === selectedId) || filtered[0]
+  const session = selected
+    ? control?.sessions.find((item) => item.id === selected.sessionId)
+    : undefined
+  const active = runs.filter((run) => run.status === 'running' || run.status === 'paused').length
+  const failed = runs.filter((run) => run.status === 'failed' || run.status === 'budget-limited').length
+  const agentsActive = runs.reduce((sum, run) => sum + run.activeAgents, 0)
+  const agentsUsed = runs.reduce((sum, run) => sum + run.agentsUsed, 0)
+  const agentBudget = runs.reduce((sum, run) => sum + run.agentBudget, 0)
+
+  const act = async (action: WorkflowControlAction) => {
+    if (!selected) return
+    setPendingAction(action)
+    setError('')
+    try {
+      await controlWorkflow(selected.sessionId, selected.id, action)
+      await onRefresh()
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : `Unable to ${action} workflow.`)
+    } finally {
+      setPendingAction('')
+    }
+  }
+
+  return (
+    <>
+      <header className="page-intro">
+        <div className="intro-index">03 / 10</div>
+        <div>
+          <div className="kicker">Cross-session orchestration</div>
+          <h1>Every run.<br /><em>One command field.</em></h1>
+        </div>
+        <p>Track Grok workflow phases, agent allocation, failures, and recoverable controls across every UI-managed session.</p>
+        <div className="intro-rule"><span /></div>
+      </header>
+
+      <section className="live-summary-strip workflow-summary-strip">
+        <div className={`live-summary-metric ${active ? 'live-tone-lime' : 'live-tone-paper'}`}>
+          <span>Active runs</span><strong>{active}</strong><small>running or paused</small>
+        </div>
+        <div className={`live-summary-metric ${failed ? 'live-tone-coral' : 'live-tone-paper'}`}>
+          <span>Recovery queue</span><strong>{failed}</strong><small>failed or budget limited</small>
+        </div>
+        <div className="live-summary-metric live-tone-paper">
+          <span>Agents live</span><strong>{agentsActive}</strong><small>across managed workflows</small>
+        </div>
+        <div className="live-summary-metric live-tone-paper">
+          <span>Agent budget</span><strong>{agentBudget ? `${agentsUsed}/${agentBudget}` : '—'}</strong>
+          <small>{agentBudget ? `${Math.round((agentsUsed / agentBudget) * 100)}% deployed` : 'waiting for telemetry'}</small>
+        </div>
+      </section>
+
+      {!runs.length ? (
+        <section className="workflow-empty section-gap">
+          <div className="workflow-radar" aria-hidden="true"><span /><span /><i /><b /></div>
+          <div>
+            <div className="kicker">Telemetry channel open</div>
+            <h2>No managed workflow runs yet.</h2>
+            <p>
+              Launch <code>/workflow &lt;name&gt;</code> from a Grok UI-managed session. Grok Build
+              v0.2.112+ runs appear here when their live workflow update arrives.
+            </p>
+            <small>
+              This view does not scrape terminal output or claim historical CLI-only runs it cannot observe.
+            </small>
+          </div>
+          <button className="text-button" type="button" onClick={() => void onRefresh()}>
+            Refresh channel <RefreshCw size={14} />
+          </button>
+        </section>
+      ) : (
+        <>
+          <div className="workflow-toolbar section-gap">
+            <div className="workflow-filter" role="group" aria-label="Workflow status filter">
+              {(['all', 'active', 'failed', 'complete'] as Filter[]).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={filter === item ? 'is-active' : ''}
+                  onClick={() => setFilter(item)}
+                >
+                  {item}
+                  <span>{runs.filter((run) => matchesFilter(run, item)).length}</span>
+                </button>
+              ))}
+            </div>
+            <div className={`workflow-link-state ${connected && control?.connected ? 'is-live' : ''}`}>
+              <i />
+              {connected && control?.connected ? 'Grok workflow stream linked' : 'Workflow stream reconnecting'}
+            </div>
+          </div>
+
+          {selected ? (
+            <section className="workflow-console">
+              <aside className="workflow-run-list">
+                <header>
+                  <span>RUN FIELD / {String(filtered.length).padStart(2, '0')}</span>
+                  <Workflow size={15} />
+                </header>
+                <div>
+                  {filtered.map((run, index) => (
+                    <button
+                      key={`${run.sessionId}:${run.id}`}
+                      type="button"
+                      className={runKey(run) === runKey(selected) ? 'is-active' : ''}
+                      onClick={() => setSelectedId(runKey(run))}
+                    >
+                      <span className="workflow-run-index">R{String(index + 1).padStart(2, '0')}</span>
+                      <span className={`workflow-status-glyph workflow-status-${run.status}`}>
+                        {statusIcon(run.status)}
+                      </span>
+                      <span className="workflow-run-copy">
+                        <strong>{privacy.capability(run.displayName, 'Run')}</strong>
+                        <small>{privacy.content(run.objective || run.lastEventDetail || 'Workflow objective unavailable')}</small>
+                      </span>
+                      <span className={`workflow-status-label workflow-status-${run.status}`}>
+                        {displayStatus(run.status)}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </aside>
+
+              <article className="workflow-mission">
+                <header className="workflow-mission-head">
+                  <div>
+                    <span className={`workflow-status-label workflow-status-${selected.status}`}>
+                      {statusIcon(selected.status)} {displayStatus(selected.status)}
+                    </span>
+                    <h2>{privacy.capability(selected.displayName, 'Run')}</h2>
+                    <p>{privacy.content(selected.objective || 'No workflow objective was reported.')}</p>
+                  </div>
+                  <div className="workflow-parent">
+                    <span>Parent session</span>
+                    <strong>{session ? privacy.sessionTitle(session.title, session.id) : 'Managed session'}</strong>
+                    <small>{session ? privacy.workspace(session.cwd) : privacy.identifier(selected.sessionId)}</small>
+                    <button type="button" onClick={() => onOpenSession(selected.sessionId)}>
+                      Open workbench <ArrowUpRight size={13} />
+                    </button>
+                  </div>
+                </header>
+
+                {(selected.status === 'failed' || selected.status === 'budget-limited') && (
+                  <div className="workflow-recovery">
+                    <span><RotateCcw size={17} /></span>
+                    <div>
+                      <strong>{selected.status === 'failed' ? 'Recovery point available' : 'Agent budget exhausted'}</strong>
+                      <p>{privacy.content(selected.lastEventDetail || selected.pauseMessage || 'The run stopped before completion.')}</p>
+                    </div>
+                    {selected.canResume ? (
+                      <button
+                        className="workflow-primary-action"
+                        type="button"
+                        disabled={Boolean(pendingAction)}
+                        onClick={() => void act('resume')}
+                      >
+                        <Play size={14} fill="currentColor" />
+                        {pendingAction === 'resume' ? 'Resuming…' : 'Resume run'}
+                      </button>
+                    ) : <small>Resume is unavailable for this run state.</small>}
+                  </div>
+                )}
+
+                <section className="workflow-phase-panel">
+                  <header>
+                    <div>
+                      <span>PHASE PROGRESSION</span>
+                      <strong>{selected.currentPhase || 'Awaiting phase signal'}</strong>
+                    </div>
+                    <em>{phaseProgress(selected)}%</em>
+                  </header>
+                  <div className="workflow-progress-track">
+                    <span style={{ width: `${phaseProgress(selected)}%` }} />
+                  </div>
+                  {selected.phases.length ? (
+                    <div className="workflow-phase-rail">
+                      {selected.phases.map((phase, index) => (
+                        <div className={`workflow-phase workflow-phase-${cssToken(phase.status)}`} key={phase.id}>
+                          <i>{String(index + 1).padStart(2, '0')}</i>
+                          <span />
+                          <div><strong>{phase.label}</strong><small>{phase.status.replaceAll('_', ' ')}</small></div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : <p className="workflow-muted">Grok has not reported a phase roster for this run.</p>}
+                </section>
+
+                <div className="workflow-detail-grid">
+                  <section className="workflow-agent-panel">
+                    <header>
+                      <div><Bot size={15} /><span>AGENT ROSTER</span></div>
+                      <strong>{selected.activeAgents} active / {selected.agentsUsed} used</strong>
+                    </header>
+                    {selected.agents.length ? (
+                      <div className="workflow-agent-list">
+                        {selected.agents.map((agent, index) => (
+                          <div key={agent.id}>
+                            <span className="workflow-agent-index">A{String(index + 1).padStart(2, '0')}</span>
+                            <i className={`workflow-agent-dot agent-${cssToken(agent.status)}`} />
+                            <span>
+                              <strong>{privacy.capability(agent.label, 'Agent')}</strong>
+                              <small>{privacy.content(agent.detail || 'No current detail')}</small>
+                            </span>
+                            <em>{agent.status.replaceAll('_', ' ')}</em>
+                          </div>
+                        ))}
+                      </div>
+                    ) : <p className="workflow-muted">No per-agent roster was included in the latest update.</p>}
+                  </section>
+
+                  <section className="workflow-event-panel">
+                    <header><Satellite size={15} /><span>LATEST EVENT</span></header>
+                    <strong>{selected.lastEvent ? selected.lastEvent.replaceAll('_', ' ') : 'workflow update'}</strong>
+                    <p>{privacy.content(selected.lastEventDetail || selected.pauseMessage || 'No event detail was reported.')}</p>
+                    <time>{eventTime(selected.lastEventAt || selected.updatedAt)}</time>
+                    <div className="workflow-budget">
+                      <span>Agent budget</span>
+                      <strong>{selected.agentsUsed} / {selected.agentBudget || '—'}</strong>
+                      <div><i style={{ width: `${selected.agentBudget ? Math.min(100, (selected.agentsUsed / selected.agentBudget) * 100) : 0}%` }} /></div>
+                      {selected.usageIncomplete && <small>Usage total is still settling.</small>}
+                    </div>
+                  </section>
+                </div>
+
+                {selected.resultSummary && (
+                  <section className="workflow-result">
+                    <span>RESULT SUMMARY</span>
+                    <p>{privacy.content(selected.resultSummary)}</p>
+                  </section>
+                )}
+
+                <footer className="workflow-controls">
+                  <span>Run controls</span>
+                  <div>
+                    <button type="button" disabled={!selected.canPause || Boolean(pendingAction)} onClick={() => void act('pause')}>
+                      <Pause size={14} /> {pendingAction === 'pause' ? 'Pausing…' : 'Pause'}
+                    </button>
+                    <button type="button" disabled={!selected.canResume || Boolean(pendingAction)} onClick={() => void act('resume')}>
+                      <Play size={14} /> {pendingAction === 'resume' ? 'Resuming…' : 'Resume'}
+                    </button>
+                    <button className="is-danger" type="button" disabled={!selected.canStop || Boolean(pendingAction)} onClick={() => void act('stop')}>
+                      <CircleStop size={14} /> {pendingAction === 'stop' ? 'Stopping…' : 'Stop'}
+                    </button>
+                  </div>
+                  {error && <p role="alert">{error}</p>}
+                </footer>
+              </article>
+            </section>
+          ) : (
+            <section className="workflow-filter-empty">
+              No workflow runs match this filter.
+            </section>
+          )}
+        </>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add the cross-session Workflow Command Center powered by Grok Build workflow telemetry
- expose run phases, agents, budgets, events, results, filters, and safe workflow controls
- preserve workflow snapshots across restarts and extend Privacy Mode coverage
- prepare the package and changelog for v0.7.0

## Validation
- npm run verify
- npm run test:e2e (9 passed)
- npm run test:package
- npm audit --omit=dev --audit-level=high

## Privacy checklist
- workflow content is covered by Privacy Mode
- persisted snapshots disable controls after restart
- release package privacy scan passed