### PR TITLE
release: improve dashboard legibility in v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.1 — 2026-07-25
+
+- Replaced scattered 5–10px dashboard typography with a consistent readable
+  scale for micro-labels, metadata, body copy, and controls.
+- Improved supporting-text contrast in both Operator and Event Horizon themes
+  while preserving intentionally dim disabled states.
+- Reworked the 390px bottom navigation into a readable horizontal command rail
+  instead of compressing nine labels into colliding fixed columns.
+- Added browser coverage that audits visible supporting text across all ten
+  dashboard sections and the mobile viewport.
+
 ## 0.8.0 — 2026-07-25
 
 - Added real per-agent workflow token usage from Grok Build’s structured

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and move through your complete local history without leaving the browser.
 <img src="docs/grok-ui-dashboard.png" width="900" alt="Grok UI Event Horizon dashboard with live runtime telemetry"/>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.8.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.8.0)
+· [**See what’s new in v0.8.1**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.8.1)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -7,6 +7,29 @@ const fixtureRoot = path.join(os.tmpdir(), 'grok-ui-e2e')
 const grokHome = path.join(fixtureRoot, 'grok-home')
 const workspace = path.join(fixtureRoot, 'secret-client')
 const sessionId = 'live-e2e-session'
+
+async function unreadableVisibleText(page: Page, minimumPx = 8) {
+  return page.locator('body *').evaluateAll((elements, minimum) => elements
+    .filter((element) => {
+      const hasDirectText = [...element.childNodes].some((node) =>
+        node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim()))
+      if (!hasDirectText) return false
+      const style = getComputedStyle(element)
+      const bounds = element.getBoundingClientRect()
+      return style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && Number(style.opacity) > 0
+        && bounds.width > 0
+        && bounds.height > 0
+        && Number.parseFloat(style.fontSize) < minimum
+    })
+    .map((element) => ({
+      element: element.tagName.toLowerCase(),
+      className: element.className,
+      text: element.textContent?.trim().slice(0, 80),
+      fontSize: getComputedStyle(element).fontSize,
+    })), minimumPx)
+}
 
 async function registerLiveSession() {
   const sessionDirectory = path.join(grokHome, 'sessions', 'e2e-workspace', sessionId)
@@ -267,5 +290,27 @@ test.describe.serial('public launch path', () => {
       clientWidth: document.documentElement.clientWidth,
     }))
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth)
+    expect(await unreadableVisibleText(page)).toEqual([])
+  })
+
+  test('keeps supporting text readable across every dashboard section', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 })
+    await page.goto('/')
+
+    for (const section of [
+      'Live',
+      'Control',
+      'Runs',
+      'Changes',
+      'Overview',
+      'Sessions',
+      'Activity',
+      'Library',
+      'Memory',
+      'Themes',
+    ]) {
+      await page.getByRole('button', { name: new RegExp(section, 'i') }).first().click()
+      expect(await unreadableVisibleText(page), `${section} contains text below 8px`).toEqual([])
+    }
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,7 +9,8 @@
   --surface-2: #141612;
   --surface-3: #1a1d17;
   --paper: #eeeee8;
-  --muted: #898d82;
+  --muted: #a1a69a;
+  --muted-dim: #777d72;
   --line: rgba(238, 238, 232, 0.13);
   --line-strong: rgba(238, 238, 232, 0.28);
   --lime: #d9ff43;
@@ -17,6 +18,11 @@
   --coral: #ff654f;
   --coral-soft: rgba(255, 101, 79, 0.12);
   --amber: #ffca57;
+  --type-micro: 8px;
+  --type-label: 9px;
+  --type-meta: 10px;
+  --type-body: 11px;
+  --type-control: 12px;
   --sidebar: 236px;
   --topbar: 64px;
 }
@@ -139,7 +145,7 @@ select:focus-visible {
   max-width: 620px;
   margin: 0 0 12px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.8;
 }
 
@@ -166,7 +172,8 @@ html[data-theme='event-horizon'] {
   --surface-2: #0b111c;
   --surface-3: #111927;
   --paper: #f4f6fa;
-  --muted: #8f9aaa;
+  --muted: #aab5c4;
+  --muted-dim: #788596;
   --line: rgba(185, 213, 241, .14);
   --line-strong: rgba(205, 227, 249, .3);
   --lime: #ff493d;
@@ -359,7 +366,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 .brand-sub {
   margin-top: 5px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   letter-spacing: .17em;
   text-transform: uppercase;
 }
@@ -374,7 +381,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 .panel-index,
 .intro-index {
   color: #64685f;
-  font-size: 9px;
+  font-size: var(--type-body);
   letter-spacing: .18em;
   text-transform: uppercase;
 }
@@ -418,8 +425,8 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 }
 
 .nav-index {
-  color: #51554d;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
 }
 
 .nav-item.is-active .nav-index,
