### PR TITLE
docs: add v0.7.0 Workflow Command Center demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ and move through your complete local history without leaving the browser.
 
 <img src="docs/grok-ui-dashboard.png" width="900" alt="Grok UI Event Horizon dashboard with live runtime telemetry"/>
 
-[**Watch the 24-second demo**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
+[**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
+· [**See what’s new in v0.7.0**](https://github.com/joeynyc/Grok-UI/releases/download/v0.7.0/grok-ui-v0.7.0-workflow-command-center-update.mp4)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 


### PR DESCRIPTION
## Summary
- add the 24-second v0.7.0 Workflow Command Center update video to the README
- keep the existing product tour available alongside the release-specific demo

## Video
- sanitized workflow data only
- 1920x1080 H.264/AAC MP4
- published as a v0.7.0 GitHub release asset
- covers workflow launch, phase and agent visibility, agent budget, safe recovery, and result summary