### PR TITLE
feat: start v0.9 runtime intelligence ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- Started the v0.9 Runtime Intelligence milestone with a persistent,
+  provenance-aware usage ledger built on the existing session and workflow
+  token telemetry.
+- Added time-windowed usage reporting by project, model, session, and agent,
+  with separate session and workflow-agent scopes to prevent silent double
+  counting.
+- Added explicit Grok-reported, derived, incomplete, and unavailable labels,
+  including a guard that never treats live context occupancy as cumulative
+  token usage.
+- Added a privacy-aware Usage view, authenticated usage API, atomic v1-to-v2
+  state migration, and coverage for persistence and mixed telemetry.
+
 ## 0.8.2 — 2026-07-26
 
 - Renamed the session “Workbench” entry points to “Open Session” and labeled

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Grok UI intentionally does not scrape the terminal dashboard or imply visibility
 into historical CLI-only workflow runs. A run appears after a UI-managed session
 emits its first workflow update.
 
+## Usage ledger
+
+The v0.9 Usage view extends the existing token and cost telemetry with a
+durable local ledger. It reports by project, model, session, agent, and time
+period, while keeping session totals separate from workflow-agent detail.
+
+Every value says whether it is Grok-reported, derived, incomplete, or
+unavailable. Grok UI does not substitute context-window occupancy for
+cumulative CLI token usage, and explicitly mixed observation scopes are never
+presented as precise spend.
+
 ## Themes
 
 Two complete visual systems ship with the dashboard:
@@ -272,6 +283,7 @@ server/
   grok-controller.ts      ACP lifecycle, prompts, approvals, cancellation
   workflow-state.ts       workflow notification projection and safe controls
   live-monitor.ts         active process and runtime event projection
+  usage-ledger.ts         provenance-aware durable usage reporting
   grok-store.ts           historical metadata aggregation
   session-reader.ts       bounded conversation and tool timeline
   session-state.ts        durable managed lanes and local annotations
@@ -280,6 +292,7 @@ server/
 src/
   views/ControlView.tsx   command deck and approval queue
   views/WorkflowsView.tsx cross-session workflow command field
+  views/UsageView.tsx     time- and dimension-based usage ledger
   views/ChangesView.tsx   live repository change workbench
   views/SessionWorkbench.tsx
                             session timeline and operations

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,11 +24,30 @@ The connection supports:
 
 Each permission request stays pending as a server-side promise until an authenticated user selects one of Grok’s options or cancels the turn. The browser cannot manufacture an option that Grok did not advertise.
 
+## Usage plane
+
+`UsageLedger` normalizes the token and cost telemetry already owned by
+`LiveMonitor`, `GrokController`, and the workflow projection. It stores
+cumulative observations rather than replaying or duplicating raw events.
+
+Every metric carries provenance: `grok-reported`, `derived`, `incomplete`, or
+`unavailable`. Session totals and workflow-agent detail are separate reporting
+scopes because they can describe overlapping work. Live context occupancy is
+never treated as cumulative token usage.
+
+Reports are time-bounded and can group by project, model, session, or agent.
+The ledger is local-only and uses the same authenticated API boundary as the
+rest of the dashboard.
+
 ## Durable UI state
 
 `SessionStateStore` atomically persists Grok UI-owned annotations and managed ACP lanes to `~/.grok-ui/state.json` with user-only file permissions. It never mutates Grok’s session directories. Rename and archive are therefore reversible UI overlays.
 
-Managed lanes retain a bounded event tail and usage totals. If the server exits during a turn, the lane restores as idle with a `server_restarted` stop reason; the user can explicitly resume it through `session/load` and `session/prompt`.
+Managed lanes retain a bounded event tail and usage totals. The same versioned
+state file retains at most 10,000 normalized usage observations and migrates
+older state in place. If the server exits during a turn, the lane restores as
+idle with a `server_restarted` stop reason; the user can explicitly resume it
+through `session/load` and `session/prompt`.
 
 ## Workspace plane
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,10 +19,14 @@ The roadmap extends those foundations instead of replacing them.
 - Inspect process trees, open ports, test state, databases, local services, and
   external tool calls.
 - Persist usage across CLI sessions, managed sessions, workflows, projects,
-  models, agents, and time periods.
+  models, agents, and time periods. The provenance-aware ledger and reporting
+  API are now implemented on the v0.9 development branch.
 - Identify each usage value as Grok-reported, derived, incomplete, or
-  unavailable.
+  unavailable. The first Usage view now exposes those labels directly.
 - Add optional budgets, alerts, and exports.
+
+The staged design, security constraints, and release gate are tracked in
+[`v0.9-runtime-intelligence.md`](./v0.9-runtime-intelligence.md).
 
 ## v0.10 — Multi-machine monitoring
 

--- a/docs/v0.9-runtime-intelligence.md
+++ b/docs/v0.9-runtime-intelligence.md
@@ -1,0 +1,114 @@
+# v0.9 Runtime Intelligence implementation plan
+
+This milestone extends the telemetry and persistence shipped through v0.8.2.
+It does not introduce a second session tracker, scrape unrestricted terminal
+history, or send local runtime data to a remote service.
+
+## Architecture audit
+
+### Existing inputs
+
+- `GrokStore` reads bounded historical metadata from Grok `summary.json` and
+  `signals.json` files. It already supplies project, model, tool, activity, and
+  session dimensions without reading conversation bodies.
+- `LiveMonitor` joins `active_sessions.json` to bounded tails of
+  `events.jsonl` and `updates.jsonl`. It already owns process liveness, current
+  phase, tool lifecycle, context occupancy, and Grok-reported live cost.
+- `GrokController` owns ACP-managed sessions. It already records cumulative
+  prompt token totals, Grok-reported cost, permissions, interruption state, and
+  structured `workflow_updated` telemetry.
+- `workflow-state.ts` is the canonical workflow projection. Per-agent token
+  values are Grok-reported; the run-wide total is derived from those values and
+  can be explicitly incomplete.
+- `SessionStateStore` atomically persists UI-owned state to
+  `~/.grok-ui/state.json` with `0700` directories and `0600` files. Managed
+  sessions and bounded feed tails already survive a dashboard restart.
+- `WorkspaceInspector` is the security model for local inspection: commands
+  use argument arrays rather than a shell, roots must be associated with a
+  known session, paths are contained, and output is bounded.
+
+### Gaps entering v0.9
+
+- Token and cost observations had different shapes and no shared provenance
+  contract.
+- CLI context occupancy could be mistaken for cumulative token usage if reused
+  naively.
+- Managed-session and workflow-agent values could be double counted without an
+  explicit reporting scope.
+- Runtime process descendants, listening ports, tests, databases, and
+  development services were not projected into a bounded snapshot.
+- Tool timelines exposed safe titles and status but did not classify external
+  calls for a cross-session inspection view.
+- There was no durable budget or alert state.
+
+## Delivery plan
+
+### Increment 1 — Usage ledger foundation
+
+Status: implemented on the v0.9 development branch.
+
+- Normalize the existing managed-session, CLI, and workflow-agent telemetry
+  into durable observations; do not replace the source projections.
+- Attach one of four source labels to every value: `grok-reported`, `derived`,
+  `incomplete`, or `unavailable`.
+- Persist observations through the existing atomic state store and migrate
+  v1 state files in place.
+- Report bounded time windows grouped by project, model, session, or agent.
+- Keep session rollups and workflow-agent detail as separate scopes. An
+  explicitly mixed report is labeled incomplete because those observation
+  levels can overlap.
+- Add an authenticated `/api/usage` endpoint and a privacy-aware Usage view.
+
+Important semantic rule: live context occupancy is not cumulative usage. It is
+never inserted into the token ledger. When Grok does not report cumulative CLI
+tokens, the ledger says `unavailable`.
+
+### Increment 2 — Bounded runtime discovery
+
+- Introduce a `RuntimeInspector` fed by active and managed session process IDs.
+- Walk descendants with platform adapters (`ps` on macOS/POSIX, a documented
+  fallback elsewhere), fixed timeouts, PID/count/depth caps, and no shell.
+- Resolve listening ports only for the bounded process set. Classify common
+  local HTTP, database, cache, queue, and emulator services from process and
+  port evidence; do not connect to arbitrary endpoints by default.
+- Publish one runtime snapshot through REST and the existing SSE channel.
+- Add the process, ports, and services panels to the existing Live/Usage visual
+  system.
+
+### Increment 3 — Tests and external calls
+
+- Derive test command lifecycle from existing structured tool calls and ACP
+  updates. Track command label, state, start/end time, exit evidence, and the
+  owning session without persisting raw command input.
+- Classify external tool calls from safe structured metadata. Keep raw input,
+  credentials, headers, and unrestricted output out of the browser contract.
+- Reconcile interrupted commands after SSE, ACP, or server reconnect and mark
+  ambiguous outcomes incomplete instead of successful.
+
+### Increment 4 — Budgets, alerts, and export
+
+- Persist optional budgets by global, project, model, session, or agent scope.
+- Evaluate budgets against a single non-overlapping ledger scope and currency.
+- Support token and spend thresholds with deduplicated local alerts.
+- Add bounded JSON/CSV export with Privacy Mode applied before browser-side
+  download.
+- Budgets remain opt-in; no telemetry or alert delivery leaves the host.
+
+### Increment 5 — Hardening and release candidate
+
+- Unit-test every parser, adapter, state migration, provenance rule, and budget
+  transition.
+- Cover live updates, privacy redaction, mobile layout, SSE recovery, ACP child
+  recovery, and ambiguous interruption in Playwright.
+- Extend the managed-session soak with ledger growth and runtime-refresh
+  assertions.
+- Run packaged-install smoke tests on the packed artifact and confirm state
+  permissions.
+- Run `npm audit`, remote-auth/origin checks, inspection-boundary tests, and
+  release metadata validation.
+
+## Release gate
+
+The v0.9 branch may be built and packaged for testing, but it must not be
+tagged, published, or merged as a v0.9 release until the user explicitly
+approves the release.

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -296,6 +296,37 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByRole('button', { name: 'Next agent page' })).toHaveCount(0)
   })
 
