### PR TITLE
release: Grok UI v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.8.2 — 2026-07-26
+
 - Renamed the session “Workbench” entry points to “Open Session” and labeled
   the focused agent view “Session Console,” with a concise explanation of its
   live chat, activity, and change-review capabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",


### PR DESCRIPTION
## Summary
- bump package and lockfile versions to `0.8.2`
- promote the accumulated reliability and release automation notes from Unreleased
- prepare the tag-triggered GitHub and npm release

## Local verification
- `RELEASE_TAG=v0.8.2 npm run verify` — 25 unit tests passed
- `npm run test:e2e` — 14 browser journeys passed
- `npm run test:soak` — 75-second ACP session remained connected
- `npm run test:package` — packed install, CLI, server, diagnostics, and security smoke passed
- `npm audit --audit-level=high` — 0 vulnerabilities