### PR TITLE
feat: rename workbench to session console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Renamed the session “Workbench” entry points to “Open Session” and labeled
+  the focused agent view “Session Console,” with a concise explanation of its
+  live chat, activity, and change-review capabilities.
+
 ## 0.8.1 — 2026-07-25
 
 - Replaced scattered 5–10px dashboard typography with a consistent readable

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ provides them—never guessed or auto-approved.
 <tr>
 <td width="50%" valign="top">
 
-**◇ One workbench per session**
+**◇ One Session Console per agent**
 
-Open any recorded CLI session or managed lane for its conversation,
-reasoning, tool timeline, permission queue, token usage, and follow-up
-controls. Managed sessions survive dashboard restarts.
+Open any recorded CLI session or managed lane in a clearly labeled Session
+Console to chat with the agent, review its activity, inspect changes, manage
+permissions, and send follow-ups. Managed sessions survive dashboard restarts.
 
 </td>
 <td width="50%" valign="top">

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -121,6 +121,18 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText(/PID \d+/).first()).toBeVisible()
   })
 
+  test('opens a live agent in the clearly labeled Session Console', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: 'Open Session' }).click()
+
+    await expect(page.getByRole('dialog', { name: /Session console:/ })).toBeVisible()
+    await expect(page.getByText(/SESSION CONSOLE/)).toBeVisible()
+    await expect(page.getByText('Chat with this agent, review its activity, and inspect changes.')).toBeVisible()
+    await expect(page.getByRole('navigation', { name: 'Session console sections' })).toBeVisible()
+    await expect(page.getByPlaceholder('Send a follow-up to this session…')).toBeVisible()
+  })
+
   test('redacts sensitive runtime data and persists Privacy Mode', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByText('Confidential Launch').first()).toBeVisible()