+  test('persists provenance-aware usage and redacts its project report', async ({ page }) => {
+    await page.goto('/')
+    const created = await page.request.post('/api/control/sessions', {
+      data: {
+        cwd: workspace,
+        prompt: 'Start workflow fixture for usage ledger verification',
+      },
+    })
+    expect(created.ok()).toBe(true)
+    const session = await created.json()
+
+    await expect.poll(async () => {
+      const report = await (await page.request.get('/api/usage?period=all&scope=sessions&groupBy=session')).json()
+      return report.entries.find((entry: { sessionId: string }) => entry.sessionId === session.id)?.totalTokens
+    }, { timeout: 10_000 }).toEqual({
+      value: 16,
+      source: 'grok-reported',
+    })
+
+    await page.getByRole('button', { name: /Usage/ }).click()
+    await expect(page.getByRole('heading', { name: /Know what was used/ })).toBeVisible()
+    await expect(page.getByText('Persistent usage ledger', { exact: true })).toBeVisible()
+    await expect(page.getByText('Telemetry coverage')).toBeVisible()
+    await expect(page.locator('.usage-ledger')).toContainText('secret-client')
+    await expect(page.locator('.usage-ledger')).toContainText(/derived|incomplete/)
+
+    await page.getByRole('button', { name: 'Privacy' }).click()
+    await expect(page.locator('.usage-ledger')).not.toContainText('secret-client')
+    await expect(page.locator('.usage-ledger')).toContainText(/Workspace [A-Z0-9]{3}/)
+  })
+
   test('cancels cleanly while a permission decision is pending', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('button', { name: /Control/ }).click()

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -69,8 +69,10 @@ function sessionSeed(id: string, cwd: string, prompt: string, model = ''): Contr
     inputTokens: 0,
     outputTokens: 0,
     totalTokens: 0,
+    tokenTelemetryAvailable: false,
     costAmount: 0,
     costCurrency: '',
+    costTelemetryAvailable: false,
     feed: [],
     workflows: [],
   }
@@ -611,6 +613,7 @@ export class GrokController extends EventEmitter {
       inputTokens: response.usage?.inputTokens || session.inputTokens,
       outputTokens: response.usage?.outputTokens || session.outputTokens,
       totalTokens: response.usage?.totalTokens || session.totalTokens,
+      tokenTelemetryAvailable: Boolean(response.usage) || session.tokenTelemetryAvailable,
     })
     this.emitSnapshot()
   }
