### PR TITLE
docs: open architecture diagram as image on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ that the current process can resume them.
 ## Architecture
 
 <div align="center">
+<a href="https://raw.githubusercontent.com/joeynyc/Grok-UI/main/docs/architecture.svg">
 <img src="docs/architecture.svg" width="820" alt="Browser connected to Grok UI server, local Grok state, ACP agent, and Git workspaces"/>
+</a>
 </div>
 
 Grok UI runs as one local Express supervisor. The browser receives runtime,


### PR DESCRIPTION
## Summary
- wrap the architecture diagram with an explicit raw-image link
- keep the existing inline README rendering unchanged
- ensure tapping the SVG on mobile opens rendered artwork instead of the repository source view

## Verification
- raw target responds with `Content-Type: image/svg+xml`
- README diff check passed