### PR TITLE
fix: publish packed npm artifact by file path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           mkdir release
           npm pack --ignore-scripts --pack-destination release
       - name: Publish npm package
-        run: npm publish release/*.tgz --access public
+        run: npm publish ./release/*.tgz --access public
       - name: Publish GitHub release
         if: github.event_name == 'push'
         env:


### PR DESCRIPTION
## Summary
- treat the packed tarball as a local file path during npm publish
- prevent npm from interpreting `release/grok-ui-0.8.1.tgz` as a GitHub repository shorthand

## Verification
- `npm publish ./grok-ui-0.8.1.tgz --dry-run --ignore-scripts`
- full release run passed verify, browser e2e, package smoke, and artifact packing before reaching the corrected step