@@ -657,6 +660,7 @@ export class GrokController extends EventEmitter {
     if (update.sessionUpdate === 'usage_update') {
       next.costAmount = update.cost?.amount || next.costAmount
       next.costCurrency = update.cost?.currency || next.costCurrency
+      next.costTelemetryAvailable = Boolean(update.cost) || next.costTelemetryAvailable
     }
     if (
       (update.sessionUpdate === 'tool_call' || update.sessionUpdate === 'agent_message_chunk')

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,9 +8,17 @@ import { SecurityGate } from './security.js'
 import { WorkspaceInspector } from './workspace-inspector.js'
 import { SessionStateStore } from './session-state.js'
 import { mergeSessionFeed, SessionReader } from './session-reader.js'
-import type { ControlSession, LiveAgent, SessionRow } from './types.js'
+import type {
+  ControlSession,
+  LiveAgent,
+  SessionRow,
+  UsageGroupDimension,
+  UsagePeriod,
+  UsageScope,
+} from './types.js'
 import { APP_VERSION } from './app-version.js'
 import { inspectSetup } from './setup-diagnostics.js'
+import { UsageLedger } from './usage-ledger.js'
 
 const app = express()
 const sessionState = new SessionStateStore()
@@ -21,19 +29,46 @@ const controller = new GrokController(sessionState)
 await controller.restore()
 const workspaceInspector = new WorkspaceInspector()
 const sessionReader = new SessionReader(store.grokHome)
+const usageLedger = new UsageLedger(sessionState)
 const port = Number(process.env.PORT || 4310)
 const host = process.env.HOST || '127.0.0.1'
 const security = new SecurityGate(host)
 const eventClients = new Set<express.Response>()
+let usageSyncTimer: NodeJS.Timeout | null = null
 
 function broadcast(event: string, payload: unknown) {
   const frame = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`
   eventClients.forEach((client) => client.write(frame))
 }
 
-liveMonitor.on('live', (payload) => broadcast('live', payload))
+async function syncUsage(): Promise<void> {
+  await usageLedger.sync({
+    sessions: (await store.dashboard()).sessions,
+    live: liveMonitor.snapshot().agents,
+    managed: controller.snapshot().sessions,
+  })
+}
+
+function scheduleUsageSync(): void {
+  if (usageSyncTimer) clearTimeout(usageSyncTimer)
+  usageSyncTimer = setTimeout(() => {
+    usageSyncTimer = null
+    void syncUsage().catch(() => {
+      // A later session or telemetry event will retry the durable snapshot.
+    })
+  }, 220)
+  usageSyncTimer.unref()
+}
+
+liveMonitor.on('live', (payload) => {
+  broadcast('live', payload)
+  scheduleUsageSync()
+})
 liveMonitor.on('dashboard', (payload) => broadcast('dashboard', payload))
-controller.on('control', (payload) => broadcast('control', payload))
+controller.on('control', (payload) => {
+  broadcast('control', payload)
+  scheduleUsageSync()
+})
 workspaceInspector.on('change', (payload) => broadcast('workspace', payload))
 
 app.disable('x-powered-by')
@@ -63,6 +98,38 @@ app.get('/api/dashboard', async (request, response, next) => {
 
 app.get('/api/live', (_request, response) => {
   response.json(liveMonitor.snapshot())
+})
+
+const USAGE_PERIODS = new Set<UsagePeriod>(['24h', '7d', '30d', '90d', 'all'])
+const USAGE_SCOPES = new Set<UsageScope>(['sessions', 'workflow-agents', 'all'])
+const USAGE_GROUPS = new Set<UsageGroupDimension>(['project', 'model', 'session', 'agent'])
+
+app.get('/api/usage', async (request, response, next) => {
+  try {
+    const period = typeof request.query.period === 'string' ? request.query.period : '30d'
+    const scope = typeof request.query.scope === 'string' ? request.query.scope : 'sessions'
+    const groupBy = typeof request.query.groupBy === 'string' ? request.query.groupBy : 'project'
+    if (!USAGE_PERIODS.has(period as UsagePeriod)) {
+      response.status(400).json({ error: 'Usage period must be 24h, 7d, 30d, 90d, or all.' })
+      return
+    }
+    if (!USAGE_SCOPES.has(scope as UsageScope)) {
+      response.status(400).json({ error: 'Usage scope must be sessions, workflow-agents, or all.' })
+      return
+    }
+    if (!USAGE_GROUPS.has(groupBy as UsageGroupDimension)) {
+      response.status(400).json({ error: 'Usage grouping must be project, model, session, or agent.' })
+      return
+    }
+    await syncUsage()
+    response.json(usageLedger.report({
+      period: period as UsagePeriod,
+      scope: scope as UsageScope,
+      groupBy: groupBy as UsageGroupDimension,
+    }))
+  } catch (error) {
+    next(error)
+  }
 })
 
 let setupCache: { expiresAt: number; payload: Awaited<ReturnType<typeof inspectSetup>> } | null = null
@@ -380,6 +447,7 @@ app.use((
 })
 
 await liveMonitor.start()
+await syncUsage()
 
 export const server = await new Promise<ReturnType<typeof app.listen>>((resolve, reject) => {
   const listener = app.listen(port, host, () => resolve(listener))
@@ -397,6 +465,7 @@ console.log('Local Grok state linked')
 console.log(`Remote authentication ${security.authRequired ? 'enabled' : 'not required on loopback'}`)
 
 async function shutdown() {
+  if (usageSyncTimer) clearTimeout(usageSyncTimer)
   server.close()
   await Promise.all([liveMonitor.stop(), controller.stop(), workspaceInspector.close()])
   process.exit(0)

--- a/server/live-monitor.ts
+++ b/server/live-monitor.ts
@@ -32,6 +32,7 @@ interface LiveUsage {
   contextSize: number
   costAmount: number
   costCurrency: string
+  costTelemetryAvailable: boolean
 }
 
 const MAX_TAIL_BYTES = 512 * 1024
@@ -197,7 +198,13 @@ function feedFromUpdates(updates: ParsedUpdate[]): LiveFeedItem[] {
 function usageFromUpdates(updates: ParsedUpdate[]): LiveUsage {
   const usage = [...updates].reverse().find(({ update }) => asString(update.sessionUpdate) === 'usage_update')?.update
   if (!usage) {
-    return { contextUsed: 0, contextSize: 0, costAmount: 0, costCurrency: '' }
+    return {
+      contextUsed: 0,
+      contextSize: 0,
+      costAmount: 0,
+      costCurrency: '',
+      costTelemetryAvailable: false,
+    }
   }
   const cost = asObject(usage.cost)
   return {
@@ -205,6 +212,7 @@ function usageFromUpdates(updates: ParsedUpdate[]): LiveUsage {
     contextSize: asNumber(usage.size),
     costAmount: asNumber(cost.amount),
     costCurrency: asString(cost.currency),
+    costTelemetryAvailable: Object.keys(cost).length > 0,
   }
 }
 

--- a/server/session-state.ts
+++ b/server/session-state.ts
@@ -1,7 +1,14 @@
 import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { ControlSession, SessionRow, WorkflowRun } from './types.js'
+import type {
+  ControlSession,
+  SessionRow,
+  UsageLedgerEntry,
+  UsageMetric,
+  UsageSource,
+  WorkflowRun,
+} from './types.js'
 import { interruptRestoredWorkflow } from './workflow-state.js'
 
 export interface SessionAnnotation {
@@ -11,19 +18,83 @@ export interface SessionAnnotation {
 }
 
 interface PersistedState {
-  version: 1
+  version: 2
   sessions: Record<string, SessionAnnotation>
   managedSessions: ControlSession[]
+  usageEntries: UsageLedgerEntry[]
 }
 
 const EMPTY_STATE: PersistedState = {
-  version: 1,
+  version: 2,
   sessions: {},
   managedSessions: [],
+  usageEntries: [],
 }
+
+const USAGE_SOURCES = new Set<UsageSource>([
+  'grok-reported',
+  'derived',
+  'incomplete',
+  'unavailable',
+])
+const MAX_USAGE_ENTRIES = 10_000
 
 function safeId(id: string): boolean {
   return Boolean(id) && /^[a-zA-Z0-9-]+$/.test(id)
+}
+
+function boundedString(value: unknown, limit = 512): string {
+  return typeof value === 'string' ? value.slice(0, limit) : ''
+}
+
+function normalizedDate(value: unknown): string {
+  const parsed = typeof value === 'string' ? new Date(value) : new Date(Number.NaN)
+  return Number.isNaN(parsed.getTime()) ? new Date(0).toISOString() : parsed.toISOString()
+}
+
+function normalizeUsageMetric(value: unknown): UsageMetric {
+  if (!value || typeof value !== 'object') return { value: null, source: 'unavailable' }
+  const metric = value as Partial<UsageMetric>
+  const source = USAGE_SOURCES.has(metric.source as UsageSource)
+    ? metric.source as UsageSource
+    : 'unavailable'
+  const numeric = typeof metric.value === 'number' && Number.isFinite(metric.value) && metric.value >= 0
+    ? metric.value
+    : null
+  return {
+    value: numeric,
+    source: numeric === null ? 'unavailable' : source,
+  }
+}
+
+function normalizeUsageEntry(value: unknown): UsageLedgerEntry | null {
+  if (!value || typeof value !== 'object') return null
+  const item = value as Partial<UsageLedgerEntry>
+  const id = boundedString(item.id)
+  const sessionId = boundedString(item.sessionId)
+  if (!id || !sessionId || !/^[a-zA-Z0-9:._-]+$/.test(id)) return null
+  if (!['managed-session', 'cli-session', 'workflow-agent'].includes(item.kind || '')) return null
+  const cost = normalizeUsageMetric(item.cost)
+  return {
+    id,
+    kind: item.kind as UsageLedgerEntry['kind'],
+    sessionId,
+    sessionTitle: boundedString(item.sessionTitle, 256),
+    workflowId: boundedString(item.workflowId),
+    project: boundedString(item.project, 256),
+    cwd: boundedString(item.cwd, 2_048),
+    model: boundedString(item.model, 256),
+    agent: boundedString(item.agent, 256),
+    startedAt: normalizedDate(item.startedAt),
+    updatedAt: normalizedDate(item.updatedAt),
+    inputTokens: normalizeUsageMetric(item.inputTokens),
+    outputTokens: normalizeUsageMetric(item.outputTokens),
+    totalTokens: normalizeUsageMetric(item.totalTokens),
+    cost: {
+      ...cost,
+      currency: boundedString(item.cost?.currency, 16).toUpperCase(),
+    },
+  }
 }
 
 function normalizeControlSession(value: unknown): ControlSession | null {
@@ -52,8 +123,15 @@ function normalizeControlSession(value: unknown): ControlSession | null {
     inputTokens: Number(item.inputTokens) || 0,
     outputTokens: Number(item.outputTokens) || 0,
     totalTokens: Number(item.totalTokens) || 0,
+    tokenTelemetryAvailable: item.tokenTelemetryAvailable === true
+      || Number(item.inputTokens) > 0
+      || Number(item.outputTokens) > 0
+      || Number(item.totalTokens) > 0,
     costAmount: Number(item.costAmount) || 0,
     costCurrency: typeof item.costCurrency === 'string' ? item.costCurrency : '',
+    costTelemetryAvailable: item.costTelemetryAvailable === true
+      || Number(item.costAmount) > 0
+      || Boolean(item.costCurrency),
     feed: Array.isArray(item.feed) ? item.feed.slice(-120) : [],
     workflows: Array.isArray(item.workflows)
       ? item.workflows
@@ -92,10 +170,16 @@ export class SessionStateStore {
         }
       })
       this.state = {
-        version: 1,
+        version: 2,
         sessions: annotations,
         managedSessions: Array.isArray(raw.managedSessions)
           ? raw.managedSessions.map(normalizeControlSession).filter((item): item is ControlSession => item !== null)
+          : [],
+        usageEntries: Array.isArray(raw.usageEntries)
+          ? raw.usageEntries
+            .map(normalizeUsageEntry)
+            .filter((item): item is UsageLedgerEntry => item !== null)
+            .slice(0, MAX_USAGE_ENTRIES)
           : [],
       }
     } catch {
@@ -158,6 +242,38 @@ export class SessionStateStore {
         agents: workflow.agents.map((agent) => ({ ...agent })),
       })),
     }))
+    await this.persist()
+  }
+
+  usageEntries(): UsageLedgerEntry[] {
+    return this.state.usageEntries.map((entry) => ({
+      ...entry,
+      inputTokens: { ...entry.inputTokens },
+      outputTokens: { ...entry.outputTokens },
+      totalTokens: { ...entry.totalTokens },
+      cost: { ...entry.cost },
+    }))
+  }
+
+  async mergeUsageEntries(entries: UsageLedgerEntry[]): Promise<void> {
+    const previousSnapshot = JSON.stringify(this.state.usageEntries)
+    const merged = new Map(this.state.usageEntries.map((entry) => [entry.id, entry]))
+    entries.forEach((entry) => {
+      const normalized = normalizeUsageEntry(entry)
+      if (!normalized) return
+      const previous = merged.get(normalized.id)
+      merged.set(normalized.id, {
+        ...previous,
+        ...normalized,
+        startedAt: previous && previous.startedAt < normalized.startedAt
+          ? previous.startedAt
+          : normalized.startedAt,
+      })
+    })
+    this.state.usageEntries = [...merged.values()]
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id))
+      .slice(0, MAX_USAGE_ENTRIES)
+    if (JSON.stringify(this.state.usageEntries) === previousSnapshot) return
     await this.persist()
   }
 

--- a/server/session-workbench.test.ts
+++ b/server/session-workbench.test.ts
@@ -39,8 +39,10 @@ function managedSession(state: ControlSession['state'] = 'working'): ControlSess
     inputTokens: 120,
     outputTokens: 80,
     totalTokens: 200,
+    tokenTelemetryAvailable: true,
     costAmount: 0.02,
     costCurrency: 'USD',
+    costTelemetryAvailable: true,
     workflows: [{
       id: 'workflow-durable-1',
       controlHandle: 'durable-run',

--- a/server/types.ts
+++ b/server/types.ts
@@ -131,6 +131,7 @@ export interface LiveAgent {
   contextSize: number
   costAmount: number
   costCurrency: string
+  costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
 }
 
@@ -223,8 +224,10 @@ export interface ControlSession {
   inputTokens: number
   outputTokens: number
   totalTokens: number
+  tokenTelemetryAvailable: boolean
   costAmount: number
   costCurrency: string
+  costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
   workflows: WorkflowRun[]
 }
@@ -303,4 +306,62 @@ export interface SessionWorkbenchData {
   control: ControlSession | null
   permissions: ControlPermission[]
   managed: boolean
+}
+
+export type UsageSource = 'grok-reported' | 'derived' | 'incomplete' | 'unavailable'
+export type UsageEntryKind = 'managed-session' | 'cli-session' | 'workflow-agent'
+export type UsageGroupDimension = 'project' | 'model' | 'session' | 'agent'
+export type UsagePeriod = '24h' | '7d' | '30d' | '90d' | 'all'
+export type UsageScope = 'sessions' | 'workflow-agents' | 'all'
+
+export interface UsageMetric {
+  value: number | null
+  source: UsageSource
+}
+
+export interface UsageCostMetric extends UsageMetric {
+  currency: string
+}
+
+export interface UsageLedgerEntry {
+  id: string
+  kind: UsageEntryKind
+  sessionId: string
+  sessionTitle: string
+  workflowId: string
+  project: string
+  cwd: string
+  model: string
+  agent: string
+  startedAt: string
+  updatedAt: string
+  inputTokens: UsageMetric
+  outputTokens: UsageMetric
+  totalTokens: UsageMetric
+  cost: UsageCostMetric
+}
+
+export interface UsageReportGroup {
+  key: string
+  label: string
+  entries: number
+  sessions: number
+  inputTokens: UsageMetric
+  outputTokens: UsageMetric
+  totalTokens: UsageMetric
+  costs: UsageCostMetric[]
+  updatedAt: string
+}
+
+export interface UsageReport {
+  generatedAt: string
+  period: UsagePeriod
+  scope: UsageScope
+  from: string
+  to: string
+  groupBy: UsageGroupDimension
+  entries: UsageLedgerEntry[]
+  totals: UsageReportGroup
+  groups: UsageReportGroup[]
+  coverage: Record<UsageSource, number>
 }

--- a/server/usage-ledger.test.ts
+++ b/server/usage-ledger.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SessionStateStore } from './session-state.js'
+import { UsageLedger } from './usage-ledger.js'
+import type { ControlSession, LiveAgent, SessionRow } from './types.js'
+
+const cleanup: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((directory) =>
+    fs.rm(directory, { recursive: true, force: true })))
+})
+
+async function stateStore(): Promise<SessionStateStore> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-usage-'))
+  cleanup.push(directory)
+  const state = new SessionStateStore(directory)
+  await state.load()
+  return state
+}
+
+function row(id: string, cwd: string): SessionRow {
+  return {
+    id,
+    title: id,
+    summary: '',
+    cwd,
+    workspace: path.basename(cwd),
+    createdAt: '2026-07-20T10:00:00.000Z',
+    updatedAt: '2026-07-25T10:00:00.000Z',
+    model: 'grok-code',
+    agent: 'Grok CLI',
+    reasoningEffort: 'medium',
+    sandboxProfile: 'default',
+    messages: 1,
+    chatMessages: 1,
+    turns: 1,
+    toolCalls: 0,
+    errors: 0,
+    filesTouched: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    durationSeconds: 60,
+    contextUsage: 0.5,
+    status: 'recent',
+    diskBytes: 0,
+    archived: false,
+  }
+}
+
+function live(session: SessionRow): LiveAgent {
+  return {
+    id: session.id,
+    pid: process.pid,
+    title: session.title,
+    cwd: session.cwd,
+    workspace: session.workspace,
+    openedAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    model: session.model,
+    phase: 'idle',
+    state: 'idle',
+    turns: 1,
+    toolCalls: 0,
+    contextUsage: 0.5,
+    currentTool: '',
+    contextUsed: 8_000,
+    contextSize: 16_000,
+    costAmount: 0.04,
+    costCurrency: 'usd',
+    costTelemetryAvailable: true,
+    feed: [],
+  }
+}
+
+function managed(session: SessionRow): ControlSession {
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    title: session.title,
+    model: 'grok-code-fast',
+    state: 'idle',
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    lastPrompt: 'Implement it',
+    stopReason: 'end_turn',
+    error: '',
+    cancellationStatus: 'none',
+    cancelRequestedAt: '',
+    cancelledAt: '',
+    inputTokens: 200,
+    outputTokens: 100,
+    totalTokens: 300,
+    tokenTelemetryAvailable: true,
+    costAmount: 0.08,
+    costCurrency: 'usd',
+    costTelemetryAvailable: true,
+    feed: [],
+    workflows: [{
+      id: 'workflow-1',
+      controlHandle: 'runtime',
+      displayName: 'runtime',
+      sessionId: session.id,
+      objective: 'Inspect runtime',
+      foreground: false,
+      status: 'running',
+      phases: [],
+      currentPhase: 'inspect',
+      agentBudget: 4,
+      agentsUsed: 1,
+      agentsReserved: 0,
+      agentsRemaining: 3,
+      usageIncomplete: true,
+      activeAgents: 1,
+      currentAgentLabel: 'Inspector',
+      agents: [{
+        id: 'agent-1',
+        label: 'Inspector',
+        status: 'working',
+        detail: '',
+        phase: 'inspect',
+        model: 'grok-code-fast',
+        tokensUsed: 125,
+        durationMs: 2_000,
+        tokenTelemetryAvailable: true,
+      }],
+      totalTokens: 125,
+      tokenTelemetryAvailable: true,
+      elapsedMs: 2_000,
+      lastEvent: 'agent_working',
+      lastEventDetail: '',
+      lastEventAt: session.updatedAt,
+      pauseMessage: '',
+      resultSummary: '',
+      updatedAt: session.updatedAt,
+      canPause: true,
+      canResume: false,
+      canStop: true,
+    }],
+  }
+}
+
+describe('UsageLedger', () => {
+  it('normalizes existing session and workflow telemetry without treating context occupancy as usage', async () => {
+    const state = await stateStore()
+    const ledger = new UsageLedger(state)
+    const cli = row('cli-session', '/tmp/project-a')
+    const controlledRow = row('managed-session', '/tmp/project-b')
+    const controlled = managed(controlledRow)
+
+    await ledger.sync({
+      sessions: [cli, controlledRow],
+      live: [live(cli)],
+      managed: [controlled],
+    })
+
+    const sessions = ledger.report({
+      period: 'all',
+      scope: 'sessions',
+      groupBy: 'project',
+      now: new Date('2026-07-26T10:00:00.000Z'),
+    })
+    expect(sessions.entries).toHaveLength(2)
+    expect(sessions.entries.find((entry) => entry.sessionId === 'cli-session')).toMatchObject({
+      kind: 'cli-session',
+      totalTokens: { value: null, source: 'unavailable' },
+      cost: { value: 0.04, source: 'grok-reported', currency: 'USD' },
+    })
+    expect(sessions.entries.find((entry) => entry.sessionId === 'managed-session')).toMatchObject({
+      kind: 'managed-session',
+      inputTokens: { value: 200, source: 'grok-reported' },
+      outputTokens: { value: 100, source: 'grok-reported' },
+      totalTokens: { value: 300, source: 'grok-reported' },
+    })
+    expect(sessions.totals.totalTokens).toEqual({ value: 300, source: 'incomplete' })
+    expect(sessions.coverage).toEqual({
+      'grok-reported': 1,
+      derived: 0,
+      incomplete: 0,
+      unavailable: 1,
+    })
+
+    const agents = ledger.report({
+      period: 'all',
+      scope: 'workflow-agents',
+      groupBy: 'agent',
+      now: new Date('2026-07-26T10:00:00.000Z'),
+    })
+    expect(agents.groups[0]).toMatchObject({
+      label: 'Inspector',
+      totalTokens: { value: 125, source: 'incomplete' },
+    })
+    expect(agents.entries[0].totalTokens.source).toBe('incomplete')
+  })
+
+  it('persists observations atomically and restores them after a restart', async () => {
+    const first = await stateStore()
+    const ledger = new UsageLedger(first)
+    const cli = row('durable-cli', '/tmp/durable-project')
+    await ledger.sync({ sessions: [cli], live: [live(cli)], managed: [] })
+    await first.flush()
+
+    const second = new SessionStateStore(first.directory)
+    await second.load()
+    const restored = new UsageLedger(second).report({
+      period: 'all',
+      scope: 'sessions',
+      groupBy: 'session',
+      now: new Date('2026-07-26T10:00:00.000Z'),
+    })
+
+    expect(restored.entries).toHaveLength(1)
+    expect(restored.entries[0]).toMatchObject({
+      sessionId: 'durable-cli',
+      project: 'durable-project',
+      cost: { value: 0.04, currency: 'USD' },
+    })
+    const persisted = JSON.parse(await fs.readFile(first.file, 'utf8'))
+    expect(persisted.version).toBe(2)
+    expect((await fs.stat(first.file)).mode & 0o777).toBe(0o600)
+  })
+
+  it('loads v1 UI state and upgrades it on the next atomic write', async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-usage-v1-'))
+    cleanup.push(directory)
+    await fs.writeFile(path.join(directory, 'state.json'), JSON.stringify({
+      version: 1,
+      sessions: {
+        legacy: {
+          title: 'Legacy session',
+          archived: false,
+          updatedAt: '2026-07-25T10:00:00.000Z',
+        },
+      },
+      managedSessions: [],
+    }), { mode: 0o600 })
+
+    const state = new SessionStateStore(directory)
+    await state.load()
+    expect(state.annotation('legacy')?.title).toBe('Legacy session')
+    expect(state.usageEntries()).toEqual([])
+
+    await state.annotate('legacy', { archived: true })
+    const upgraded = JSON.parse(await fs.readFile(state.file, 'utf8'))
+    expect(upgraded).toMatchObject({
+      version: 2,
+      usageEntries: [],
+    })
+  })
+})

--- a/server/usage-ledger.ts
+++ b/server/usage-ledger.ts
@@ -1,0 +1,326 @@
+import crypto from 'node:crypto'
+import path from 'node:path'
+import type {
+  ControlSession,
+  LiveAgent,
+  SessionRow,
+  UsageCostMetric,
+  UsageGroupDimension,
+  UsageLedgerEntry,
+  UsageMetric,
+  UsagePeriod,
+  UsageReport,
+  UsageReportGroup,
+  UsageScope,
+  UsageSource,
+} from './types.js'
+import { SessionStateStore } from './session-state.js'
+
+interface UsageInputs {
+  sessions: SessionRow[]
+  live: LiveAgent[]
+  managed: ControlSession[]
+}
+
+interface UsageReportOptions {
+  period?: UsagePeriod
+  scope?: UsageScope
+  groupBy?: UsageGroupDimension
+  now?: Date
+}
+
+const PERIODS: Record<Exclude<UsagePeriod, 'all'>, number> = {
+  '24h': 24 * 60 * 60_000,
+  '7d': 7 * 24 * 60 * 60_000,
+  '30d': 30 * 24 * 60 * 60_000,
+  '90d': 90 * 24 * 60 * 60_000,
+}
+
+function unavailable(): UsageMetric {
+  return { value: null, source: 'unavailable' }
+}
+
+function observed(value: number, available: boolean, incomplete = false): UsageMetric {
+  if (!available || !Number.isFinite(value) || value < 0) return unavailable()
+  return {
+    value,
+    source: incomplete ? 'incomplete' : 'grok-reported',
+  }
+}
+
+function safeDate(value: string, fallback: string): string {
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed.toISOString()
+}
+
+function stableId(...parts: string[]): string {
+  const digest = crypto.createHash('sha256').update(parts.join('\u0000')).digest('base64url').slice(0, 24)
+  return `usage:${digest}`
+}
+
+function projectName(cwd: string): string {
+  return path.basename(cwd) || cwd || 'Unknown project'
+}
+
+function sessionEntry(
+  session: SessionRow,
+  live: LiveAgent | undefined,
+  managed: ControlSession | undefined,
+): UsageLedgerEntry {
+  if (managed) {
+    return {
+      id: stableId('session', session.id),
+      kind: 'managed-session',
+      sessionId: session.id,
+      sessionTitle: managed.title || session.title,
+      workflowId: '',
+      project: projectName(managed.cwd || session.cwd),
+      cwd: managed.cwd || session.cwd,
+      model: managed.model || session.model || 'unknown',
+      agent: 'Grok UI',
+      startedAt: safeDate(managed.createdAt, session.createdAt),
+      updatedAt: safeDate(managed.updatedAt, session.updatedAt),
+      inputTokens: observed(managed.inputTokens, managed.tokenTelemetryAvailable),
+      outputTokens: observed(managed.outputTokens, managed.tokenTelemetryAvailable),
+      totalTokens: observed(managed.totalTokens, managed.tokenTelemetryAvailable),
+      cost: {
+        ...observed(managed.costAmount, managed.costTelemetryAvailable),
+        currency: managed.costCurrency.toUpperCase(),
+      },
+    }
+  }
+
+  const cwd = live?.cwd || session.cwd
+  return {
+    id: stableId('session', session.id),
+    kind: 'cli-session',
+    sessionId: session.id,
+    sessionTitle: session.title,
+    workflowId: '',
+    project: projectName(cwd),
+    cwd,
+    model: live?.model || session.model || 'unknown',
+    agent: session.agent || 'Grok CLI',
+    startedAt: safeDate(live?.openedAt || session.createdAt, session.createdAt),
+    updatedAt: safeDate(live?.updatedAt || session.updatedAt, session.updatedAt),
+    inputTokens: unavailable(),
+    outputTokens: unavailable(),
+    // Live context occupancy is not cumulative usage and must not be counted as spend.
+    totalTokens: unavailable(),
+    cost: {
+      ...observed(live?.costAmount || 0, live?.costTelemetryAvailable === true),
+      currency: (live?.costCurrency || '').toUpperCase(),
+    },
+  }
+}
+
+function syntheticRow(session: ControlSession): SessionRow {
+  return {
+    id: session.id,
+    title: session.title,
+    summary: '',
+    cwd: session.cwd,
+    workspace: projectName(session.cwd),
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    model: session.model,
+    agent: 'Grok UI',
+    reasoningEffort: '',
+    sandboxProfile: '',
+    messages: 0,
+    chatMessages: 0,
+    turns: 0,
+    toolCalls: 0,
+    errors: 0,
+    filesTouched: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    durationSeconds: 0,
+    contextUsage: 0,
+    status: 'recent',
+    diskBytes: 0,
+    archived: false,
+  }
+}
+
+function workflowEntries(session: ControlSession): UsageLedgerEntry[] {
+  return session.workflows.flatMap((workflow) =>
+    workflow.agents
+      .map((agent): UsageLedgerEntry => ({
+        id: stableId('workflow-agent', session.id, workflow.id, agent.id),
+        kind: 'workflow-agent',
+        sessionId: session.id,
+        sessionTitle: session.title,
+        workflowId: workflow.id,
+        project: projectName(session.cwd),
+        cwd: session.cwd,
+        model: agent.model || session.model || 'unknown',
+        agent: agent.label || agent.id || 'Workflow agent',
+        startedAt: safeDate(session.createdAt, new Date(0).toISOString()),
+        updatedAt: safeDate(workflow.updatedAt, session.updatedAt),
+        inputTokens: unavailable(),
+        outputTokens: unavailable(),
+        totalTokens: observed(
+          agent.tokensUsed,
+          agent.tokenTelemetryAvailable,
+          workflow.usageIncomplete,
+        ),
+        cost: { ...unavailable(), currency: '' },
+      })),
+  )
+}
+
+function metricAggregate(entries: UsageLedgerEntry[], select: (entry: UsageLedgerEntry) => UsageMetric): UsageMetric {
+  if (!entries.length) return unavailable()
+  const metrics = entries.map(select)
+  const values = metrics.flatMap((metric) => metric.value === null ? [] : [metric.value])
+  if (!values.length) return unavailable()
+  const incomplete = metrics.some((metric) =>
+    metric.source === 'incomplete' || metric.source === 'unavailable')
+  const mixesObservationLevels = entries.some((entry) => entry.kind === 'workflow-agent')
+    && entries.some((entry) => entry.kind !== 'workflow-agent')
+  return {
+    value: values.reduce((sum, value) => sum + value, 0),
+    source: incomplete || mixesObservationLevels ? 'incomplete' : 'derived',
+  }
+}
+
+function costAggregate(entries: UsageLedgerEntry[]): UsageCostMetric[] {
+  const currencies = [...new Set(entries.map((entry) => entry.cost.currency).filter(Boolean))].sort()
+  if (!currencies.length) return [{ ...unavailable(), currency: '' }]
+  return currencies.map((currency) => {
+    const matching = entries.filter((entry) => entry.cost.currency === currency)
+    const values = matching.flatMap((entry) => entry.cost.value === null ? [] : [entry.cost.value])
+    const missing = entries.some((entry) =>
+      entry.cost.currency !== currency || entry.cost.value === null || entry.cost.source === 'incomplete')
+    return {
+      value: values.length ? values.reduce((sum, value) => sum + value, 0) : null,
+      source: values.length ? missing ? 'incomplete' : 'derived' : 'unavailable',
+      currency,
+    }
+  })
+}
+
+function groupValue(entry: UsageLedgerEntry, dimension: UsageGroupDimension): { key: string; label: string } {
+  if (dimension === 'project') return { key: entry.cwd || entry.project, label: entry.project }
+  if (dimension === 'model') return { key: entry.model || 'unknown', label: entry.model || 'Unknown model' }
+  if (dimension === 'session') {
+    return { key: entry.sessionId, label: entry.sessionTitle || entry.sessionId }
+  }
+  return { key: entry.agent || 'unknown', label: entry.agent || 'Unknown agent' }
+}
+
+function summarize(key: string, label: string, entries: UsageLedgerEntry[]): UsageReportGroup {
+  return {
+    key,
+    label,
+    entries: entries.length,
+    sessions: new Set(entries.map((entry) => entry.sessionId)).size,
+    inputTokens: metricAggregate(entries, (entry) => entry.inputTokens),
+    outputTokens: metricAggregate(entries, (entry) => entry.outputTokens),
+    totalTokens: metricAggregate(entries, (entry) => entry.totalTokens),
+    costs: costAggregate(entries),
+    updatedAt: entries.reduce((latest, entry) => entry.updatedAt > latest ? entry.updatedAt : latest, ''),
+  }
+}
+
+export class UsageLedger {
+  constructor(private readonly state: SessionStateStore) {}
+
+  async sync(inputs: UsageInputs): Promise<void> {
+    const managedById = new Map(inputs.managed.map((session) => [session.id, session]))
+    const liveById = new Map(inputs.live.map((session) => [session.id, session]))
+    const sessionsById = new Map(inputs.sessions.map((session) => [session.id, session]))
+    inputs.managed.forEach((session) => {
+      if (!sessionsById.has(session.id)) sessionsById.set(session.id, syntheticRow(session))
+    })
+    inputs.live.forEach((session) => {
+      if (!sessionsById.has(session.id)) {
+        sessionsById.set(session.id, {
+          ...syntheticRow({
+            id: session.id,
+            cwd: session.cwd,
+            title: session.title,
+            model: session.model,
+            state: 'idle',
+            createdAt: session.openedAt,
+            updatedAt: session.updatedAt,
+            lastPrompt: '',
+            stopReason: '',
+            error: '',
+            cancellationStatus: 'none',
+            cancelRequestedAt: '',
+            cancelledAt: '',
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            tokenTelemetryAvailable: false,
+            costAmount: 0,
+            costCurrency: '',
+            costTelemetryAvailable: false,
+            feed: [],
+            workflows: [],
+          }),
+          agent: 'Grok CLI',
+          status: 'live',
+        })
+      }
+    })
+
+    const entries = [...sessionsById.values()].map((session) =>
+      sessionEntry(session, liveById.get(session.id), managedById.get(session.id)))
+    entries.push(...inputs.managed.flatMap(workflowEntries))
+    await this.state.mergeUsageEntries(entries)
+  }
+
+  report(options: UsageReportOptions = {}): UsageReport {
+    const period = options.period || '30d'
+    const scope = options.scope || 'sessions'
+    const groupBy = options.groupBy || 'project'
+    const now = options.now || new Date()
+    const to = now.toISOString()
+    const from = period === 'all'
+      ? new Date(0).toISOString()
+      : new Date(now.getTime() - PERIODS[period]).toISOString()
+    const entries = this.state.usageEntries()
+      .filter((entry) => entry.updatedAt >= from && entry.updatedAt <= to)
+      .filter((entry) => scope === 'all'
+        || (scope === 'workflow-agents') === (entry.kind === 'workflow-agent'))
+
+    const grouped = new Map<string, { label: string; entries: UsageLedgerEntry[] }>()
+    entries.forEach((entry) => {
+      const value = groupValue(entry, groupBy)
+      const current = grouped.get(value.key) || { label: value.label, entries: [] }
+      current.entries.push(entry)
+      grouped.set(value.key, current)
+    })
+    const groups = [...grouped.entries()]
+      .map(([key, value]) => summarize(key, value.label, value.entries))
+      .sort((left, right) =>
+        (right.totalTokens.value || 0) - (left.totalTokens.value || 0)
+        || right.updatedAt.localeCompare(left.updatedAt)
+        || left.label.localeCompare(right.label))
+    const coverage: Record<UsageSource, number> = {
+      'grok-reported': 0,
+      derived: 0,
+      incomplete: 0,
+      unavailable: 0,
+    }
+    entries.forEach((entry) => {
+      coverage[entry.totalTokens.source] += 1
+    })
+
+    return {
+      generatedAt: new Date().toISOString(),
+      period,
+      scope,
+      from,
+      to,
+      groupBy,
+      entries,
+      totals: summarize('all', 'All usage', entries),
+      groups,
+      coverage,
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
   TimerReset,
   ToolCase,
   Workflow,
+  WalletCards,
   X,
   Zap,
   type LucideIcon,
@@ -52,11 +53,13 @@ import { ChangesView } from './views/ChangesView'
 import { ControlView } from './views/ControlView'
 import { SessionWorkbench } from './views/SessionWorkbench'
 import { WorkflowsView } from './views/WorkflowsView'
+import { UsageView } from './views/UsageView'
 import { PrivacyProvider, usePrivacy } from './privacy'
 import packageJson from '../package.json'
 
 interface NavItem {
   id: ViewId
+  index: string
   label: string
   eyebrow: string
   icon: LucideIcon
@@ -64,16 +67,17 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { id: 'live', label: 'Live', eyebrow: 'Runtime', icon: Radio, shortcut: '1' },
-  { id: 'control', label: 'Control', eyebrow: 'Operate', icon: Command, shortcut: '2' },
-  { id: 'runs', label: 'Runs', eyebrow: 'Orchestrate', icon: Workflow, shortcut: '3' },
-  { id: 'changes', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '4' },
-  { id: 'overview', label: 'Overview', eyebrow: 'Command', icon: Gauge, shortcut: '5' },
-  { id: 'sessions', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '6' },
-  { id: 'activity', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '7' },
-  { id: 'library', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: '8' },
-  { id: 'memory', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: '9' },
-  { id: 'themes', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '0' },
+  { id: 'live', index: '01', label: 'Live', eyebrow: 'Runtime', icon: Radio, shortcut: '1' },
+  { id: 'control', index: '02', label: 'Control', eyebrow: 'Operate', icon: Command, shortcut: '2' },
+  { id: 'runs', index: '03', label: 'Runs', eyebrow: 'Orchestrate', icon: Workflow, shortcut: '3' },
+  { id: 'changes', index: '04', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '4' },
+  { id: 'overview', index: '05', label: 'Overview', eyebrow: 'Command', icon: Gauge, shortcut: '5' },
+  { id: 'sessions', index: '06', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '6' },
+  { id: 'activity', index: '07', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '7' },
+  { id: 'usage', index: '08', label: 'Usage', eyebrow: 'Ledger', icon: WalletCards, shortcut: 'u' },
+  { id: 'library', index: '09', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: '8' },
+  { id: 'memory', index: '10', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: '9' },
+  { id: 'themes', index: '11', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '0' },
 ]
 
 type ThemeId = 'operator' | 'event-horizon'
@@ -401,6 +405,7 @@ function App() {
               />
             )}
             {view === 'activity' && <ActivityView data={data} />}
+            {view === 'usage' && <UsageView />}
             {view === 'library' && <LibraryView data={data} query={query} onQuery={setQuery} />}
             {view === 'memory' && <MemoryView data={data} />}
             {view === 'themes' && <ThemesView active={theme} onSelect={setTheme} />}
@@ -466,7 +471,7 @@ function ThemesView({
   return (
     <>
       <PageIntro
-        index="10"
+        index="11"
         eyebrow="Visual systems"
         title={<>Choose your<br /><em>command atmosphere.</em></>}
         description="Switch the entire dashboard aesthetic without changing your data, sessions, or workflow. Your selection stays active on this device."
@@ -557,7 +562,7 @@ function Sidebar({
                 className={`nav-item ${active === item.id ? 'is-active' : ''}`}
                 onClick={() => onNavigate(item.id)}
               >
-                <span className="nav-index">{item.shortcut === '0' ? '10' : `0${item.shortcut}`}</span>
+                <span className="nav-index">{item.index}</span>
                 <Icon size={17} strokeWidth={1.7} />
                 <span className="nav-copy">
                   <strong>{item.label}</strong>
@@ -1518,7 +1523,7 @@ function LibraryView({
   return (
     <>
       <PageIntro
-        index="08"
+        index="09"
         eyebrow="Capability library"
         title={<>What Grok can<br /><em>reach for.</em></>}
         description="The local skills, agent profiles, and marketplace packages shaping every run."
@@ -1557,7 +1562,7 @@ function MemoryView({ data }: { data: DashboardPayload }) {
   return (
     <>
       <PageIntro
-        index="09"
+        index="10"
         eyebrow="Durable recall"
         title={<>Memory without<br /><em>the mystery.</em></>}
         description="A privacy-conscious inventory of Grok’s durable Markdown memory. Content stays on disk and is not rendered here."
@@ -1606,7 +1611,7 @@ function PageIntro({
 }) {
   return (
     <header className="page-intro">
-      <div className="intro-index">{index} / 10</div>
+      <div className="intro-index">{index} / 11</div>
       <div>
         <div className="kicker">{eyebrow}</div>
         <h1>{title}</h1>

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,6 +6,10 @@ import type {
   SessionWorkbenchData,
   LiveSnapshot,
   SetupStatus,
+  UsageGroupDimension,
+  UsagePeriod,
+  UsageReport,
+  UsageScope,
   WorkflowControlAction,
   WorkspaceDiff,
   WorkspaceSnapshot,
@@ -27,6 +31,20 @@ export async function getDashboard(force = false): Promise<DashboardPayload> {
 export async function getLiveSnapshot(): Promise<LiveSnapshot> {
   const response = await fetch('/api/live', { headers: { Accept: 'application/json' } })
   return json<LiveSnapshot>(response, 'Live runtime request failed')
+}
+
+export async function getUsageReport(input: {
+  period: UsagePeriod
+  scope: UsageScope
+  groupBy: UsageGroupDimension
+}): Promise<UsageReport> {
+  const query = new URLSearchParams(input)
+  return json(
+    await fetch(`/api/usage?${query.toString()}`, {
+      headers: { Accept: 'application/json' },
+    }),
+    'Usage ledger request failed',
+  )
 }
 
 export async function getSetupStatus(force = false): Promise<SetupStatus> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7453,7 +7453,7 @@ kbd {
   .workflow-empty { grid-template-columns: 130px minmax(0, 1fr); }
   .workflow-empty > button { grid-column: 2; width: max-content; }
   .workflow-radar { width: 120px; }
-  .mobile-bottom-nav { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+  .mobile-bottom-nav { grid-template-columns: repeat(10, minmax(0, 1fr)); }
 }
 
 @media (max-width: 680px) {
@@ -7516,5 +7516,366 @@ kbd {
     overflow: visible;
     font-size: var(--type-label);
     white-space: nowrap;
+  }
+}
+
+/* v0.9 persistent usage ledger */
+
+.usage-toolbar {
+  display: grid;
+  grid-template-columns: minmax(360px, 1fr) minmax(170px, .35fr) minmax(150px, .3fr);
+  gap: 1px;
+  margin-bottom: 18px;
+  border: 1px solid var(--line);
+  background: var(--line);
+}
+
+.usage-toolbar > div {
+  min-width: 0;
+  padding: 13px 15px;
+  display: grid;
+  gap: 9px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.usage-toolbar > div > span {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .15em;
+  text-transform: uppercase;
+}
+
+.usage-toolbar select {
+  width: 100%;
+  height: 36px;
+  padding: 0 34px 0 11px;
+  color: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--surface-2);
+  text-transform: capitalize;
+}
+
+.usage-segment {
+  display: flex;
+  gap: 4px;
+}
+
+.usage-segment button {
+  min-width: 54px;
+  height: 36px;
+  padding: 0 12px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  background: transparent;
+  cursor: pointer;
+}
+
+.usage-segment button:hover {
+  color: var(--paper);
+  border-color: var(--line-strong);
+}
+
+.usage-segment button.is-active {
+  color: var(--ink);
+  border-color: var(--lime);
+  background: var(--lime);
+}
+
+.usage-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(240px, 1.2fr);
+  gap: 1px;
+  border: 1px solid var(--line);
+  background: var(--line);
+}
+
+.usage-metric-card,
+.usage-coverage-card {
+  min-width: 0;
+  min-height: 142px;
+  padding: 17px;
+  background:
+    linear-gradient(135deg, var(--lime-soft), transparent 55%),
+    var(--surface);
+}
+
+.usage-metric-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-content: space-between;
+  gap: 10px;
+}
+
+.usage-metric-card > svg {
+  color: var(--lime);
+}
+
+.usage-metric-card > span,
+.usage-coverage-card > span {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.usage-metric-card > strong {
+  grid-column: 1 / -1;
+  color: var(--paper);
+  font-family: 'Syne Variable', sans-serif;
+  font-size: clamp(24px, 2.4vw, 38px);
+  font-weight: 560;
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+.usage-metric-card > small {
+  grid-column: 1 / -1;
+}
+
+.usage-source {
+  width: fit-content;
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.usage-source.source-grok-reported {
+  color: var(--lime);
+}
+
+.usage-source.source-derived {
+  color: var(--coral);
+}
+
+.usage-source.source-incomplete {
+  color: var(--amber);
+}
+
+.usage-source.source-unavailable {
+  color: var(--muted-dim);
+}
+
+.usage-coverage-card {
+  display: grid;
+  align-content: space-between;
+  gap: 14px;
+}
+
+.usage-coverage-card > div {
+  display: grid;
+  gap: 7px;
+}
+
+.usage-coverage-card small {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--type-meta);
+}
+
+.usage-coverage-card small strong {
+  color: var(--paper);
+  font-size: var(--type-body);
+}
+
+.usage-source-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted-dim);
+}
+
+.usage-source-dot.source-grok-reported {
+  background: var(--lime);
+  box-shadow: 0 0 9px color-mix(in srgb, var(--lime) 50%, transparent);
+}
+
+.usage-source-dot.source-derived {
+  background: var(--coral);
+}
+
+.usage-source-dot.source-incomplete {
+  background: var(--amber);
+}
+
+.usage-ledger {
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.usage-ledger > header {
+  min-height: 78px;
+  padding: 15px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.usage-ledger > header div {
+  display: grid;
+  gap: 5px;
+}
+
+.usage-ledger > header span {
+  color: var(--lime);
+  font-size: var(--type-meta);
+  letter-spacing: .14em;
+}
+
+.usage-ledger > header h2 {
+  margin: 0;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 20px;
+  font-weight: 560;
+}
+
+.usage-ledger > header > small {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+}
+
+.usage-table {
+  display: grid;
+  grid-template-columns: minmax(220px, 2fr) .6fr .75fr .75fr .85fr minmax(110px, .85fr);
+  gap: 14px;
+  align-items: center;
+}
+
+.usage-table-head {
+  min-height: 38px;
+  padding: 0 18px;
+  color: var(--muted-dim);
+  border-bottom: 1px solid var(--line);
+  font-size: var(--type-meta);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.usage-table-row {
+  min-height: 68px;
+  padding: 11px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.usage-table-row:last-child {
+  border-bottom: 0;
+}
+
+.usage-table-row:hover {
+  background: rgba(255,255,255,.025);
+}
+
+.usage-table-row > span {
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--type-body);
+}
+
+.usage-table-row > span:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.usage-table-row > span:first-child strong,
+.usage-table-row > span:nth-child(5) strong {
+  color: var(--paper);
+}
+
+.usage-table-row > span:first-child strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.usage-table-row > span:first-child small {
+  color: var(--muted-dim);
+}
+
+.usage-state {
+  min-height: 180px;
+  padding: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+}
+
+.usage-state.is-error {
+  color: var(--coral);
+}
+
+.usage-state > div {
+  display: grid;
+  gap: 5px;
+}
+
+.usage-state strong {
+  color: var(--paper);
+}
+
+.usage-scope-note {
+  margin: 14px 0 0;
+  padding: 12px 14px;
+  color: var(--amber);
+  border-left: 2px solid var(--amber);
+  background: color-mix(in srgb, var(--amber) 6%, transparent);
+  font-size: var(--type-body);
+  line-height: 1.7;
+}
+
+@media (max-width: 1040px) {
+  .usage-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .usage-toolbar > div:first-child {
+    grid-column: 1 / -1;
+  }
+
+  .usage-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .usage-toolbar,
+  .usage-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .usage-toolbar > div:first-child {
+    grid-column: auto;
+  }
+
+  .usage-segment {
+    overflow-x: auto;
+  }
+
+  .usage-table-head {
+    display: none;
+  }
+
+  .usage-table-row {
+    grid-template-columns: 1.5fr .7fr .9fr;
+    gap: 10px;
+  }
+
+  .usage-table-row > span:nth-child(3),
+  .usage-table-row > span:nth-child(4) {
+    display: none;
+  }
+
+  .usage-table-row > span:nth-child(6) {
+    grid-column: 2 / -1;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type ViewId = 'live' | 'control' | 'runs' | 'changes' | 'overview' | 'sessions' | 'activity' | 'library' | 'memory' | 'themes'
+export type ViewId = 'live' | 'control' | 'runs' | 'changes' | 'overview' | 'sessions' | 'activity' | 'usage' | 'library' | 'memory' | 'themes'
 export type SessionStatus = 'live' | 'recent' | 'idle' | 'attention'
 
 export interface SessionRow {
@@ -132,6 +132,7 @@ export interface LiveAgent {
   contextSize: number
   costAmount: number
   costCurrency: string
+  costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
 }
 
@@ -224,8 +225,10 @@ export interface ControlSession {
   inputTokens: number
   outputTokens: number
   totalTokens: number
+  tokenTelemetryAvailable: boolean
   costAmount: number
   costCurrency: string
+  costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
   workflows: WorkflowRun[]
 }
@@ -304,4 +307,62 @@ export interface SessionWorkbenchData {
   control: ControlSession | null
   permissions: ControlPermission[]
   managed: boolean
+}
+
+export type UsageSource = 'grok-reported' | 'derived' | 'incomplete' | 'unavailable'
+export type UsageEntryKind = 'managed-session' | 'cli-session' | 'workflow-agent'
+export type UsageGroupDimension = 'project' | 'model' | 'session' | 'agent'
+export type UsagePeriod = '24h' | '7d' | '30d' | '90d' | 'all'
+export type UsageScope = 'sessions' | 'workflow-agents' | 'all'
+
+export interface UsageMetric {
+  value: number | null
+  source: UsageSource
+}
+
+export interface UsageCostMetric extends UsageMetric {
+  currency: string
+}
+
+export interface UsageLedgerEntry {
+  id: string
+  kind: UsageEntryKind
+  sessionId: string
+  sessionTitle: string
+  workflowId: string
+  project: string
+  cwd: string
+  model: string
+  agent: string
+  startedAt: string
+  updatedAt: string
+  inputTokens: UsageMetric
+  outputTokens: UsageMetric
+  totalTokens: UsageMetric
+  cost: UsageCostMetric
+}
+
+export interface UsageReportGroup {
+  key: string
+  label: string
+  entries: number
+  sessions: number
+  inputTokens: UsageMetric
+  outputTokens: UsageMetric
+  totalTokens: UsageMetric
+  costs: UsageCostMetric[]
+  updatedAt: string
+}
+
+export interface UsageReport {
+  generatedAt: string
+  period: UsagePeriod
+  scope: UsageScope
+  from: string
+  to: string
+  groupBy: UsageGroupDimension
+  entries: UsageLedgerEntry[]
+  totals: UsageReportGroup
+  groups: UsageReportGroup[]
+  coverage: Record<UsageSource, number>
 }

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -1,0 +1,239 @@
+import {
+  CircleDollarSign,
+  DatabaseZap,
+  RefreshCw,
+  Sigma,
+  WalletCards,
+  type LucideIcon,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { getUsageReport } from '../api'
+import { usePrivacy } from '../privacy'
+import type {
+  UsageGroupDimension,
+  UsageMetric,
+  UsagePeriod,
+  UsageReport,
+  UsageScope,
+  UsageSource,
+} from '../types'
+
+const PERIODS: UsagePeriod[] = ['24h', '7d', '30d', '90d', 'all']
+const SCOPES: Array<{ id: UsageScope; label: string }> = [
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'workflow-agents', label: 'Workflow agents' },
+  { id: 'all', label: 'All observations' },
+]
+const GROUPS: UsageGroupDimension[] = ['project', 'model', 'session', 'agent']
+const compact = new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 })
+
+function metricValue(metric: UsageMetric): string {
+  if (metric.value === null) return '—'
+  return metric.value >= 10_000 ? compact.format(metric.value) : metric.value.toLocaleString()
+}
+
+function sourceLabel(source: UsageSource): string {
+  return source === 'grok-reported' ? 'Grok-reported' : source
+}
+
+function costValue(report: UsageReport | null): string {
+  if (!report) return '—'
+  const costs = report.totals.costs.filter((cost) => cost.value !== null)
+  if (!costs.length) return '—'
+  return costs.map((cost) =>
+    `${cost.value?.toLocaleString(undefined, { maximumFractionDigits: 4 })} ${cost.currency}`,
+  ).join(' + ')
+}
+
+export function UsageView() {
+  const privacy = usePrivacy()
+  const [period, setPeriod] = useState<UsagePeriod>('30d')
+  const [scope, setScope] = useState<UsageScope>('sessions')
+  const [groupBy, setGroupBy] = useState<UsageGroupDimension>('project')
+  const [report, setReport] = useState<UsageReport | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    void getUsageReport({ period, scope, groupBy })
+      .then((next) => {
+        if (cancelled) return
+        setReport(next)
+        setError('')
+      })
+      .catch((requestError) => {
+        if (cancelled) return
+        setError(requestError instanceof Error ? requestError.message : 'Unable to read usage ledger.')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [period, scope, groupBy])
+
+  const totalCost = useMemo(() => costValue(report), [report])
+  const visibleLabel = (label: string, key: string) => {
+    if (groupBy === 'project') return privacy.workspace(label)
+    if (groupBy === 'session') return privacy.sessionTitle(label, key)
+    if (groupBy === 'agent') return privacy.capability(label, 'Agent')
+    return label
+  }
+
+  return (
+    <>
+      <header className="page-intro">
+        <div className="intro-index">08 / 11</div>
+        <div>
+          <div className="kicker">Persistent usage ledger</div>
+          <h1>Know what was used,<br /><em>and how we know.</em></h1>
+        </div>
+        <p>
+          Durable token and cost observations across CLI sessions, managed sessions, and workflow agents,
+          with provenance attached to every value.
+        </p>
+        <div className="intro-rule"><span /></div>
+      </header>
+
+      <section className="usage-toolbar" aria-label="Usage report controls">
+        <div>
+          <span>Period</span>
+          <div className="usage-segment">
+            {PERIODS.map((item) => (
+              <button key={item} className={period === item ? 'is-active' : ''} onClick={() => setPeriod(item)}>
+                {item.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <span>Scope</span>
+          <select value={scope} onChange={(event) => setScope(event.target.value as UsageScope)}>
+            {SCOPES.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
+          </select>
+        </div>
+        <div>
+          <span>Group by</span>
+          <select value={groupBy} onChange={(event) => setGroupBy(event.target.value as UsageGroupDimension)}>
+            {GROUPS.map((item) => <option key={item} value={item}>{item}</option>)}
+          </select>
+        </div>
+      </section>
+
+      {error ? (
+        <section className="usage-state is-error">
+          <DatabaseZap size={22} />
+          <div><strong>Usage ledger unavailable</strong><span>{error}</span></div>
+        </section>
+      ) : (
+        <>
+          <section className="usage-summary">
+            <UsageMetricCard
+              icon={Sigma}
+              label="Total tokens"
+              value={metricValue(report?.totals.totalTokens || { value: null, source: 'unavailable' })}
+              source={report?.totals.totalTokens.source || 'unavailable'}
+            />
+            <UsageMetricCard
+              icon={CircleDollarSign}
+              label="Reported cost"
+              value={totalCost}
+              source={report?.totals.costs.some((cost) => cost.source === 'incomplete')
+                ? 'incomplete'
+                : report?.totals.costs.some((cost) => cost.value !== null) ? 'derived' : 'unavailable'}
+            />
+            <UsageMetricCard
+              icon={WalletCards}
+              label="Observations"
+              value={report ? report.entries.length.toLocaleString() : '—'}
+              source={report?.entries.length ? 'derived' : 'unavailable'}
+            />
+            <article className="usage-coverage-card">
+              <span>Telemetry coverage</span>
+              <div>
+                {(['grok-reported', 'derived', 'incomplete', 'unavailable'] as UsageSource[]).map((source) => (
+                  <small key={source}>
+                    <i className={`usage-source-dot source-${source}`} />
+                    {sourceLabel(source)}
+                    <strong>{report?.coverage[source] || 0}</strong>
+                  </small>
+                ))}
+              </div>
+            </article>
+          </section>
+
+          <section className="usage-ledger section-gap">
+            <header>
+              <div>
+                <span>08A / REPORT</span>
+                <h2>{groupBy[0].toUpperCase() + groupBy.slice(1)} ledger</h2>
+              </div>
+              <small>{loading ? <><RefreshCw className="is-spinning" size={13} /> Syncing observations</> : `${report?.groups.length || 0} groups`}</small>
+            </header>
+            <div className="usage-table usage-table-head" aria-hidden="true">
+              <span>{groupBy}</span><span>Sessions</span><span>Input</span><span>Output</span><span>Total</span><span>Source</span>
+            </div>
+            {report?.groups.length ? report.groups.map((group) => (
+              <article className="usage-table usage-table-row" key={group.key}>
+                <span>
+                  <strong>{visibleLabel(group.label, group.key)}</strong>
+                  <small>{group.entries} observation{group.entries === 1 ? '' : 's'}</small>
+                </span>
+                <span>{group.sessions.toLocaleString()}</span>
+                <span>{metricValue(group.inputTokens)}</span>
+                <span>{metricValue(group.outputTokens)}</span>
+                <span><strong>{metricValue(group.totalTokens)}</strong></span>
+                <span className={`usage-source source-${group.totalTokens.source}`}>
+                  {sourceLabel(group.totalTokens.source)}
+                </span>
+              </article>
+            )) : (
+              <div className="usage-state">
+                <DatabaseZap size={22} />
+                <div>
+                  <strong>{loading ? 'Syncing usage observations' : 'No usage in this window'}</strong>
+                  <span>
+                    {loading
+                      ? 'Reading the existing session and workflow telemetry.'
+                      : 'Try a wider period or another observation scope.'}
+                  </span>
+                </div>
+              </div>
+            )}
+          </section>
+
+          {scope === 'all' && (
+            <p className="usage-scope-note">
+              “All observations” mixes session totals with workflow-agent detail. Grok UI labels mixed rollups
+              incomplete so the same work is never presented as a precise spend total.
+            </p>
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+function UsageMetricCard({
+  icon: Icon,
+  label,
+  value,
+  source,
+}: {
+  icon: LucideIcon
+  label: string
+  value: string
+  source: UsageSource
+}) {
+  return (
+    <article className="usage-metric-card">
+      <Icon size={18} />
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small className={`usage-source source-${source}`}>{sourceLabel(source)}</small>
+    </article>
+  )
+}


### PR DESCRIPTION
## Summary
- start the v0.9 Runtime Intelligence milestone with a durable usage ledger built on existing telemetry
- add provenance labels and reporting by project, model, session, agent, scope, and time period
- add the privacy-aware Usage view and v1-to-v2 state migration
- document the remaining process, port, service, test, tool-call, budget, and alert increments

## Validation
- npm run verify
- npm run test:e2e (15 passed)
- npm run test:package
- npm run test:soak (75 seconds)
- npm audit (0 vulnerabilities)

## Release posture
This merges unreleased v0.9 development only. It intentionally keeps package version 0.8.2 and does not tag or publish a release.