@@ -439,7 +446,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 }
 
 .nav-copy small {
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -469,7 +476,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 10px;
+  font-size: var(--type-control);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
@@ -497,8 +504,8 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 .sidebar-foot {
   display: flex;
   justify-content: space-between;
-  color: #696d64;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   letter-spacing: .1em;
 }
 
@@ -538,13 +545,13 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
   display: flex;
   align-items: center;
   min-width: 0;
-  font-size: 10px;
+  font-size: var(--type-control);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
 
 .topbar-path {
-  color: #686c63;
+  color: var(--muted-dim);
   margin-right: 8px;
 }
 
@@ -568,13 +575,13 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
   gap: 8px;
   padding-right: 14px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
 
 .sync-time {
-  color: #55584f;
+  color: var(--muted-dim);
 }
 
 .command-trigger {
@@ -596,7 +603,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 
 .command-trigger span {
   margin-right: auto;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 kbd {
@@ -605,7 +612,7 @@ kbd {
   color: #7d8177;
   border: 1px solid var(--line);
   background: #121410;
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-align: center;
   box-shadow: inset 0 -1px 0 rgba(255,255,255,.08);
 }
@@ -674,7 +681,7 @@ kbd {
   align-items: center;
   gap: 7px;
   color: var(--lime);
-  font-size: 9px;
+  font-size: var(--type-body);
   letter-spacing: .18em;
   text-transform: uppercase;
 }
@@ -741,7 +748,7 @@ kbd {
 
 .live-summary-metric > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .1em;
   text-transform: uppercase;
 }
@@ -756,8 +763,8 @@ kbd {
 
 .live-summary-metric > small {
   align-self: end;
-  color: #62665d;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .live-tone-lime > strong { color: var(--lime); }
@@ -786,9 +793,9 @@ kbd {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: #666a61;
+  color: var(--muted-dim);
   border-bottom: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .1em;
   text-transform: uppercase;
 }
@@ -841,8 +848,8 @@ kbd {
 }
 
 .agent-number {
-  color: #565a52;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .agent-roster-copy {
@@ -854,7 +861,7 @@ kbd {
 .agent-roster-copy strong {
   overflow: hidden;
   font-family: 'Syne Variable', sans-serif;
-  font-size: 10px;
+  font-size: var(--type-control);
   font-weight: 540;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -862,8 +869,8 @@ kbd {
 
 .agent-roster-copy small {
   overflow: hidden;
-  color: #666a61;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -919,9 +926,9 @@ kbd {
   padding: 14px;
   display: grid;
   gap: 5px;
-  color: #575b53;
+  color: var(--muted-dim);
   border-top: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .roster-foot strong {
@@ -963,7 +970,7 @@ kbd {
 
 .runtime-identity span {
   color: var(--lime);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .08em;
   text-transform: uppercase;
 }
@@ -992,7 +999,7 @@ kbd {
   gap: 7px;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -1043,15 +1050,15 @@ kbd {
 }
 
 .runtime-instruments span {
-  color: #61655c;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
 .runtime-instruments strong {
   overflow: hidden;
   color: #b5b8ae;
-  font-size: 9px;
+  font-size: var(--type-body);
   font-weight: 450;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -1068,10 +1075,10 @@ kbd {
   display: flex;
   align-items: center;
   gap: 9px;
-  color: #696d64;
+  color: var(--muted-dim);
   border-bottom: 1px solid rgba(217,255,67,.15);
   background: rgba(217,255,67,.035);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .08em;
 }
 
@@ -1118,8 +1125,8 @@ kbd {
 
 .feed-sequence {
   padding-top: 2px;
-  color: #4f534c;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .feed-rail {
@@ -1175,7 +1182,7 @@ kbd {
 
 .feed-content header > span {
   color: var(--lime);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .1em;
 }
 
@@ -1186,7 +1193,7 @@ kbd {
 .feed-content header strong {
   overflow: hidden;
   color: #b6b9af;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 450;
   text-overflow: ellipsis;
   text-transform: uppercase;
@@ -1195,8 +1202,8 @@ kbd {
 
 .feed-content time {
   margin-left: auto;
-  color: #51554e;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   white-space: nowrap;
 }
 
@@ -1204,7 +1211,7 @@ kbd {
   padding: 2px 4px;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 6px;
+  font-size: var(--type-micro);
   font-style: normal;
   text-transform: uppercase;
 }
@@ -1222,7 +1229,7 @@ kbd {
 .feed-content p {
   margin: 7px 0 0;
   color: #9da096;
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.65;
   white-space: pre-wrap;
   word-break: break-word;
@@ -1235,7 +1242,7 @@ kbd {
 
 .feed-tool .feed-content p {
   color: #7d8177;
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .no-live-agent {
@@ -1260,7 +1267,7 @@ kbd {
   max-width: 590px;
   margin: 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.7;
 }
 
@@ -1273,7 +1280,7 @@ kbd {
   padding: 9px 30px;
   border: 1px solid rgba(217,255,67,.3);
   background: var(--lime-soft);
-  font-size: 10px;
+  font-size: var(--type-control);
 }
 
 .idle-radar {
@@ -1370,7 +1377,7 @@ kbd {
 
 .hero-label {
   color: var(--lime);
-  font-size: 10px;
+  font-size: var(--type-control);
   letter-spacing: .2em;
 }
 
@@ -1401,7 +1408,7 @@ kbd {
 
 .system-readouts span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-transform: uppercase;
 }
 
@@ -1479,7 +1486,7 @@ kbd {
 .orbit-center small {
   margin-top: -3px;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .1em;
 }
 
@@ -1503,8 +1510,8 @@ kbd {
   display: flex;
   justify-content: space-between;
   gap: 20px;
-  color: #62665d;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   letter-spacing: .08em;
   text-transform: uppercase;
 }
@@ -1557,8 +1564,8 @@ kbd {
 .metric-card-top {
   display: flex;
   justify-content: space-between;
-  color: #5f635a;
-  font-size: 9px;
+  color: var(--muted-dim);
+  font-size: var(--type-body);
 }
 
 .tone-lime .metric-card-top svg,
@@ -1574,7 +1581,7 @@ kbd {
 .metric-label {
   margin-bottom: 6px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   letter-spacing: .1em;
   text-transform: uppercase;
 }
@@ -1587,8 +1594,8 @@ kbd {
 
 .metric-detail {
   margin-top: 8px;
-  color: #6c7067;
-  font-size: 9px;
+  color: var(--muted-dim);
+  font-size: var(--type-body);
 }
 
 .metric-rule {
@@ -1609,7 +1616,7 @@ kbd {
 
 .tone-lime .metric-rule { color: var(--lime); }
 .tone-coral .metric-rule { color: var(--coral); }
-.tone-paper .metric-rule { color: #55594f; }
+.tone-paper .metric-rule { color: var(--muted-dim); }
 
 .section-gap {
   margin-top: 10px;
@@ -1767,7 +1774,7 @@ kbd {
 
 .theme-card-index,
 .theme-card-eyebrow {
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .16em;
   text-transform: uppercase;
 }
@@ -1776,7 +1783,7 @@ kbd {
   position: absolute;
   right: 28px;
   top: 29px;
-  color: #60665c;
+  color: var(--muted-dim);
 }
 
 .theme-card-eyebrow {
@@ -1795,7 +1802,7 @@ kbd {
   max-width: 460px;
   margin-top: 17px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.7;
 }
 
@@ -1808,7 +1815,7 @@ kbd {
   gap: 8px;
   color: var(--muted);
   border-top: 1px solid var(--line);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -1830,14 +1837,14 @@ kbd {
 
 .theme-note span {
   color: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .16em;
 }
 
 .theme-note p {
   margin: 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.65;
 }
 
@@ -1879,8 +1886,8 @@ kbd {
 }
 
 .panel-meta {
-  color: #666a61;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
@@ -1893,7 +1900,7 @@ kbd {
   color: var(--muted);
   border: 0;
   background: none;
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -1930,7 +1937,7 @@ kbd {
 
 .chart-summary span {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .08em;
   text-transform: uppercase;
 }
@@ -1952,8 +1959,8 @@ kbd {
   grid-template-rows: 1fr 20px;
   align-items: end;
   gap: 5px;
-  color: #60645b;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-align: center;
   text-transform: uppercase;
 }
@@ -1986,8 +1993,8 @@ kbd {
   margin-top: 12px;
   display: flex;
   gap: 18px;
-  color: #656960;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -2018,8 +2025,8 @@ kbd {
 }
 
 .rank-number {
-  color: #50544c;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
 }
 
 .rank-main {
@@ -2031,7 +2038,7 @@ kbd {
   display: flex;
   justify-content: space-between;
   min-width: 0;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .rank-copy strong {
@@ -2115,8 +2122,8 @@ kbd {
 .session-copy span,
 .session-metrics,
 .session-row time {
-  color: #686c63;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
 }
 
 .session-metrics {
@@ -2204,7 +2211,7 @@ kbd {
   grid-template-columns: 7px 1fr auto;
   align-items: center;
   gap: 8px;
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .model-dot {
@@ -2235,7 +2242,7 @@ kbd {
   align-items: center;
   gap: 5px;
   border-bottom: 1px solid rgba(255,255,255,.055);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workspace-list > div:last-child {
@@ -2244,7 +2251,7 @@ kbd {
 
 .workspace-index,
 .workspace-list > div > span:last-child {
-  color: #62665d;
+  color: var(--muted-dim);
 }
 
 .workspace-list strong {
@@ -2296,11 +2303,11 @@ kbd {
   border: 0;
   outline: 0;
   background: transparent;
-  font-size: 10px;
+  font-size: var(--type-control);
 }
 
 .search-field input::placeholder {
-  color: #555950;
+  color: var(--muted-dim);
 }
 
 .search-field button {
@@ -2329,7 +2336,7 @@ kbd {
 
 .toolbar-stat span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .data-table-wrap {
@@ -2348,9 +2355,9 @@ kbd {
 .session-table-head {
   min-height: 42px;
   padding: 0 16px;
-  color: #5d6158;
+  color: var(--muted-dim);
   border-bottom: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-transform: uppercase;
   letter-spacing: .08em;
 }
@@ -2365,7 +2372,7 @@ kbd {
   background: transparent;
   text-align: left;
   cursor: pointer;
-  font-size: 9px;
+  font-size: var(--type-body);
   transition: background .15s;
 }
 
@@ -2391,8 +2398,8 @@ kbd {
 }
 
 .session-table-row small {
-  color: #5e6259;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -2439,7 +2446,7 @@ kbd {
 
 .signal-metric span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .09em;
   text-transform: uppercase;
 }
@@ -2478,7 +2485,7 @@ kbd {
 .matrix-dates > span {
   display: grid;
   color: #74786e;
-  font-size: 7px;
+  font-size: var(--type-label);
   text-align: center;
   text-transform: uppercase;
 }
@@ -2486,7 +2493,7 @@ kbd {
 .matrix-dates small {
   margin-top: 3px;
   color: #494d46;
-  font-size: 6px;
+  font-size: var(--type-micro);
 }
 
 .matrix-row {
@@ -2497,7 +2504,7 @@ kbd {
   display: flex;
   align-items: center;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 450;
   text-transform: uppercase;
 }
@@ -2509,7 +2516,7 @@ kbd {
   color: color-mix(in srgb, var(--paper) calc(var(--intensity) * 85%), #555 15%);
   border: 1px solid color-mix(in srgb, var(--lime) calc(var(--intensity) * 38%), var(--line));
   background: color-mix(in srgb, var(--lime) calc(var(--intensity) * 24%), var(--surface));
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .matrix-cell.is-error {
@@ -2538,7 +2545,7 @@ kbd {
 .library-intro p {
   margin: 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.6;
 }
 
@@ -2560,7 +2567,7 @@ kbd {
 .capability-list strong {
   min-width: 0;
   overflow: hidden;
-  font-size: 9px;
+  font-size: var(--type-body);
   font-weight: 450;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2573,14 +2580,14 @@ kbd {
   place-items: center;
   color: var(--lime);
   border: 1px solid rgba(217,255,67,.35);
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .source-tag {
   padding: 3px 5px;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 6px;
+  font-size: var(--type-micro);
   text-transform: uppercase;
 }
 
@@ -2644,7 +2651,7 @@ kbd {
 .memory-hero p {
   margin: 8px 0 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .privacy-badge {
@@ -2666,13 +2673,13 @@ kbd {
 
 .privacy-badge strong {
   color: var(--paper);
-  font-size: 9px;
+  font-size: var(--type-body);
   text-transform: uppercase;
 }
 
 .privacy-badge small {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   line-height: 1.5;
 }
 
@@ -2708,7 +2715,7 @@ kbd {
 
 .memory-file-list strong {
   overflow: hidden;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 450;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2717,7 +2724,7 @@ kbd {
 .memory-file-list small,
 .memory-file-list em {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-style: normal;
 }
 
@@ -2775,7 +2782,7 @@ kbd {
   align-items: center;
   gap: 10px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .1em;
 }
 
@@ -2793,7 +2800,7 @@ kbd {
 .drawer-summary {
   margin: 0;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.75;
 }
 
@@ -2806,7 +2813,7 @@ kbd {
   color: var(--muted);
   border: 1px solid var(--line);
   background: rgba(255,255,255,.02);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .drawer-path svg {
@@ -2846,7 +2853,7 @@ kbd {
 
 .drawer-stat-grid span {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -2863,7 +2870,7 @@ kbd {
   display: flex;
   justify-content: space-between;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-transform: uppercase;
 }
 
@@ -2894,7 +2901,7 @@ kbd {
   grid-template-columns: 140px 1fr;
   align-items: center;
   border-bottom: 1px solid var(--line);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .session-spec dt {
@@ -2926,7 +2933,7 @@ kbd {
   display: grid;
   gap: 5px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   line-height: 1.5;
 }
 
@@ -2987,8 +2994,8 @@ kbd {
 
 .palette-label {
   padding: 8px 9px 5px;
-  color: #555950;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-transform: uppercase;
   letter-spacing: .12em;
 }
@@ -3023,13 +3030,13 @@ kbd {
 }
 
 .palette-results button strong {
-  font-size: 9px;
+  font-size: var(--type-body);
   font-weight: 500;
 }
 
 .palette-results button small {
-  color: #656960;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .command-palette footer {
@@ -3038,9 +3045,9 @@ kbd {
   display: flex;
   align-items: center;
   gap: 15px;
-  color: #5e6259;
+  color: var(--muted-dim);
   border-top: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -3103,7 +3110,7 @@ kbd {
   max-width: 520px;
   margin: 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.7;
 }
 
@@ -3122,7 +3129,7 @@ kbd {
   color: var(--ink);
   border: 0;
   background: var(--lime);
-  font-size: 9px;
+  font-size: var(--type-body);
   font-weight: 600;
   text-transform: uppercase;
   cursor: pointer;
@@ -3130,8 +3137,8 @@ kbd {
 
 .empty-inline {
   padding: 25px 8px;
-  color: #5f635a;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   text-align: center;
 }
 
@@ -3141,7 +3148,7 @@ kbd {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: #61655c;
+  color: var(--muted-dim);
   text-align: center;
 }
 
@@ -3155,7 +3162,7 @@ kbd {
 .empty-block p {
   max-width: 370px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 /* Command deck */
@@ -3197,7 +3204,7 @@ kbd {
 .control-health-strip span,
 .control-health-strip small {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .12em;
 }
 
@@ -3211,7 +3218,7 @@ kbd {
 
 .control-health-strip > div:first-child strong {
   font-family: inherit;
-  font-size: 10px;
+  font-size: var(--type-control);
   letter-spacing: .08em;
 }
 
@@ -3238,7 +3245,7 @@ kbd {
   align-items: center;
   gap: 9px;
   border: 1px solid var(--line);
-  font-size: 10px;
+  font-size: var(--type-control);
 }
 
 .control-banner.is-error {
@@ -3322,7 +3329,7 @@ kbd {
 
 .panel-index {
   color: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .15em;
 }
 
@@ -3330,7 +3337,7 @@ kbd {
   padding: 5px 8px;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .mode-switch {
@@ -3352,7 +3359,7 @@ kbd {
   border: 0;
   border-right: 1px solid var(--line);
   background: transparent;
-  font-size: 9px;
+  font-size: var(--type-body);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -3376,13 +3383,13 @@ kbd {
 .prompt-field > span,
 .workspace-toolbar label > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .16em;
 }
 
 .control-field > span em {
   margin-left: 6px;
-  color: #55594f;
+  color: var(--muted-dim);
   font-style: normal;
 }
 
@@ -3405,7 +3412,7 @@ kbd {
 .access-card input {
   height: 43px;
   padding: 0 12px;
-  font-size: 10px;
+  font-size: var(--type-control);
 }
 
 .control-field select,
@@ -3438,9 +3445,9 @@ kbd {
   right: 10px;
   bottom: 9px;
   padding: 3px 5px;
-  color: #62665d;
+  color: var(--muted-dim);
   background: #090a08;
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .launch-button {
@@ -3454,7 +3461,7 @@ kbd {
   color: var(--ink);
   border: 1px solid var(--lime);
   background: var(--lime);
-  font-size: 10px;
+  font-size: var(--type-control);
   font-weight: 700;
   letter-spacing: .14em;
   cursor: pointer;
@@ -3473,8 +3480,8 @@ kbd {
 
 .composer-note {
   margin: 11px 0 0;
-  color: #62665d;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   line-height: 1.6;
 }
 
@@ -3489,7 +3496,7 @@ kbd {
   color: var(--muted);
   border: 1px solid var(--line);
   text-align: center;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .approval-count.has-items {
@@ -3520,7 +3527,7 @@ kbd {
 
 .approval-card-head span {
   color: var(--coral);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -3549,7 +3556,7 @@ kbd {
   border: 1px solid rgba(217,255,67,.25);
   background: rgba(217,255,67,.06);
   text-align: left;
-  font-size: 8px;
+  font-size: var(--type-meta);
   cursor: pointer;
 }
 
@@ -3618,7 +3625,7 @@ kbd {
   max-width: 270px;
   margin: 7px 0 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.6;
 }
 
@@ -3626,7 +3633,7 @@ kbd {
 
 .managed-lanes > header > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .14em;
 }
 
@@ -3667,14 +3674,14 @@ kbd {
 .lane-card.state-stopping::before { background: var(--amber); box-shadow: 0 0 14px rgba(255,202,87,.35); }
 .lane-card.state-cancelled::before { background: var(--lime); box-shadow: 0 0 12px rgba(217,255,67,.25); }
 .lane-card.is-selected { border-color: rgba(217,255,67,.3); }
-.lane-index { color: #5c6057; font-size: 8px; }
+.lane-index { color: var(--muted-dim); font-size: var(--type-meta); }
 
 .lane-state {
   display: flex;
   align-items: center;
   gap: 6px;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -3731,7 +3738,7 @@ kbd {
   gap: 6px;
   overflow: hidden;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -3750,15 +3757,15 @@ kbd {
 
 .lane-telemetry span {
   display: block;
-  color: #62665d;
-  font-size: 6px;
+  color: var(--muted-dim);
+  font-size: var(--type-micro);
   letter-spacing: .14em;
 }
 
 .lane-telemetry strong {
   display: block;
   margin-top: 8px;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .stop-lane {
@@ -3770,7 +3777,7 @@ kbd {
   color: var(--coral);
   border: 1px solid rgba(255,101,79,.25);
   background: var(--coral-soft);
-  font-size: 8px;
+  font-size: var(--type-meta);
   cursor: pointer;
 }
 
@@ -3788,7 +3795,7 @@ kbd {
   color: var(--lime);
   border: 1px solid rgba(217,255,67,.25);
   background: rgba(217,255,67,.06);
-  font-size: 8px;
+  font-size: var(--type-meta);
   cursor: pointer;
 }
 
@@ -3821,7 +3828,7 @@ kbd {
 .lane-cancellation span {
   display: block;
   color: var(--muted);
-  font-size: 6px;
+  font-size: var(--type-micro);
   letter-spacing: .13em;
 }
 
@@ -3829,7 +3836,7 @@ kbd {
   display: block;
   margin-top: 5px;
   color: var(--text);
-  font-size: 8px;
+  font-size: var(--type-meta);
   line-height: 1.45;
 }
 
@@ -3839,7 +3846,7 @@ kbd {
   color: var(--muted);
   border: 1px solid var(--line);
   background: transparent;
-  font-size: 7px;
+  font-size: var(--type-label);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -3858,7 +3865,7 @@ kbd {
   gap: 10px;
   color: var(--muted);
   border: 1px dashed var(--line);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .managed-stream {
@@ -3889,7 +3896,7 @@ kbd {
 
 .managed-stream > header span {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .13em;
 }
 
@@ -3917,8 +3924,8 @@ kbd {
 }
 
 .managed-event > span {
-  color: #50544c;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .managed-event > div > header {
@@ -3929,27 +3936,27 @@ kbd {
 
 .managed-event header strong {
   color: var(--lime);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
 
 .managed-event header em {
   color: var(--amber);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-style: normal;
 }
 
 .managed-event header time {
   margin-left: auto;
-  color: #5c6057;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .managed-event p {
   margin: 7px 0 0;
   color: #c9cbc4;
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.65;
   white-space: pre-wrap;
 }
@@ -3963,7 +3970,7 @@ kbd {
   display: grid;
   place-items: center;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 /* Changes workbench */
@@ -3996,7 +4003,7 @@ kbd {
   gap: 8px;
   border: 1px solid var(--line);
   color: var(--coral);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .09em;
   white-space: nowrap;
 }
@@ -4032,7 +4039,7 @@ kbd {
 
 .git-summary-strip span {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .14em;
 }
 
@@ -4075,7 +4082,7 @@ kbd {
 .change-files > header > span,
 .diff-truncated {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .12em;
 }
 
@@ -4096,7 +4103,7 @@ kbd {
   border: 0;
   background: transparent;
   outline: 0;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .change-file-list {
@@ -4126,13 +4133,13 @@ kbd {
 
 .file-status {
   color: var(--amber);
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-align: center;
 }
 
 .file-path {
   overflow: hidden;
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4140,7 +4147,7 @@ kbd {
 .file-delta {
   display: flex;
   gap: 6px;
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .file-delta i { color: var(--lime); font-style: normal; }
@@ -4150,7 +4157,7 @@ kbd {
   padding: 40px 20px;
   color: var(--muted);
   text-align: center;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .diff-viewer {
@@ -4173,7 +4180,7 @@ kbd {
   overflow: auto;
   color: #cfd1ca;
   background: linear-gradient(90deg, rgba(217,255,67,.025) 1px, transparent 1px) 0 0 / 42px 100%, #090a08;
-  font: 9px/1.7 'IBM Plex Mono', monospace;
+  font: var(--type-body)/1.7 'IBM Plex Mono', monospace;
   white-space: pre;
   tab-size: 2;
 }
@@ -4185,7 +4192,7 @@ kbd {
   justify-items: center;
   gap: 12px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 /* Authentication gate */
@@ -4242,7 +4249,7 @@ kbd {
 .access-card > p {
   margin: 0 0 24px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.75;
 }
 
@@ -4250,14 +4257,14 @@ kbd {
 
 .access-card > label > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .15em;
 }
 
 .access-error {
   margin-top: 10px;
   color: #ff9f91;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .boot-card {
@@ -4280,7 +4287,7 @@ kbd {
 
 .boot-card strong {
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .17em;
 }
 
@@ -4517,7 +4524,7 @@ kbd {
   }
 
   .page-intro > p {
-    font-size: 9px;
+    font-size: var(--type-body);
   }
 
   .overview-grid {
@@ -4604,7 +4611,7 @@ kbd {
   }
 
   .feed-content p {
-    font-size: 8px;
+    font-size: var(--type-meta);
   }
 
   .system-card {
@@ -4697,7 +4704,7 @@ kbd {
 
   .model-list,
   .workspace-list {
-    font-size: 9px;
+    font-size: var(--type-body);
   }
 
   .view-toolbar {
@@ -4817,10 +4824,10 @@ kbd {
     display: grid;
     place-items: center;
     gap: 3px;
-    color: #6d7167;
+    color: var(--muted-dim);
     border: 0;
     background: transparent;
-    font-size: 7px;
+    font-size: var(--type-label);
     cursor: pointer;
   }
 
@@ -4965,7 +4972,7 @@ kbd {
   }
 
   .workspace-toolbar select {
-    font-size: 8px;
+    font-size: var(--type-meta);
   }
 
   .git-summary-strip > div {
@@ -4983,7 +4990,7 @@ kbd {
 
   .diff-viewer pre {
     padding: 14px 12px 70px;
-    font-size: 8px;
+    font-size: var(--type-meta);
   }
 
   .mobile-bottom-nav {
@@ -4993,7 +5000,7 @@ kbd {
   }
 
   .mobile-bottom-nav button {
-    font-size: 6px;
+    font-size: var(--type-micro);
   }
 
   .mobile-bottom-nav button svg {
@@ -5106,7 +5113,7 @@ kbd {
   align-items: center;
   gap: 7px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 700;
   letter-spacing: .17em;
 }
@@ -5147,8 +5154,8 @@ kbd {
 .workbench-title span {
   display: block;
   margin-bottom: 2px;
-  color: #6f7369;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   letter-spacing: .14em;
 }
 
@@ -5196,7 +5203,7 @@ kbd {
   gap: 7px;
   overflow: hidden;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -5239,7 +5246,7 @@ kbd {
   gap: 7px;
   border: 1px solid var(--line);
   background: transparent;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 700;
   letter-spacing: .1em;
   text-transform: uppercase;
@@ -5279,8 +5286,8 @@ kbd {
 .workbench-composer .composer-mode,
 .workbench-details dt {
   display: block;
-  color: #6e7268;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: .15em;
 }
@@ -5316,7 +5323,7 @@ kbd {
   border: 0;
   border-right: 1px solid var(--line);
   background: transparent;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 700;
   letter-spacing: .08em;
   text-transform: uppercase;
@@ -5332,7 +5339,7 @@ kbd {
   padding: 2px 4px;
   color: #74786e;
   background: var(--surface-3);
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .workbench-tabs button.is-active {
@@ -5364,7 +5371,7 @@ kbd {
   align-items: center;
   gap: 9px;
   border-bottom: 1px solid;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .workbench-banner-placeholder {
@@ -5403,7 +5410,7 @@ kbd {
 .workbench-loading span,
 .workbench-empty p {
   margin: 0;
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.6;
 }
 
@@ -5436,8 +5443,8 @@ kbd {
 
 .workbench-event-rail span {
   padding-top: 8px;
-  color: #5f635a;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   letter-spacing: .08em;
 }
 
@@ -5463,7 +5470,7 @@ kbd {
 .workbench-event-content > header > span {
   min-width: 58px;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: .13em;
 }
@@ -5484,7 +5491,7 @@ kbd {
 .workbench-event-content > header strong {
   overflow: hidden;
   color: #a9ada2;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5495,15 +5502,15 @@ kbd {
   padding: 2px 5px;
   color: var(--amber);
   border: 1px solid rgba(255,202,87,.2);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-style: normal;
   text-transform: uppercase;
 }
 
 .workbench-event-content > header time {
   margin-left: auto;
-  color: #5f635a;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .workbench-event-content > header em + time {
@@ -5515,7 +5522,7 @@ kbd {
   max-width: 980px;
   color: #d3d4cd;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.72;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -5559,13 +5566,13 @@ kbd {
 }
 
 .workbench-permission small {
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .14em;
 }
 
 .workbench-permission strong {
   color: var(--paper);
-  font-size: 10px;
+  font-size: var(--type-control);
 }
 
 .workbench-permission > div:last-child {
@@ -5582,7 +5589,7 @@ kbd {
   color: var(--lime);
   border: 1px solid rgba(217,255,67,.3);
   background: var(--lime-soft);
-  font-size: 7px;
+  font-size: var(--type-label);
   cursor: pointer;
 }
 
@@ -5604,7 +5611,7 @@ kbd {
   color: var(--ink);
   border: 0;
   background: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 700;
   cursor: pointer;
   transform: translateX(-50%);
@@ -5638,12 +5645,12 @@ kbd {
   color: var(--paper);
   border: 1px solid var(--line);
   background: var(--surface-2);
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.5;
 }
 
 .workbench-composer textarea::placeholder {
-  color: #666a60;
+  color: var(--muted-dim);
 }
 
 .workbench-composer > button {
@@ -5656,14 +5663,14 @@ kbd {
   color: var(--ink);
   border: 0;
   background: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 800;
   letter-spacing: .12em;
   cursor: pointer;
 }
 
 .workbench-composer > button:disabled {
-  color: #66695f;
+  color: var(--muted-dim);
   background: var(--surface-3);
   cursor: not-allowed;
 }
@@ -5672,8 +5679,8 @@ kbd {
   position: absolute;
   right: 19px;
   top: 16px;
-  color: #666a60;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .workbench-changes {
@@ -5704,13 +5711,13 @@ kbd {
 }
 
 .workbench-changes > header strong {
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .workbench-changes > header small {
   overflow: hidden;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -5719,7 +5726,7 @@ kbd {
   margin-left: auto;
   display: flex;
   gap: 10px;
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .workbench-changes > header > div:nth-child(2) strong {
@@ -5771,13 +5778,13 @@ kbd {
 
 .workbench-change-grid > aside > button > span {
   color: var(--amber);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workbench-change-grid > aside > button > strong {
   min-width: 0;
   overflow: hidden;
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5786,7 +5793,7 @@ kbd {
 .workbench-change-grid > aside > button > small {
   display: flex;
   gap: 5px;
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .workbench-change-grid > aside > button b {
@@ -5817,12 +5824,12 @@ kbd {
   color: var(--muted);
   border-bottom: 1px solid var(--line);
   background: rgba(9,10,8,.94);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workbench-change-grid > section > header em {
   color: var(--amber);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-style: normal;
 }
 
@@ -5831,7 +5838,7 @@ kbd {
   margin: 0;
   padding: 18px 18px 70px;
   color: #bdc0b7;
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.65;
   tab-size: 2;
 }
@@ -5843,7 +5850,7 @@ kbd {
   justify-content: center;
   gap: 8px;
   color: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workbench-details {
@@ -5877,7 +5884,7 @@ kbd {
 
 .workbench-details > section > div:last-child > span {
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .14em;
 }
 
@@ -5885,7 +5892,7 @@ kbd {
   max-width: 880px;
   margin: 8px 0 0;
   color: #c9cbc3;
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.65;
 }
 
@@ -5916,7 +5923,7 @@ kbd {
   margin: 0;
   overflow: hidden;
   color: #c7c9c1;
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-align: right;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5937,7 +5944,7 @@ kbd {
   border: 0;
   border-right: 1px solid var(--line);
   background: transparent;
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-transform: uppercase;
   cursor: pointer;
 }
@@ -5954,7 +5961,7 @@ kbd {
 
 .archive-switch span {
   color: #777b71;
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 @media (max-width: 900px) {
@@ -6040,7 +6047,7 @@ kbd {
 
   .workbench-identity > p {
     max-width: 260px;
-    font-size: 7px;
+    font-size: var(--type-label);
   }
 
   .workbench-head-actions {
@@ -6061,7 +6068,7 @@ kbd {
     min-width: 0;
     flex: 1;
     padding: 0 7px;
-    font-size: 7px;
+    font-size: var(--type-label);
   }
 
   .workbench-tabs .workbench-refresh {
@@ -6086,7 +6093,7 @@ kbd {
   }
 
   .workbench-event-content > p {
-    font-size: 9px;
+    font-size: var(--type-body);
   }
 
   .workbench-permission {
@@ -6147,7 +6154,7 @@ kbd {
   border: 1px solid var(--line);
   background: rgba(255,255,255,.025);
   font: inherit;
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .08em;
   text-transform: uppercase;
   cursor: pointer;
@@ -6176,7 +6183,7 @@ kbd {
   color: var(--lime);
   border: 1px solid color-mix(in srgb, var(--lime) 34%, transparent);
   background: color-mix(in srgb, var(--bg) 90%, transparent);
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .13em;
   pointer-events: none;
   backdrop-filter: blur(12px);
@@ -6253,8 +6260,8 @@ kbd {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: #666a61;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   letter-spacing: .1em;
   text-transform: uppercase;
 }
@@ -6324,7 +6331,7 @@ kbd {
   align-items: center;
   gap: 6px;
   margin-bottom: 13px;
-  font-size: 7px;
+  font-size: var(--type-label);
   font-style: normal;
   letter-spacing: .11em;
   text-transform: uppercase;
@@ -6363,7 +6370,7 @@ kbd {
   max-width: 310px;
   margin: 0;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.75;
 }
 
@@ -6390,7 +6397,7 @@ kbd {
 .first-run footer code {
   color: inherit;
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 .first-run-radar {
@@ -6441,7 +6448,7 @@ kbd {
   padding: 11px clamp(22px, 3vw, 38px);
   color: var(--muted);
   border-top: 1px solid var(--line);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .04em;
 }
 
@@ -6501,7 +6508,7 @@ kbd {
 
   .first-run-status span {
     align-items: flex-start;
-    font-size: 7px;
+    font-size: var(--type-label);
     line-height: 1.4;
   }
 
@@ -6551,7 +6558,7 @@ kbd {
 .workflow-empty p {
   margin: 0 0 12px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--type-control);
   line-height: 1.8;
 }
 
@@ -6560,8 +6567,8 @@ kbd {
 }
 
 .workflow-empty small {
-  color: #62665d;
-  font-size: 8px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
   line-height: 1.6;
 }
 
@@ -6629,7 +6636,7 @@ kbd {
   border: 0;
   border-bottom: 1px solid transparent;
   background: transparent;
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .12em;
   text-transform: uppercase;
   cursor: pointer;
@@ -6650,7 +6657,7 @@ kbd {
   padding: 2px 4px;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .workflow-link-state {
@@ -6658,7 +6665,7 @@ kbd {
   align-items: center;
   gap: 8px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .08em;
   text-transform: uppercase;
 }
@@ -6695,9 +6702,9 @@ kbd {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: #666a61;
+  color: var(--muted-dim);
   border-bottom: 1px solid var(--line);
-  font-size: 8px;
+  font-size: var(--type-meta);
   letter-spacing: .14em;
 }
 
@@ -6730,8 +6737,8 @@ kbd {
 }
 
 .workflow-run-index {
-  color: #555950;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
 }
 
 .workflow-status-glyph {
@@ -6768,8 +6775,8 @@ kbd {
 
 .workflow-run-copy small {
   overflow: hidden;
-  color: #6d7168;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -6780,7 +6787,7 @@ kbd {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .12em;
   text-transform: uppercase;
 }
@@ -6818,7 +6825,7 @@ kbd {
   max-width: 670px;
   margin: 0;
   color: var(--muted);
-  font-size: 9px;
+  font-size: var(--type-body);
   line-height: 1.7;
 }
 
@@ -6837,7 +6844,7 @@ kbd {
 .workflow-result > span,
 .workflow-controls > span {
   color: #676b62;
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .15em;
   text-transform: uppercase;
 }
@@ -6849,8 +6856,8 @@ kbd {
   white-space: nowrap;
 }
 
-.workflow-parent strong { margin-top: 5px; color: var(--paper); font-size: 9px; }
-.workflow-parent small { color: var(--muted); font-size: 7px; }
+.workflow-parent strong { margin-top: 5px; color: var(--paper); font-size: var(--type-body); }
+.workflow-parent small { color: var(--muted); font-size: var(--type-label); }
 
 .workflow-parent button {
   width: max-content;
@@ -6862,7 +6869,7 @@ kbd {
   color: var(--lime);
   border: 0;
   background: transparent;
-  font-size: 8px;
+  font-size: var(--type-meta);
   cursor: pointer;
 }
 
@@ -6887,9 +6894,9 @@ kbd {
   border-radius: 50%;
 }
 
-.workflow-recovery strong { color: var(--paper); font-size: 9px; }
-.workflow-recovery p { margin: 4px 0 0; color: #9e817a; font-size: 8px; }
-.workflow-recovery > small { color: #9e817a; font-size: 7px; }
+.workflow-recovery strong { color: var(--paper); font-size: var(--type-body); }
+.workflow-recovery p { margin: 4px 0 0; color: #9e817a; font-size: var(--type-meta); }
+.workflow-recovery > small { color: #9e817a; font-size: var(--type-label); }
 
 .workflow-primary-action {
   min-height: 34px;
@@ -6900,7 +6907,7 @@ kbd {
   color: var(--ink);
   border: 1px solid var(--lime);
   background: var(--lime);
-  font-size: 8px;
+  font-size: var(--type-meta);
   font-weight: 700;
   text-transform: uppercase;
   cursor: pointer;
@@ -6921,7 +6928,7 @@ kbd {
 }
 
 .workflow-phase-panel header > div { display: grid; gap: 7px; }
-.workflow-phase-panel header strong { color: var(--paper); font-size: 10px; }
+.workflow-phase-panel header strong { color: var(--paper); font-size: var(--type-control); }
 .workflow-phase-panel header em {
   color: var(--lime);
   font-family: 'Syne Variable', sans-serif;
@@ -6958,8 +6965,8 @@ kbd {
 }
 
 .workflow-phase > i {
-  color: #5a5e55;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   font-style: normal;
 }
 
@@ -6996,14 +7003,14 @@ kbd {
 .workflow-phase strong {
   overflow: hidden;
   color: var(--paper);
-  font-size: 8px;
+  font-size: var(--type-meta);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .workflow-phase small {
-  color: #62665d;
-  font-size: 6px;
+  color: var(--muted-dim);
+  font-size: var(--type-micro);
   letter-spacing: .08em;
   text-transform: uppercase;
 }
@@ -7053,7 +7060,7 @@ kbd {
   gap: 8px;
 }
 
-.workflow-agent-panel > header strong { color: var(--muted); font-size: 7px; font-weight: 400; }
+.workflow-agent-panel > header strong { color: var(--muted); font-size: var(--type-label); font-weight: 400; }
 
 .workflow-agent-tools {
   min-height: 42px;
@@ -7073,7 +7080,7 @@ kbd {
   display: flex;
   align-items: center;
   gap: 7px;
-  color: #5d6158;
+  color: var(--muted-dim);
   border: 1px solid var(--line);
   background: rgba(0,0,0,.16);
 }
@@ -7092,12 +7099,12 @@ kbd {
   outline: 0;
   background: transparent;
   font: inherit;
-  font-size: 7px;
+  font-size: var(--type-label);
   letter-spacing: .06em;
 }
 
-.workflow-agent-tools input::placeholder { color: #51554d; opacity: 1; }
-.workflow-agent-tools > span { color: #5d6158; font-size: 7px; white-space: nowrap; }
+.workflow-agent-tools input::placeholder { color: var(--muted-dim); opacity: 1; }
+.workflow-agent-tools > span { color: var(--muted-dim); font-size: var(--type-label); white-space: nowrap; }
 
 .workflow-agent-list > div {
   min-height: 76px;
@@ -7110,7 +7117,7 @@ kbd {
 }
 
 .workflow-agent-list > div:last-child { border-bottom: 0; }
-.workflow-agent-index { color: #555950; font-size: 7px; }
+.workflow-agent-index { color: var(--muted-dim); font-size: var(--type-label); }
 
 .workflow-agent-dot {
   width: 6px;
@@ -7147,24 +7154,24 @@ kbd {
   flex: 0 1 auto;
   overflow: hidden;
   color: #777b71;
-  font-size: 6px;
+  font-size: var(--type-micro);
   letter-spacing: .06em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.workflow-agent-list strong { color: var(--paper); font-size: 8px; }
+.workflow-agent-list strong { color: var(--paper); font-size: var(--type-meta); }
 .workflow-agent-detail {
   overflow: hidden;
-  color: #666a61;
-  font-size: 7px;
+  color: var(--muted-dim);
+  font-size: var(--type-label);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .workflow-agent-phase {
-  color: #6d7168;
-  font-size: 6px;
+  color: var(--muted-dim);
+  font-size: var(--type-micro);
   letter-spacing: .09em;
   text-transform: uppercase;
 }
@@ -7185,16 +7192,16 @@ kbd {
 .workflow-agent-metrics strong > span {
   color: #676b62;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 5px;
+  font-size: var(--type-micro);
   font-weight: 400;
   letter-spacing: .08em;
 }
 
-.workflow-agent-metrics > small { color: #666a61; font-size: 6px; }
+.workflow-agent-metrics > small { color: var(--muted-dim); font-size: var(--type-micro); }
 
 .workflow-agent-metrics em {
   color: var(--muted);
-  font-size: 6px;
+  font-size: var(--type-micro);
   font-style: normal;
   letter-spacing: .1em;
   text-transform: uppercase;
@@ -7211,8 +7218,8 @@ kbd {
 }
 
 .workflow-agent-pages span {
-  color: #5d6158;
-  font-size: 6px;
+  color: var(--muted-dim);
+  font-size: var(--type-micro);
   letter-spacing: .08em;
 }
 
@@ -7226,7 +7233,7 @@ kbd {
   color: var(--muted);
   border: 1px solid var(--line);
   background: transparent;
-  font-size: 7px;
+  font-size: var(--type-label);
   cursor: pointer;
 }
 
@@ -7256,7 +7263,7 @@ kbd {
 .workflow-event-panel > strong {
   display: block;
   color: var(--paper);
-  font-size: 9px;
+  font-size: var(--type-body);
   text-transform: capitalize;
 }
 
@@ -7265,11 +7272,11 @@ kbd {
   margin-top: 7px;
   margin-bottom: 7px;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   line-height: 1.55;
 }
 
-.workflow-event-panel > time { color: #5f635a; font-size: 7px; }
+.workflow-event-panel > time { color: var(--muted-dim); font-size: var(--type-label); }
 
 .workflow-budget {
   margin-top: 18px;
@@ -7279,13 +7286,13 @@ kbd {
   gap: 7px;
   border-top: 1px solid var(--line);
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
 }
 
 .workflow-budget > strong { color: var(--paper); }
 .workflow-budget > div { grid-column: 1 / -1; height: 2px; background: var(--line); }
 .workflow-budget > div i { display: block; height: 100%; background: var(--lime); }
-.workflow-budget > small { grid-column: 1 / -1; color: var(--amber); font-size: 6px; }
+.workflow-budget > small { grid-column: 1 / -1; color: var(--amber); font-size: var(--type-micro); }
 
 .workflow-token-total {
   margin-top: 14px;
@@ -7302,7 +7309,7 @@ kbd {
 .workflow-token-total > span {
   align-self: center;
   color: var(--muted);
-  font-size: 7px;
+  font-size: var(--type-label);
   text-transform: uppercase;
 }
 
@@ -7316,12 +7323,12 @@ kbd {
   letter-spacing: -.04em;
 }
 
-.workflow-token-total > small { color: #62665d; font-size: 6px; }
+.workflow-token-total > small { color: var(--muted-dim); font-size: var(--type-micro); }
 
 .workflow-muted {
   margin: 20px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workflow-result {
@@ -7337,7 +7344,7 @@ kbd {
 .workflow-result p {
   margin: 0;
   color: var(--paper);
-  font-size: 8px;
+  font-size: var(--type-meta);
   line-height: 1.6;
 }
 
@@ -7362,7 +7369,7 @@ kbd {
   color: var(--paper);
   border: 1px solid var(--line-strong);
   background: rgba(255,255,255,.025);
-  font-size: 8px;
+  font-size: var(--type-meta);
   cursor: pointer;
 }
 
@@ -7377,7 +7384,7 @@ kbd {
 }
 
 .workflow-controls button:disabled {
-  color: #52564e;
+  color: var(--muted-dim);
   border-color: var(--line);
   cursor: not-allowed;
 }
@@ -7386,7 +7393,7 @@ kbd {
   grid-column: 1 / -1;
   margin: 0;
   color: #ff9f91;
-  font-size: 8px;
+  font-size: var(--type-meta);
 }
 
 .workflow-filter-empty {
@@ -7395,7 +7402,7 @@ kbd {
   place-items: center;
   color: var(--muted);
   border: 1px solid var(--line);
-  font-size: 9px;
+  font-size: var(--type-body);
 }
 
 @media (max-width: 1050px) {
@@ -7451,8 +7458,27 @@ kbd {
   .workflow-empty { grid-template-columns: 1fr; justify-items: start; padding: 28px 20px; }
   .workflow-empty > button { grid-column: 1; }
   .workflow-radar { width: 100px; }
-  .mobile-bottom-nav { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-  .mobile-bottom-nav button { min-width: 0; padding-left: 0; padding-right: 0; }
+  .mobile-bottom-nav {
+    grid-template-columns: none;
+    grid-auto-flow: column;
+    grid-auto-columns: 64px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+  .mobile-bottom-nav::-webkit-scrollbar { display: none; }
+  .mobile-bottom-nav button {
+    min-width: 64px;
+    padding-left: 4px;
+    padding-right: 4px;
+    scroll-snap-align: start;
+  }
   .mobile-bottom-nav button svg { width: 15px; }
-  .mobile-bottom-nav button span { font-size: 5px; }
+  .mobile-bottom-nav button span {
+    overflow: visible;
+    font-size: var(--type-label);
+    white-space: nowrap;
+  }
 }


### PR DESCRIPTION
## Summary
- replace scattered 5–10px dashboard declarations with a readable, named typography scale
- improve muted supporting-text contrast across Operator and Event Horizon without brightening disabled states
- turn the crowded 390px bottom navigation into a readable horizontal command rail
- add all-section and mobile browser regressions for visible text below the 8px floor
- prepare package metadata, README, and changelog for v0.8.1

## Validation
- npm run verify (24 Vitest tests)
- npm run test:e2e (11 Chromium tests)
- npm run test:package
- npm audit --omit=dev --audit-level=high
- desktop and 390px screenshot QA across Live, Control, Runs, and Changes

## Privacy checklist
- presentation-only CSS and test changes introduce no new data collection or persistence
- release package privacy scan passed
- Privacy Mode browser coverage remains green