@@ -290,6 +302,16 @@ test.describe.serial('public launch path', () => {
       clientWidth: document.documentElement.clientWidth,
     }))
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth)
+    expect(await unreadableVisibleText(page)).toEqual([])
+
+    await page.getByRole('button', { name: 'Open Session' }).click()
+    await expect(page.getByRole('dialog', { name: /Session console:/ })).toBeVisible()
+    await expect(page.getByText(/SESSION CONSOLE/)).toBeVisible()
+    const consoleOverflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(consoleOverflow.scrollWidth).toBeLessThanOrEqual(consoleOverflow.clientWidth)
     expect(await unreadableVisibleText(page)).toEqual([])
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -772,7 +772,7 @@ function LiveView({
               <div className="runtime-actions">
                 <AgentStatePill agent={selected} />
                 <button className="text-button" onClick={() => onOpenSession(selectedSession || selected.id)}>
-                  Open workbench <ArrowRight size={14} />
+                  Open Session <ArrowRight size={14} />
                 </button>
               </div>
             </header>
@@ -1406,7 +1406,7 @@ function SessionsView({
           icon={archiveScope === 'archived' ? Archive : Search}
           title={archiveScope === 'archived' ? 'No archived sessions' : 'No matching sessions'}
           copy={archiveScope === 'archived'
-            ? 'Archive a session from its workbench and it will appear here.'
+            ? 'Archive a session from its Session Console and it will appear here.'
             : 'Try a broader title, workspace, model, or agent name.'}
         />}
       </section>

--- a/src/api.ts
+++ b/src/api.ts
@@ -126,7 +126,7 @@ export async function getSessionWorkbench(sessionId: string): Promise<SessionWor
     await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/workbench`, {
       headers: { Accept: 'application/json' },
     }),
-    'Session workbench request failed',
+    'Session console request failed',
   )
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4572,10 +4572,6 @@ kbd {
     font-size: 14px;
   }
 
-  .runtime-actions .text-button {
-    display: none;
-  }
-
   .runtime-instruments {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -5195,14 +5191,43 @@ kbd {
   background: var(--lime-soft);
 }
 
-.workbench-identity > p {
+.workbench-context {
   max-width: 950px;
   margin: 10px 0 0;
   display: flex;
   align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.workbench-context p {
+  margin: 0;
+  display: flex;
+  align-items: center;
   gap: 7px;
-  overflow: hidden;
+  min-width: 0;
   color: var(--muted);
+  font-size: var(--type-body);
+  white-space: nowrap;
+}
+
+.workbench-context p > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workbench-context p svg {
+  flex: 0 0 auto;
+}
+
+.workbench-context > span {
+  flex: 0 0 auto;
+  overflow: hidden;
+  padding-left: 12px;
+  color: var(--muted);
+  border-left: 1px solid var(--line-strong);
   font-size: var(--type-body);
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -5990,7 +6015,10 @@ kbd {
     width: 38px;
     padding: 0;
     justify-content: center;
-    font-size: 0;
+  }
+
+  .workbench-head-actions > button:not(.icon-button) > span {
+    display: none;
   }
 
   .workbench-instruments {
@@ -6045,9 +6073,17 @@ kbd {
     font-size: 18px;
   }
 
-  .workbench-identity > p {
+  .workbench-context {
     max-width: 260px;
+    margin-top: 7px;
+  }
+
+  .workbench-context p {
     font-size: var(--type-label);
+  }
+
+  .workbench-context > span {
+    display: none;
   }
 
   .workbench-head-actions {

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -383,7 +383,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
                     Open stream
                   </button>
                   <button className="open-lane" onClick={() => onOpenSession(session.id)}>
-                    Workbench
+                    Open Session
                   </button>
                 </div>
                 {session.cancellationStatus !== 'none' && (

--- a/src/views/SessionWorkbench.tsx
+++ b/src/views/SessionWorkbench.tsx
@@ -274,9 +274,9 @@ export function SessionWorkbench({
       className="workbench-layer"
       role="dialog"
       aria-modal="true"
-      aria-label={`Session workbench: ${privacy.sessionTitle(session?.title || sessionId, sessionId)}`}
+      aria-label={`Session console: ${privacy.sessionTitle(session?.title || sessionId, sessionId)}`}
     >
-      <button className="workbench-scrim" onClick={onClose} aria-label="Close session workbench" />
+      <button className="workbench-scrim" onClick={onClose} aria-label="Close session console" />
       <section className="session-workbench">
         <header className="workbench-head">
           <div className="workbench-identity">
@@ -292,25 +292,40 @@ export function SessionWorkbench({
             ) : (
               <div className="workbench-title">
                 <div>
-                  <span>SESSION / {privacy.identifier(sessionId)}</span>
+                  <span>SESSION CONSOLE / {privacy.identifier(sessionId)}</span>
                   <h1>{privacy.sessionTitle(session?.title || `Session ${sessionId.slice(0, 8)}`, sessionId)}</h1>
                 </div>
                 <button onClick={() => setRenaming(true)} aria-label="Rename session"><Pencil size={15} /></button>
               </div>
             )}
-            <p><FolderGit2 size={14} /> {session?.cwd ? privacy.path(session.cwd) : 'Resolving workspace…'}</p>
+            <div className="workbench-context">
+              <p>
+                <FolderGit2 size={14} />
+                <span>{session?.cwd ? privacy.path(session.cwd) : 'Resolving workspace…'}</span>
+              </p>
+              <span>Chat with this agent, review its activity, and inspect changes.</span>
+            </div>
           </div>
           <div className="workbench-head-actions">
-            <button className="workbench-archive" onClick={() => void toggleArchive()}>
+            <button
+              className="workbench-archive"
+              onClick={() => void toggleArchive()}
+              aria-label={session?.archived ? 'Restore session' : 'Archive session'}
+            >
               {session?.archived ? <ArchiveRestore size={16} /> : <Archive size={16} />}
-              {session?.archived ? 'Restore' : 'Archive'}
+              <span>{session?.archived ? 'Restore' : 'Archive'}</span>
             </button>
             {canCancel && (
-              <button className="workbench-stop" onClick={() => void cancel()}>
-                <CircleStop size={16} /> {data?.control?.cancellationStatus === 'timed_out' ? 'Retry stop' : 'Stop turn'}
+              <button
+                className="workbench-stop"
+                onClick={() => void cancel()}
+                aria-label={data?.control?.cancellationStatus === 'timed_out' ? 'Retry stop' : 'Stop turn'}
+              >
+                <CircleStop size={16} />
+                <span>{data?.control?.cancellationStatus === 'timed_out' ? 'Retry stop' : 'Stop turn'}</span>
               </button>
             )}
-            <button className="icon-button" onClick={onClose} aria-label="Close session workbench"><X size={19} /></button>
+            <button className="icon-button" onClick={onClose} aria-label="Close session console"><X size={19} /></button>
           </div>
         </header>
 
@@ -325,7 +340,7 @@ export function SessionWorkbench({
           <div><span>UPDATED</span><strong>{elapsed(session?.updatedAt || '')}</strong></div>
         </div>
 
-        <nav className="workbench-tabs" aria-label="Session workbench sections">
+        <nav className="workbench-tabs" aria-label="Session console sections">
           <button className={tab === 'timeline' ? 'is-active' : ''} onClick={() => setTab('timeline')}>
             <Radio size={15} /> Timeline <span>{transcript.length}</span>
           </button>

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -289,7 +289,7 @@ export function WorkflowsView({
                     <strong>{session ? privacy.sessionTitle(session.title, session.id) : 'Managed session'}</strong>
                     <small>{session ? privacy.workspace(session.cwd) : privacy.identifier(selected.sessionId)}</small>
                     <button type="button" onClick={() => onOpenSession(selected.sessionId)}>
-                      Open workbench <ArrowUpRight size={13} />
+                      Open Session <ArrowUpRight size={13} />
                     </button>
                   </div>
                 </header>


### PR DESCRIPTION
## Summary
- rename every session entry point to Open Session
- label the focused agent view Session Console and explain its purpose
- keep Open Session discoverable on mobile and improve compact control accessibility

## Verification
- npm run verify
- npm run test:e2e (12 Chromium tests)
- npm run test:package