### PR TITLE
feat: ship v0.9 runtime intelligence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.9.0 — 2026-07-26
 
 - Started the v0.9 Runtime Intelligence milestone with a persistent,
   provenance-aware usage ledger built on the existing session and workflow
@@ -13,6 +13,16 @@
   token usage.
 - Added a privacy-aware Usage view, authenticated usage API, atomic v1-to-v2
   state migration, and coverage for persistence and mixed telemetry.
+- Added bounded process-tree and listening-port inspection for known Grok
+  process roots, with database, cache, queue, emulator, and development-service
+  classification that never probes arbitrary endpoints.
+- Added structured test-status and external tool-call panels using existing
+  safe telemetry titles, including incomplete interruption state after a
+  session or event-stream disconnect.
+- Added optional local budgets for global, project, model, session, and agent
+  scopes; deduplicated 80% and 100% alerts; and atomic v3 state migration.
+- Added bounded JSON/CSV usage exports with Privacy Mode redaction applied by
+  the authenticated server before download.
 
 ## 0.8.2 — 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,24 @@ unavailable. Grok UI does not substitute context-window occupancy for
 cumulative CLI token usage, and explicitly mixed observation scopes are never
 presented as precise spend.
 
+Optional token or reported-cost budgets can be scoped globally or to a project,
+model, session, or workflow agent. They are evaluated only against a
+non-overlapping ledger scope, and local alerts are deduplicated at 80% and
+100%. JSON and CSV exports are capped, authenticated, and redacted on the
+server before download whenever Privacy Mode is active.
+
+## Runtime intelligence
+
+The Live view projects bounded process trees from active Grok and UI-managed
+process IDs. It discovers listening TCP ports only for that selected process
+set, classifies common databases and development services without connecting
+to them, and shows structured test status and external-call categories from the
+existing safe tool lifecycle.
+
+Inspection uses fixed timeouts, output, process-count, and tree-depth caps. Raw
+command arguments, tool input, credentials, headers, terminal history, and
+unrelated host processes are never included in the browser contract.
+
 ## Themes
 
 Two complete visual systems ship with the dashboard:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,13 +17,16 @@ The roadmap extends those foundations instead of replacing them.
 ## v0.9 — Runtime intelligence
 
 - Inspect process trees, open ports, test state, databases, local services, and
-  external tool calls.
+  external tool calls. The bounded runtime inspector and Live panels are
+  implemented without shell execution, endpoint probing, or raw command input.
 - Persist usage across CLI sessions, managed sessions, workflows, projects,
   models, agents, and time periods. The provenance-aware ledger and reporting
   API are now implemented on the v0.9 development branch.
 - Identify each usage value as Grok-reported, derived, incomplete, or
   unavailable. The first Usage view now exposes those labels directly.
-- Add optional budgets, alerts, and exports.
+- Add optional budgets, alerts, and exports. Budgets now persist locally,
+  evaluate non-overlapping ledger scopes, deduplicate 80%/100% alerts, and
+  export bounded JSON/CSV with server-side Privacy Mode redaction.
 
 The staged design, security constraints, and release gate are tracked in
 [`v0.9-runtime-intelligence.md`](./v0.9-runtime-intelligence.md).

--- a/docs/v0.9-runtime-intelligence.md
+++ b/docs/v0.9-runtime-intelligence.md
@@ -65,6 +65,8 @@ tokens, the ledger says `unavailable`.
 
 ### Increment 2 — Bounded runtime discovery
 
+Status: implemented and covered by unit and browser tests.
+
 - Introduce a `RuntimeInspector` fed by active and managed session process IDs.
 - Walk descendants with platform adapters (`ps` on macOS/POSIX, a documented
   fallback elsewhere), fixed timeouts, PID/count/depth caps, and no shell.
@@ -77,6 +79,8 @@ tokens, the ledger says `unavailable`.
 
 ### Increment 3 — Tests and external calls
 
+Status: implemented and covered by interruption/privacy tests.
+
 - Derive test command lifecycle from existing structured tool calls and ACP
   updates. Track command label, state, start/end time, exit evidence, and the
   owning session without persisting raw command input.
@@ -87,6 +91,8 @@ tokens, the ledger says `unavailable`.
 
 ### Increment 4 — Budgets, alerts, and export
 
+Status: implemented with atomic v3 state migration.
+
 - Persist optional budgets by global, project, model, session, or agent scope.
 - Evaluate budgets against a single non-overlapping ledger scope and currency.
 - Support token and spend thresholds with deduplicated local alerts.
@@ -95,6 +101,8 @@ tokens, the ledger says `unavailable`.
 - Budgets remain opt-in; no telemetry or alert delivery leaves the host.
 
 ### Increment 5 — Hardening and release candidate
+
+Status: in release-candidate verification.
 
 - Unit-test every parser, adapter, state migration, provenance rule, and budget
   transition.

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -48,7 +48,7 @@ async function registerLiveSession() {
     })),
     fs.writeFile(path.join(sessionDirectory, 'signals.json'), JSON.stringify({
       turnCount: 1,
-      toolCallCount: 1,
+      toolCallCount: 3,
       contextWindowUsage: 25,
       modelsUsed: ['grok-e2e'],
     })),
@@ -71,6 +71,24 @@ async function registerLiveSession() {
           toolCallId: 'live-tool',
           title: 'Inspect secret-client',
           status: 'in_progress',
+        },
+      }),
+      JSON.stringify({
+        timestamp,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'runtime-test-tool',
+          title: 'Run Vitest suite',
+          status: 'completed',
+        },
+      }),
+      JSON.stringify({
+        timestamp,
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'runtime-external-tool',
+          title: 'Fetch GitHub issue',
+          status: 'completed',
         },
       }),
     ].join('\n') + '\n'),
@@ -134,6 +152,37 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('EVENT STREAM LINKED')).toBeVisible({ timeout: 15_000 })
   })
 
+  test('shows bounded process, test, and external-call runtime intelligence', async ({ page }) => {
+    await page.goto('/')
+
+    const intelligence = page.locator('.runtime-intelligence')
+    await expect(intelligence.getByRole('heading', { name: /What the agents started/ })).toBeVisible()
+    await expect(intelligence.getByText('Spawned descendants')).toBeVisible()
+    await expect(intelligence.getByText('Run Vitest suite')).toBeVisible()
+    await expect(intelligence.getByText('Fetch GitHub issue')).toBeVisible()
+
+    const runtime = await (await page.request.get('/api/runtime?refresh=1')).json()
+    expect(runtime.roots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          managed: false,
+          sessionIds: ['live-e2e-session'],
+        }),
+      ]),
+    )
+    expect(runtime.processes.length).toBeGreaterThan(0)
+    expect(runtime.tests[0]).toMatchObject({
+      title: 'Run Vitest suite',
+      framework: 'Vitest',
+      status: 'passed',
+    })
+    expect(runtime.externalCalls[0]).toMatchObject({
+      title: 'Fetch GitHub issue',
+      category: 'vcs',
+    })
+    expect(JSON.stringify(runtime)).not.toContain('--secret')
+  })
+
   test('opens a live agent in the clearly labeled Session Console', async ({ page }) => {
     await page.goto('/')
 
@@ -159,6 +208,8 @@ test.describe.serial('public launch path', () => {
     expect(body).not.toContain('secret-client')
     expect(body).not.toContain('Example Person')
     expect(body).not.toContain('192.168.1.42')
+    expect(body).not.toContain('Run Vitest suite')
+    expect(body).not.toContain('Fetch GitHub issue')
     expect(body).not.toContain(String(process.pid))
 
     await page.reload()
@@ -322,9 +373,23 @@ test.describe.serial('public launch path', () => {
     await expect(page.locator('.usage-ledger')).toContainText('secret-client')
     await expect(page.locator('.usage-ledger')).toContainText(/derived|incomplete/)
 
+    const budgets = page.locator('.usage-budget-panel')
+    await budgets.getByLabel('Limit').fill('1')
+    await budgets.getByRole('button', { name: 'Add budget' }).click()
+    await expect(budgets.getByText('All usage', { exact: true })).toBeVisible()
+    await expect(budgets.locator('.usage-budget-row.is-exceeded')).toBeVisible()
+    await expect(budgets.getByText(/100% threshold reached/)).toBeVisible()
+
     await page.getByRole('button', { name: 'Privacy' }).click()
     await expect(page.locator('.usage-ledger')).not.toContainText('secret-client')
     await expect(page.locator('.usage-ledger')).toContainText(/Workspace [A-Z0-9]{3}/)
+
+    const exported = await page.request.get('/api/usage/export?period=all&scope=sessions&groupBy=project&format=json&privacy=1')
+    expect(exported.ok()).toBe(true)
+    expect(exported.headers()['content-disposition']).toContain('grok-ui-usage.json')
+    const exportBody = await exported.text()
+    expect(exportBody).toContain('"privacyApplied": true')
+    expect(exportBody).not.toContain('secret-client')
   })
 
   test('cancels cleanly while a permission decision is pending', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/scripts/control-soak.mjs
+++ b/scripts/control-soak.mjs
@@ -3,12 +3,20 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { GrokController } from '../dist-server/grok-controller.js'
+import { RuntimeInspector } from '../dist-server/runtime-inspector.js'
+import { SessionStateStore } from '../dist-server/session-state.js'
+import { UsageLedger } from '../dist-server/usage-ledger.js'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const fakeGrok = path.join(projectRoot, 'scripts', 'fake-grok-e2e.mjs')
 const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-soak-'))
 const previousGrokBin = process.env.GROK_BIN
-const controller = new GrokController()
+const state = new SessionStateStore(path.join(workspace, 'state'))
+await state.load()
+const controller = new GrokController(state)
+await controller.restore()
+const runtime = new RuntimeInspector()
+const usage = new UsageLedger(state)
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -30,6 +38,19 @@ try {
   })
   await waitFor(() => controller.snapshot().sessions.find((item) => item.id === session.id)
     ?.feed.some((item) => item.title === 'Long-running cancellation fixture'))
+  const usageBefore = state.usageEntries().length
+  await usage.sync({ sessions: [], live: [], managed: controller.snapshot().sessions })
+  const usageAfter = state.usageEntries().length
+  if (usageAfter <= usageBefore) throw new Error('Usage ledger did not grow during the soak.')
+
+  runtime.update({ generatedAt: new Date().toISOString(), agents: [] }, controller.snapshot())
+  await runtime.refresh()
+  const initialRuntime = runtime.snapshot()
+  const managedRoot = initialRuntime.roots.find((root) => root.managed)
+  if (!managedRoot
+    || !initialRuntime.processes.some((process) => process.rootPid === managedRoot.pid)) {
+    throw new Error(`Runtime inspector did not retain the managed process root: ${JSON.stringify(initialRuntime)}`)
+  }
 
   const startedAt = Date.now()
   await delay(75_000)
@@ -42,6 +63,15 @@ try {
       error: snapshot.error,
     })}`)
   }
+  await usage.sync({ sessions: [], live: [], managed: snapshot.sessions })
+  runtime.update({ generatedAt: new Date().toISOString(), agents: [] }, snapshot)
+  await runtime.refresh()
+  const refreshedRuntime = runtime.snapshot()
+  const refreshedRoot = refreshedRuntime.roots.find((root) => root.managed)
+  if (!refreshedRoot
+    || !refreshedRuntime.processes.some((process) => process.rootPid === refreshedRoot.pid)) {
+    throw new Error('Runtime process root disappeared during the soak.')
+  }
 
   await controller.cancelSession(session.id)
   await waitFor(() => controller.snapshot().sessions.find((item) => item.id === session.id)
@@ -51,8 +81,11 @@ try {
   console.log(`✓ Sustained session   ${Math.round((Date.now() - startedAt) / 1_000)} seconds`)
   console.log('✓ ACP channel         remained connected')
   console.log('✓ Managed turn        remained working')
+  console.log('✓ Usage ledger        persisted managed observations')
+  console.log('✓ Runtime discovery   retained the managed process root')
   console.log('✓ Interruption        confirmed after soak')
 } finally {
+  await runtime.stop()
   await controller.stop()
   if (previousGrokBin === undefined) delete process.env.GROK_BIN
   else process.env.GROK_BIN = previousGrokBin

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -174,6 +174,7 @@ export class GrokController extends EventEmitter {
     return {
       generatedAt: now(),
       connected: this.connected,
+      processId: this.process?.pid || 0,
       starting: this.starting,
       reconnecting: Boolean(this.reconnectTimer) || (this.starting && this.reconnectAttempt > 0),
       reconnectAttempt: this.reconnectAttempt,

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,12 +13,17 @@ import type {
   LiveAgent,
   SessionRow,
   UsageGroupDimension,
+  UsageBudgetDimension,
+  UsageBudgetMetric,
   UsagePeriod,
   UsageScope,
 } from './types.js'
 import { APP_VERSION } from './app-version.js'
 import { inspectSetup } from './setup-diagnostics.js'
 import { UsageLedger } from './usage-ledger.js'
+import { RuntimeInspector } from './runtime-inspector.js'
+import { UsageBudgetManager } from './usage-budgets.js'
+import { usageExport, type UsageExportFormat } from './usage-export.js'
 
 const app = express()
 const sessionState = new SessionStateStore()
@@ -30,6 +35,8 @@ await controller.restore()
 const workspaceInspector = new WorkspaceInspector()
 const sessionReader = new SessionReader(store.grokHome)
 const usageLedger = new UsageLedger(sessionState)
+const usageBudgets = new UsageBudgetManager(sessionState, usageLedger)
+const runtimeInspector = new RuntimeInspector()
 const port = Number(process.env.PORT || 4310)
 const host = process.env.HOST || '127.0.0.1'
 const security = new SecurityGate(host)
@@ -62,14 +69,17 @@ function scheduleUsageSync(): void {
 
 liveMonitor.on('live', (payload) => {
   broadcast('live', payload)
+  runtimeInspector.update(payload, controller.snapshot())
   scheduleUsageSync()
 })
 liveMonitor.on('dashboard', (payload) => broadcast('dashboard', payload))
 controller.on('control', (payload) => {
   broadcast('control', payload)
+  runtimeInspector.update(liveMonitor.snapshot(), payload)
   scheduleUsageSync()
 })
 workspaceInspector.on('change', (payload) => broadcast('workspace', payload))
+runtimeInspector.on('runtime', (payload) => broadcast('runtime', payload))
 
 app.disable('x-powered-by')
 app.use(express.json({ limit: '64kb' }))
@@ -100,6 +110,15 @@ app.get('/api/live', (_request, response) => {
   response.json(liveMonitor.snapshot())
 })
 
+app.get('/api/runtime', async (request, response, next) => {
+  try {
+    if (request.query.refresh === '1') await runtimeInspector.refresh()
+    response.json(runtimeInspector.snapshot())
+  } catch (error) {
+    next(error)
+  }
+})
+
 const USAGE_PERIODS = new Set<UsagePeriod>(['24h', '7d', '30d', '90d', 'all'])
 const USAGE_SCOPES = new Set<UsageScope>(['sessions', 'workflow-agents', 'all'])
 const USAGE_GROUPS = new Set<UsageGroupDimension>(['project', 'model', 'session', 'agent'])
@@ -127,6 +146,82 @@ app.get('/api/usage', async (request, response, next) => {
       scope: scope as UsageScope,
       groupBy: groupBy as UsageGroupDimension,
     }))
+  } catch (error) {
+    next(error)
+  }
+})
+
+app.get('/api/usage/budgets', async (_request, response, next) => {
+  try {
+    await syncUsage()
+    response.json(await usageBudgets.snapshot())
+  } catch (error) {
+    next(error)
+  }
+})
+
+app.post('/api/usage/budgets', async (request, response) => {
+  try {
+    const body = request.body as Record<string, unknown>
+    const budget = await usageBudgets.upsert({
+      id: typeof body.id === 'string' ? body.id : undefined,
+      dimension: body.dimension as UsageBudgetDimension,
+      key: typeof body.key === 'string' ? body.key : undefined,
+      label: typeof body.label === 'string' ? body.label : undefined,
+      metric: body.metric as UsageBudgetMetric,
+      limit: Number(body.limit),
+      period: body.period as UsagePeriod,
+      currency: typeof body.currency === 'string' ? body.currency : undefined,
+      enabled: body.enabled !== false,
+    })
+    await syncUsage()
+    response.status(201).json({ budget, snapshot: await usageBudgets.snapshot() })
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Invalid budget.' })
+  }
+})
+
+app.delete('/api/usage/budgets/:id', async (request, response) => {
+  const removed = await usageBudgets.remove(request.params.id)
+  if (!removed) {
+    response.status(404).json({ error: 'Budget not found.' })
+    return
+  }
+  response.status(204).end()
+})
+
+app.post('/api/usage/alerts/:id/acknowledge', async (request, response) => {
+  const acknowledged = await usageBudgets.acknowledge(request.params.id)
+  if (!acknowledged) {
+    response.status(404).json({ error: 'Usage alert not found.' })
+    return
+  }
+  response.json(await usageBudgets.snapshot())
+})
+
+app.get('/api/usage/export', async (request, response, next) => {
+  try {
+    const period = typeof request.query.period === 'string' ? request.query.period : '30d'
+    const scope = typeof request.query.scope === 'string' ? request.query.scope : 'sessions'
+    const groupBy = typeof request.query.groupBy === 'string' ? request.query.groupBy : 'project'
+    const format = typeof request.query.format === 'string' ? request.query.format : 'json'
+    if (!USAGE_PERIODS.has(period as UsagePeriod)
+      || !USAGE_SCOPES.has(scope as UsageScope)
+      || !USAGE_GROUPS.has(groupBy as UsageGroupDimension)
+      || !['json', 'csv'].includes(format)) {
+      response.status(400).json({ error: 'Invalid usage export options.' })
+      return
+    }
+    await syncUsage()
+    const exported = usageExport(usageLedger.report({
+      period: period as UsagePeriod,
+      scope: scope as UsageScope,
+      groupBy: groupBy as UsageGroupDimension,
+    }), format as UsageExportFormat, request.query.privacy === '1')
+    response.setHeader('Content-Type', exported.contentType)
+    response.setHeader('Content-Disposition', `attachment; filename="grok-ui-usage.${exported.extension}"`)
+    response.setHeader('Cache-Control', 'no-store')
+    response.send(exported.body)
   } catch (error) {
     next(error)
   }
@@ -411,6 +506,7 @@ app.get('/api/events', (request, response) => {
   response.write(`event: ready\ndata: ${JSON.stringify({ connected: true })}\n\n`)
   response.write(`event: live\ndata: ${JSON.stringify(liveMonitor.snapshot())}\n\n`)
   response.write(`event: control\ndata: ${JSON.stringify(controller.snapshot())}\n\n`)
+  response.write(`event: runtime\ndata: ${JSON.stringify(runtimeInspector.snapshot())}\n\n`)
   void store.dashboard().then((payload) => {
     response.write(`event: dashboard\ndata: ${JSON.stringify(payload)}\n\n`)
   })
@@ -447,6 +543,8 @@ app.use((
 })
 
 await liveMonitor.start()
+runtimeInspector.update(liveMonitor.snapshot(), controller.snapshot())
+await runtimeInspector.start()
 await syncUsage()
 
 export const server = await new Promise<ReturnType<typeof app.listen>>((resolve, reject) => {
@@ -467,7 +565,12 @@ console.log(`Remote authentication ${security.authRequired ? 'enabled' : 'not re
 async function shutdown() {
   if (usageSyncTimer) clearTimeout(usageSyncTimer)
   server.close()
-  await Promise.all([liveMonitor.stop(), controller.stop(), workspaceInspector.close()])
+  await Promise.all([
+    liveMonitor.stop(),
+    runtimeInspector.stop(),
+    controller.stop(),
+    workspaceInspector.close(),
+  ])
   process.exit(0)
 }
 

--- a/server/runtime-inspector.test.ts
+++ b/server/runtime-inspector.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  classifyServices,
+  parseLsofPorts,
+  parseProcessTable,
+  parseSsPorts,
+  projectRuntimeSignals,
+  RuntimeInspector,
+  selectProcessTree,
+} from './runtime-inspector.js'
+import type { ControlSnapshot, LiveSnapshot, RuntimeRoot } from './types.js'
+
+function liveSnapshot(status = 'completed'): LiveSnapshot {
+  return {
+    generatedAt: '2026-07-26T12:00:00.000Z',
+    connected: true,
+    activeCount: 1,
+    workingCount: 1,
+    attentionCount: 0,
+    agents: [{
+      id: 'session-1',
+      pid: 100,
+      title: 'Runtime fixture',
+      cwd: '/tmp/runtime-fixture',
+      workspace: 'runtime-fixture',
+      openedAt: '2026-07-26T11:59:00.000Z',
+      updatedAt: '2026-07-26T12:00:00.000Z',
+      model: 'grok-code',
+      phase: 'tool_execution',
+      state: 'working',
+      turns: 1,
+      toolCalls: 2,
+      contextUsage: 0.1,
+      currentTool: 'Run Vitest suite',
+      contextUsed: 1_000,
+      contextSize: 10_000,
+      costAmount: 0,
+      costCurrency: '',
+      costTelemetryAvailable: false,
+      feed: [{
+        id: 'tool-test',
+        type: 'tool',
+        title: 'Run Vitest suite',
+        text: '',
+        status,
+        timestamp: '2026-07-26T12:00:00.000Z',
+      }, {
+        id: 'tool-external',
+        type: 'tool',
+        title: 'Fetch GitHub issue',
+        text: 'raw input is intentionally ignored',
+        status: 'completed',
+        timestamp: '2026-07-26T12:00:01.000Z',
+      }],
+    }],
+  }
+}
+
+function controlSnapshot(): ControlSnapshot {
+  return {
+    generatedAt: '2026-07-26T12:00:00.000Z',
+    connected: true,
+    processId: 0,
+    starting: false,
+    reconnecting: false,
+    reconnectAttempt: 0,
+    lastDisconnectedAt: '',
+    agentName: 'Grok',
+    agentVersion: 'test',
+    error: '',
+    sessions: [],
+    workflows: [],
+    permissions: [],
+  }
+}
+
+const processOutput = [
+  '  1     0 S 01:00:00 /sbin/launchd',
+  '100     1 S    00:12 /usr/local/bin/grok',
+  '110   100 R    00:08 /usr/local/bin/node --secret ignored',
+  '111   110 S    00:03 /opt/homebrew/bin/postgres',
+  '900     1 S    10:00 /usr/bin/unrelated',
+].join('\n')
+
+describe('runtime process and port projection', () => {
+  it('selects only bounded descendants and exposes executable names without arguments', () => {
+    const roots: RuntimeRoot[] = [{
+      pid: 100,
+      managed: false,
+      sessionIds: ['session-1'],
+      workspaces: ['/tmp/runtime-fixture'],
+    }]
+    const selected = selectProcessTree(parseProcessTable(processOutput), roots)
+
+    expect(selected.map((process) => process.pid)).toEqual([100, 110, 111])
+    expect(selected[1]).toMatchObject({
+      parentPid: 100,
+      depth: 1,
+      name: 'node',
+      state: 'running',
+      sessionIds: ['session-1'],
+    })
+    expect(JSON.stringify(selected)).not.toContain('secret')
+    expect(JSON.stringify(selected)).not.toContain('unrelated')
+  })
+
+  it('parses lsof and Linux ss listeners only for the selected process set', () => {
+    const allowed = new Set([110, 111])
+    const lsof = parseLsofPorts([
+      'p110',
+      'cnode',
+      'n127.0.0.1:3000',
+      'p111',
+      'cpostgres',
+      'n*:5432',
+      'p900',
+      'nuntrusted.example:443',
+    ].join('\n'), allowed)
+    expect(lsof).toEqual([
+      { pid: 110, port: 3000, protocol: 'tcp', bind: 'loopback' },
+      { pid: 111, port: 5432, protocol: 'tcp', bind: 'all' },
+    ])
+
+    const ss = parseSsPorts([
+      'LISTEN 0 511 127.0.0.1:4173 0.0.0.0:* users:(("node",pid=110,fd=20))',
+      'LISTEN 0 511 0.0.0.0:9999 0.0.0.0:* users:(("other",pid=900,fd=4))',
+    ].join('\n'), allowed)
+    expect(ss).toEqual([
+      { pid: 110, port: 4173, protocol: 'tcp', bind: 'loopback' },
+    ])
+  })
+
+  it('classifies database and local development services without probing them', () => {
+    const roots: RuntimeRoot[] = [{
+      pid: 100,
+      managed: false,
+      sessionIds: ['session-1'],
+      workspaces: ['/tmp/runtime-fixture'],
+    }]
+    const processes = selectProcessTree(parseProcessTable(processOutput), roots)
+    const ports = parseLsofPorts([
+      'p110',
+      'n127.0.0.1:3000',
+      'p111',
+      'n*:5432',
+    ].join('\n'), new Set([100, 110, 111]))
+
+    expect(classifyServices(processes, ports)).toEqual([
+      {
+        id: 'service:110:3000',
+        pid: 110,
+        name: 'Web development server',
+        kind: 'dev-server',
+        port: 3000,
+        bind: 'loopback',
+        status: 'listening',
+      },
+      {
+        id: 'service:111:5432',
+        pid: 111,
+        name: 'PostgreSQL',
+        kind: 'database',
+        port: 5432,
+        bind: 'all',
+        status: 'listening',
+      },
+    ])
+  })
+})
+
+describe('runtime structured signals', () => {
+  it('tracks test status and external tools from safe titles without raw tool input', () => {
+    const signals = projectRuntimeSignals(liveSnapshot(), controlSnapshot())
+
+    expect(signals.tests[0]).toMatchObject({
+      sessionId: 'session-1',
+      title: 'Run Vitest suite',
+      framework: 'Vitest',
+      status: 'passed',
+      incomplete: false,
+    })
+    expect(signals.externalCalls[0]).toMatchObject({
+      sessionId: 'session-1',
+      title: 'Fetch GitHub issue',
+      category: 'vcs',
+      status: 'completed',
+    })
+    expect(JSON.stringify(signals)).not.toContain('raw input')
+  })
+
+  it('joins process, port, service, test, and external-call projections in one snapshot', async () => {
+    const runner = {
+      run: vi.fn(async (command: string) => command === 'ps'
+        ? processOutput
+        : [
+          'p110',
+          'n127.0.0.1:3000',
+          'p111',
+          'n*:5432',
+        ].join('\n')),
+    }
+    const inspector = new RuntimeInspector(
+      runner,
+      'darwin',
+      2_000,
+      () => new Date('2026-07-26T12:00:02.000Z'),
+    )
+    inspector.update(liveSnapshot(), controlSnapshot())
+    await inspector.refresh()
+    const snapshot = inspector.snapshot()
+
+    expect(snapshot).toMatchObject({
+      available: true,
+      partial: false,
+    })
+    expect(snapshot.processes).toHaveLength(3)
+    expect(snapshot.ports).toHaveLength(2)
+    expect(snapshot.services.map((service) => service.kind)).toEqual(['dev-server', 'database'])
+    expect(snapshot.tests[0].status).toBe('passed')
+    expect(snapshot.externalCalls[0].category).toBe('vcs')
+    expect(runner.run).toHaveBeenCalledWith('ps', expect.any(Array), 1_500)
+    expect(runner.run).toHaveBeenCalledWith('lsof', expect.any(Array), 1_500)
+  })
+
+  it('marks a running test interrupted when its live session disappears', async () => {
+    const runner = {
+      run: vi.fn(async (command: string) => command === 'ps' ? processOutput : ''),
+    }
+    const inspector = new RuntimeInspector(
+      runner,
+      'darwin',
+      2_000,
+      () => new Date('2026-07-26T12:00:02.000Z'),
+    )
+    inspector.update(liveSnapshot('in_progress'), controlSnapshot())
+    await inspector.refresh()
+    expect(inspector.snapshot().tests[0].status).toBe('running')
+
+    inspector.update({
+      ...liveSnapshot(),
+      activeCount: 0,
+      workingCount: 0,
+      agents: [],
+    }, controlSnapshot())
+    await inspector.refresh()
+
+    expect(inspector.snapshot().tests[0]).toMatchObject({
+      status: 'interrupted',
+      incomplete: true,
+    })
+  })
+
+  it('returns structured signal telemetry while marking OS inspection unavailable on Windows', async () => {
+    const runner = { run: vi.fn(async () => '') }
+    const inspector = new RuntimeInspector(
+      runner,
+      'win32',
+      2_000,
+      () => new Date('2026-07-26T12:00:02.000Z'),
+    )
+    inspector.update(liveSnapshot(), controlSnapshot())
+    await inspector.refresh()
+
+    expect(inspector.snapshot()).toMatchObject({
+      available: false,
+      partial: true,
+      processes: [],
+    })
+    expect(inspector.snapshot().tests[0].status).toBe('passed')
+    expect(runner.run).not.toHaveBeenCalled()
+  })
+})

--- a/server/runtime-inspector.ts
+++ b/server/runtime-inspector.ts
@@ -1,0 +1,660 @@
+import crypto from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import type {
+  ControlSnapshot,
+  ExternalCallCategory,
+  ExternalToolCall,
+  LiveFeedItem,
+  LiveSnapshot,
+  RuntimeBindScope,
+  RuntimePort,
+  RuntimeProcess,
+  RuntimeProcessState,
+  RuntimeRoot,
+  RuntimeService,
+  RuntimeServiceKind,
+  RuntimeSnapshot,
+  RuntimeTestRun,
+  RuntimeTestStatus,
+} from './types.js'
+
+const execFileAsync = promisify(execFile)
+const MAX_PROCESSES = 160
+const MAX_DEPTH = 8
+const MAX_OUTPUT_BYTES = 1024 * 1024
+const COMMAND_TIMEOUT_MS = 1_500
+const MAX_SIGNALS = 80
+const RETAIN_SIGNAL_MS = 10 * 60_000
+
+interface ProcessRecord {
+  pid: number
+  parentPid: number
+  state: RuntimeProcessState
+  elapsed: string
+  name: string
+}
+
+interface RuntimeCommandRunner {
+  run(command: string, args: string[], timeoutMs: number): Promise<string>
+}
+
+interface ProjectedSignals {
+  tests: RuntimeTestRun[]
+  externalCalls: ExternalToolCall[]
+}
+
+interface SignalFeed {
+  sessionId: string
+  items: LiveFeedItem[]
+}
+
+class SystemCommandRunner implements RuntimeCommandRunner {
+  async run(command: string, args: string[], timeoutMs: number): Promise<string> {
+    try {
+      const result = await execFileAsync(command, args, {
+        encoding: 'utf8',
+        maxBuffer: MAX_OUTPUT_BYTES,
+        timeout: timeoutMs,
+        windowsHide: true,
+      })
+      return result.stdout
+    } catch (error) {
+      const failure = error as { code?: number; stdout?: string }
+      // lsof uses exit code 1 for a valid query with no matching listeners.
+      if (command === 'lsof' && failure.code === 1 && typeof failure.stdout === 'string') {
+        return failure.stdout
+      }
+      throw error
+    }
+  }
+}
+
+function safeName(value: string): string {
+  const first = value.trim().split(/\s+/)[0] || 'process'
+  return path.basename(first).replace(/[^\w.+-]/g, '').slice(0, 80) || 'process'
+}
+
+function safeTitle(value: string): string {
+  const cleaned = value.replace(/\u0000/g, '').replace(/\s+/g, ' ').trim()
+  return cleaned.slice(0, 180)
+}
+
+function processState(value: string): RuntimeProcessState {
+  const state = value.trim().charAt(0).toUpperCase()
+  if (state === 'R') return 'running'
+  if (state === 'S' || state === 'I' || state === 'D') return 'sleeping'
+  if (state === 'T') return 'stopped'
+  if (state === 'Z') return 'zombie'
+  return 'unknown'
+}
+
+export function parseProcessTable(output: string): ProcessRecord[] {
+  return output.split('\n').flatMap((line) => {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(.+)$/)
+    if (!match) return []
+    const pid = Number(match[1])
+    const parentPid = Number(match[2])
+    if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(parentPid) || parentPid < 0) return []
+    return [{
+      pid,
+      parentPid,
+      state: processState(match[3]),
+      elapsed: match[4].slice(0, 24),
+      name: safeName(match[5]),
+    }]
+  })
+}
+
+function mergeRoots(roots: RuntimeRoot[]): RuntimeRoot[] {
+  const merged = new Map<number, RuntimeRoot>()
+  roots.forEach((root) => {
+    if (!Number.isInteger(root.pid) || root.pid <= 0) return
+    const existing = merged.get(root.pid)
+    if (!existing) {
+      merged.set(root.pid, {
+        ...root,
+        sessionIds: [...new Set(root.sessionIds)].slice(0, 80),
+        workspaces: [...new Set(root.workspaces)].slice(0, 80),
+      })
+      return
+    }
+    existing.managed ||= root.managed
+    existing.sessionIds = [...new Set([...existing.sessionIds, ...root.sessionIds])].slice(0, 80)
+    existing.workspaces = [...new Set([...existing.workspaces, ...root.workspaces])].slice(0, 80)
+  })
+  return [...merged.values()].sort((left, right) => left.pid - right.pid)
+}
+
+export function selectProcessTree(records: ProcessRecord[], roots: RuntimeRoot[]): RuntimeProcess[] {
+  const recordsByPid = new Map(records.map((record) => [record.pid, record]))
+  const children = new Map<number, ProcessRecord[]>()
+  records.forEach((record) => {
+    const siblings = children.get(record.parentPid) || []
+    siblings.push(record)
+    children.set(record.parentPid, siblings)
+  })
+  children.forEach((items) => items.sort((left, right) => left.pid - right.pid))
+
+  const selected = new Map<number, RuntimeProcess>()
+  for (const root of mergeRoots(roots)) {
+    const queue: Array<{ pid: number; depth: number }> = [{ pid: root.pid, depth: 0 }]
+    const visited = new Set<number>()
+    while (queue.length && selected.size < MAX_PROCESSES) {
+      const current = queue.shift()!
+      if (visited.has(current.pid) || current.depth > MAX_DEPTH) continue
+      visited.add(current.pid)
+      const record = recordsByPid.get(current.pid)
+      if (!record) continue
+      const existing = selected.get(current.pid)
+      if (existing) {
+        existing.sessionIds = [...new Set([...existing.sessionIds, ...root.sessionIds])].slice(0, 80)
+        existing.workspaces = [...new Set([...existing.workspaces, ...root.workspaces])].slice(0, 80)
+      } else {
+        selected.set(current.pid, {
+          pid: record.pid,
+          parentPid: record.parentPid,
+          rootPid: root.pid,
+          depth: current.depth,
+          name: record.name,
+          state: record.state,
+          elapsed: record.elapsed,
+          sessionIds: [...root.sessionIds],
+          workspaces: [...root.workspaces],
+          ports: [],
+        })
+      }
+      if (current.depth < MAX_DEPTH) {
+        for (const child of children.get(current.pid) || []) {
+          queue.push({ pid: child.pid, depth: current.depth + 1 })
+        }
+      }
+    }
+  }
+  return [...selected.values()].sort((left, right) =>
+    left.rootPid - right.rootPid || left.depth - right.depth || left.pid - right.pid)
+}
+
+function bindScope(host: string): RuntimeBindScope {
+  const normalized = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase()
+  if (normalized === '*' || normalized === '0.0.0.0' || normalized === '::') return 'all'
+  if (normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1') return 'loopback'
+  if (
+    /^10\./.test(normalized)
+    || /^192\.168\./.test(normalized)
+    || /^172\.(1[6-9]|2\d|3[01])\./.test(normalized)
+    || /^fe80:/.test(normalized)
+  ) return 'lan'
+  return normalized ? 'unknown' : 'unknown'
+}
+
+function portFromAddress(value: string): { port: number; bind: RuntimeBindScope } | null {
+  const cleaned = value.trim()
+  const match = cleaned.match(/^(.*):(\d+)$/)
+  if (!match) return null
+  const port = Number(match[2])
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return null
+  return { port, bind: bindScope(match[1]) }
+}
+
+export function parseLsofPorts(output: string, allowedPids: Set<number>): RuntimePort[] {
+  const ports: RuntimePort[] = []
+  let pid = 0
+  for (const line of output.split('\n')) {
+    if (line.startsWith('p')) {
+      pid = Number(line.slice(1))
+      continue
+    }
+    if (!line.startsWith('n') || !allowedPids.has(pid)) continue
+    const parsed = portFromAddress(line.slice(1))
+    if (parsed) ports.push({ pid, protocol: 'tcp', ...parsed })
+  }
+  return dedupePorts(ports)
+}
+
+export function parseSsPorts(output: string, allowedPids: Set<number>): RuntimePort[] {
+  const ports: RuntimePort[] = []
+  for (const line of output.split('\n')) {
+    const pidMatches = [...line.matchAll(/\bpid=(\d+)/g)].map((match) => Number(match[1]))
+    const address = line.split(/\s+/).find((token) => portFromAddress(token))
+    const parsed = address ? portFromAddress(address) : null
+    if (!parsed) continue
+    pidMatches.forEach((pid) => {
+      if (allowedPids.has(pid)) ports.push({ pid, protocol: 'tcp', ...parsed })
+    })
+  }
+  return dedupePorts(ports)
+}
+
+function dedupePorts(ports: RuntimePort[]): RuntimePort[] {
+  return [...new Map(ports.map((port) => [`${port.pid}:${port.port}`, port])).values()]
+    .sort((left, right) => left.port - right.port || left.pid - right.pid)
+}
+
+function knownService(name: string, port: number): { name: string; kind: RuntimeServiceKind } | null {
+  const process = name.toLowerCase()
+  const rules: Array<[RegExp, string, RuntimeServiceKind]> = [
+    [/postgres|postmaster/, 'PostgreSQL', 'database'],
+    [/mysqld|mariadb/, 'MySQL', 'database'],
+    [/mongod/, 'MongoDB', 'database'],
+    [/sqlite/, 'SQLite', 'database'],
+    [/cockroach/, 'CockroachDB', 'database'],
+    [/clickhouse/, 'ClickHouse', 'database'],
+    [/neo4j/, 'Neo4j', 'database'],
+    [/influxd/, 'InfluxDB', 'database'],
+    [/redis|valkey/, 'Redis', 'cache'],
+    [/memcached/, 'Memcached', 'cache'],
+    [/rabbitmq/, 'RabbitMQ', 'queue'],
+    [/kafka/, 'Kafka', 'queue'],
+    [/\bnats/, 'NATS', 'queue'],
+    [/localstack/, 'LocalStack', 'emulator'],
+    [/firebase/, 'Firebase Emulator', 'emulator'],
+    [/azurite/, 'Azurite', 'emulator'],
+    [/supabase/, 'Supabase', 'emulator'],
+    [/vite/, 'Vite', 'dev-server'],
+    [/next/, 'Next.js', 'dev-server'],
+    [/nuxt/, 'Nuxt', 'dev-server'],
+    [/webpack/, 'Webpack', 'dev-server'],
+    [/astro/, 'Astro', 'dev-server'],
+    [/uvicorn|gunicorn|flask|django/, 'Python web service', 'dev-server'],
+    [/rails|puma/, 'Rails', 'dev-server'],
+  ]
+  const processMatch = rules.find(([pattern]) => pattern.test(process))
+  if (processMatch) return { name: processMatch[1], kind: processMatch[2] }
+
+  const ports: Record<number, { name: string; kind: RuntimeServiceKind }> = {
+    3000: { name: 'Web development server', kind: 'dev-server' },
+    3306: { name: 'MySQL', kind: 'database' },
+    4173: { name: 'Vite preview', kind: 'dev-server' },
+    4310: { name: 'Grok UI', kind: 'web' },
+    5432: { name: 'PostgreSQL', kind: 'database' },
+    5672: { name: 'RabbitMQ', kind: 'queue' },
+    6379: { name: 'Redis', kind: 'cache' },
+    8000: { name: 'Local web service', kind: 'web' },
+    8080: { name: 'Local web service', kind: 'web' },
+    8123: { name: 'ClickHouse', kind: 'database' },
+    9200: { name: 'Elasticsearch', kind: 'database' },
+    27017: { name: 'MongoDB', kind: 'database' },
+  }
+  return ports[port] || null
+}
+
+export function classifyServices(processes: RuntimeProcess[], ports: RuntimePort[]): RuntimeService[] {
+  const processByPid = new Map(processes.map((process) => [process.pid, process]))
+  const services: RuntimeService[] = ports.map((port) => {
+    const process = processByPid.get(port.pid)
+    const classified = knownService(process?.name || '', port.port)
+    return {
+      id: `service:${port.pid}:${port.port}`,
+      pid: port.pid,
+      name: classified?.name || safeName(process?.name || 'Local service'),
+      kind: classified?.kind || 'other',
+      port: port.port,
+      bind: port.bind,
+      status: 'listening',
+    }
+  })
+  processes.forEach((process) => {
+    if (ports.some((port) => port.pid === process.pid)) return
+    const classified = knownService(process.name, 0)
+    if (!classified || !['database', 'cache', 'queue', 'emulator'].includes(classified.kind)) return
+    services.push({
+      id: `service:${process.pid}:${classified.kind}`,
+      pid: process.pid,
+      name: classified.name,
+      kind: classified.kind,
+      port: 0,
+      bind: 'unknown',
+      status: 'running',
+    })
+  })
+  return services.slice(0, MAX_PROCESSES)
+}
+
+function testFramework(title: string): string {
+  const normalized = title.toLowerCase()
+  if (normalized.includes('vitest')) return 'Vitest'
+  if (normalized.includes('jest')) return 'Jest'
+  if (normalized.includes('playwright')) return 'Playwright'
+  if (normalized.includes('pytest')) return 'pytest'
+  if (normalized.includes('xcodebuild')) return 'XCTest'
+  if (normalized.includes('swift test')) return 'Swift Testing'
+  if (normalized.includes('cargo test')) return 'Cargo'
+  if (normalized.includes('go test')) return 'Go'
+  if (normalized.includes('rspec')) return 'RSpec'
+  return 'Test command'
+}
+
+function isTestTitle(title: string): boolean {
+  return /\b(test|tests|testing|vitest|jest|playwright|pytest|xcodebuild|rspec)\b/i.test(title)
+}
+
+function testStatus(status: string): RuntimeTestStatus {
+  const normalized = status.toLowerCase().replaceAll('-', '_').replaceAll(' ', '_')
+  if (['pending', 'in_progress', 'running', 'started'].includes(normalized)) return 'running'
+  if (['completed', 'success', 'succeeded', 'passed', 'done'].includes(normalized)) return 'passed'
+  if (['failed', 'failure', 'error'].includes(normalized)) return 'failed'
+  if (['cancelled', 'canceled', 'interrupted', 'aborted'].includes(normalized)) return 'interrupted'
+  return 'unknown'
+}
+
+function externalCategory(title: string): ExternalCallCategory | null {
+  const normalized = title.toLowerCase()
+  if (/\b(browser|chrome|safari|playwright)\b/.test(normalized)) return 'browser'
+  if (/\b(mcp|model context protocol)\b/.test(normalized)) return 'mcp'
+  if (/\b(github|gitlab|bitbucket|pull request|issue)\b/.test(normalized)) return 'vcs'
+  if (/\b(aws|amazon web services|gcp|google cloud|azure|vercel|netlify|slack|notion)\b/.test(normalized)) return 'cloud'
+  if (/\b(curl|wget|http|https|url|fetch|request|web search|search query|api)\b/.test(normalized)) return 'network'
+  return null
+}
+
+function signalId(kind: string, sessionId: string, title: string): string {
+  return `${kind}:${crypto.createHash('sha256').update(`${sessionId}\0${title.toLowerCase()}`).digest('base64url').slice(0, 20)}`
+}
+
+function signalFeeds(live: LiveSnapshot, control: ControlSnapshot): SignalFeed[] {
+  return [
+    ...live.agents.map((agent) => ({ sessionId: agent.id, items: agent.feed })),
+    ...control.sessions.map((session) => ({ sessionId: session.id, items: session.feed })),
+  ]
+}
+
+export function projectRuntimeSignals(live: LiveSnapshot, control: ControlSnapshot): ProjectedSignals {
+  const tools = new Map<string, {
+    sessionId: string
+    title: string
+    status: string
+    startedAt: string
+    updatedAt: string
+  }>()
+  for (const feed of signalFeeds(live, control)) {
+    for (const item of feed.items) {
+      if (item.type !== 'tool') continue
+      const title = safeTitle(item.title)
+      if (!title) continue
+      const key = `${feed.sessionId}\0${title.toLowerCase()}`
+      const existing = tools.get(key)
+      const timestamp = item.timestamp || new Date(0).toISOString()
+      if (!existing) {
+        tools.set(key, {
+          sessionId: feed.sessionId,
+          title,
+          status: item.status,
+          startedAt: timestamp,
+          updatedAt: timestamp,
+        })
+      } else {
+        if (timestamp < existing.startedAt) existing.startedAt = timestamp
+        if (timestamp >= existing.updatedAt) {
+          existing.updatedAt = timestamp
+          existing.status = item.status || existing.status
+          existing.title = title
+        }
+      }
+    }
+  }
+
+  const tests: RuntimeTestRun[] = []
+  const externalCalls: ExternalToolCall[] = []
+  tools.forEach((tool) => {
+    if (isTestTitle(tool.title)) {
+      const status = testStatus(tool.status)
+      tests.push({
+        id: signalId('test', tool.sessionId, tool.title),
+        sessionId: tool.sessionId,
+        title: tool.title,
+        framework: testFramework(tool.title),
+        status,
+        startedAt: tool.startedAt,
+        updatedAt: tool.updatedAt,
+        incomplete: status === 'unknown' || status === 'interrupted',
+      })
+    }
+    const category = externalCategory(tool.title)
+    if (category) {
+      externalCalls.push({
+        id: signalId('external', tool.sessionId, tool.title),
+        sessionId: tool.sessionId,
+        title: tool.title,
+        category,
+        status: tool.status || 'unknown',
+        updatedAt: tool.updatedAt,
+      })
+    }
+  })
+  return {
+    tests: tests.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)).slice(0, MAX_SIGNALS),
+    externalCalls: externalCalls
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, MAX_SIGNALS),
+  }
+}
+
+function emptySnapshot(): RuntimeSnapshot {
+  return {
+    generatedAt: new Date().toISOString(),
+    available: true,
+    partial: false,
+    error: '',
+    roots: [],
+    processes: [],
+    ports: [],
+    services: [],
+    tests: [],
+    externalCalls: [],
+  }
+}
+
+export class RuntimeInspector extends EventEmitter {
+  private current = emptySnapshot()
+  private live: LiveSnapshot = {
+    generatedAt: new Date().toISOString(),
+    connected: false,
+    activeCount: 0,
+    workingCount: 0,
+    attentionCount: 0,
+    agents: [],
+  }
+  private control: ControlSnapshot = {
+    generatedAt: new Date().toISOString(),
+    connected: false,
+    processId: 0,
+    starting: false,
+    reconnecting: false,
+    reconnectAttempt: 0,
+    lastDisconnectedAt: '',
+    agentName: '',
+    agentVersion: '',
+    error: '',
+    sessions: [],
+    workflows: [],
+    permissions: [],
+  }
+  private refreshTimer: NodeJS.Timeout | null = null
+  private interval: NodeJS.Timeout | null = null
+  private refreshPromise: Promise<void> | null = null
+  private retainedTests = new Map<string, RuntimeTestRun>()
+  private retainedCalls = new Map<string, ExternalToolCall>()
+
+  constructor(
+    private readonly runner: RuntimeCommandRunner = new SystemCommandRunner(),
+    private readonly platform = process.platform,
+    private readonly intervalMs = 2_000,
+    private readonly now: () => Date = () => new Date(),
+  ) {
+    super()
+  }
+
+  snapshot(): RuntimeSnapshot {
+    return this.current
+  }
+
+  update(live: LiveSnapshot, control: ControlSnapshot): void {
+    this.live = live
+    this.control = control
+    this.scheduleRefresh()
+  }
+
+  async start(): Promise<void> {
+    await this.refresh()
+    this.interval = setInterval(() => void this.refresh(), this.intervalMs)
+    this.interval.unref()
+  }
+
+  async stop(): Promise<void> {
+    if (this.refreshTimer) clearTimeout(this.refreshTimer)
+    if (this.interval) clearInterval(this.interval)
+    this.refreshTimer = null
+    this.interval = null
+    await this.refreshPromise
+  }
+
+  async refresh(): Promise<void> {
+    if (this.refreshPromise) return this.refreshPromise
+    this.refreshPromise = this.refreshInternal().finally(() => {
+      this.refreshPromise = null
+    })
+    return this.refreshPromise
+  }
+
+  private scheduleRefresh(): void {
+    if (this.refreshTimer) clearTimeout(this.refreshTimer)
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null
+      void this.refresh()
+    }, 100)
+    this.refreshTimer.unref()
+  }
+
+  private roots(): RuntimeRoot[] {
+    const roots: RuntimeRoot[] = this.live.agents.map((agent) => ({
+      pid: agent.pid,
+      managed: false,
+      sessionIds: [agent.id],
+      workspaces: [agent.cwd],
+    }))
+    if (this.control.processId) {
+      roots.push({
+        pid: this.control.processId,
+        managed: true,
+        sessionIds: this.control.sessions.map((session) => session.id),
+        workspaces: this.control.sessions.map((session) => session.cwd),
+      })
+    }
+    return mergeRoots(roots)
+  }
+
+  private retainSignals(signals: ProjectedSignals, now: string): ProjectedSignals {
+    signals.tests.forEach((test) => this.retainedTests.set(test.id, test))
+    signals.externalCalls.forEach((call) => this.retainedCalls.set(call.id, call))
+    const cutoff = new Date(new Date(now).getTime() - RETAIN_SIGNAL_MS).toISOString()
+    this.retainedTests.forEach((test, id) => {
+      if (test.updatedAt < cutoff) this.retainedTests.delete(id)
+      else if (!signals.tests.some((candidate) => candidate.id === id) && test.status === 'running') {
+        this.retainedTests.set(id, {
+          ...test,
+          status: 'interrupted',
+          updatedAt: now,
+          incomplete: true,
+        })
+      }
+    })
+    this.retainedCalls.forEach((call, id) => {
+      if (call.updatedAt < cutoff) this.retainedCalls.delete(id)
+    })
+    return {
+      tests: [...this.retainedTests.values()]
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .slice(0, MAX_SIGNALS),
+      externalCalls: [...this.retainedCalls.values()]
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .slice(0, MAX_SIGNALS),
+    }
+  }
+
+  private async refreshInternal(): Promise<void> {
+    const generatedAt = this.now().toISOString()
+    const roots = this.roots()
+    const signals = this.retainSignals(projectRuntimeSignals(this.live, this.control), generatedAt)
+    if (this.platform === 'win32') {
+      this.current = {
+        ...emptySnapshot(),
+        generatedAt,
+        available: false,
+        partial: true,
+        error: 'Process and port inspection is not available on this platform.',
+        roots,
+        ...signals,
+      }
+      this.emit('runtime', this.current)
+      return
+    }
+
+    let processes: RuntimeProcess[] = []
+    let ports: RuntimePort[] = []
+    let partial = false
+    let error = ''
+    try {
+      const output = await this.runner.run(
+        'ps',
+        ['-axo', 'pid=,ppid=,state=,etime=,comm='],
+        COMMAND_TIMEOUT_MS,
+      )
+      processes = selectProcessTree(parseProcessTable(output), roots)
+    } catch {
+      partial = true
+      error = 'Process inspection is temporarily unavailable.'
+    }
+
+    if (processes.length) {
+      const allowedPids = new Set(processes.map((process) => process.pid))
+      const pidList = [...allowedPids].join(',')
+      try {
+        const output = await this.runner.run(
+          'lsof',
+          ['-nP', '-a', '-p', pidList, '-iTCP', '-sTCP:LISTEN', '-FpcPnT'],
+          COMMAND_TIMEOUT_MS,
+        )
+        ports = parseLsofPorts(output, allowedPids)
+      } catch {
+        if (this.platform === 'linux') {
+          try {
+            const output = await this.runner.run('ss', ['-ltnpH'], COMMAND_TIMEOUT_MS)
+            ports = parseSsPorts(output, allowedPids)
+          } catch {
+            partial = true
+            error ||= 'Listening-port inspection is temporarily unavailable.'
+          }
+        } else {
+          partial = true
+          error ||= 'Listening-port inspection is temporarily unavailable.'
+        }
+      }
+    }
+
+    const portsByPid = new Map<number, number[]>()
+    ports.forEach((port) => {
+      const values = portsByPid.get(port.pid) || []
+      values.push(port.port)
+      portsByPid.set(port.pid, values)
+    })
+    processes = processes.map((process) => ({
+      ...process,
+      ports: [...new Set(portsByPid.get(process.pid) || [])].sort((left, right) => left - right),
+    }))
+    this.current = {
+      generatedAt,
+      available: !error || processes.length > 0,
+      partial,
+      error,
+      roots,
+      processes,
+      ports,
+      services: classifyServices(processes, ports),
+      ...signals,
+    }
+    this.emit('runtime', this.current)
+  }
+}

--- a/server/session-state.ts
+++ b/server/session-state.ts
@@ -4,6 +4,8 @@ import path from 'node:path'
 import type {
   ControlSession,
   SessionRow,
+  UsageBudget,
+  UsageBudgetAlert,
   UsageLedgerEntry,
   UsageMetric,
   UsageSource,
@@ -18,17 +20,21 @@ export interface SessionAnnotation {
 }
 
 interface PersistedState {
-  version: 2
+  version: 3
   sessions: Record<string, SessionAnnotation>
   managedSessions: ControlSession[]
   usageEntries: UsageLedgerEntry[]
+  usageBudgets: UsageBudget[]
+  usageAlerts: UsageBudgetAlert[]
 }
 
 const EMPTY_STATE: PersistedState = {
-  version: 2,
+  version: 3,
   sessions: {},
   managedSessions: [],
   usageEntries: [],
+  usageBudgets: [],
+  usageAlerts: [],
 }
 
 const USAGE_SOURCES = new Set<UsageSource>([
@@ -38,6 +44,8 @@ const USAGE_SOURCES = new Set<UsageSource>([
   'unavailable',
 ])
 const MAX_USAGE_ENTRIES = 10_000
+const MAX_USAGE_BUDGETS = 100
+const MAX_USAGE_ALERTS = 500
 
 function safeId(id: string): boolean {
   return Boolean(id) && /^[a-zA-Z0-9-]+$/.test(id)
@@ -94,6 +102,65 @@ function normalizeUsageEntry(value: unknown): UsageLedgerEntry | null {
       ...cost,
       currency: boundedString(item.cost?.currency, 16).toUpperCase(),
     },
+  }
+}
+
+function normalizeUsageBudget(value: unknown): UsageBudget | null {
+  if (!value || typeof value !== 'object') return null
+  const item = value as Partial<UsageBudget>
+  const id = boundedString(item.id, 80)
+  const dimension = item.dimension
+  const metric = item.metric
+  const period = item.period
+  if (!id || !/^[a-zA-Z0-9:._-]+$/.test(id)) return null
+  if (!['global', 'project', 'model', 'session', 'agent'].includes(dimension || '')) return null
+  if (!['tokens', 'cost'].includes(metric || '')) return null
+  if (!['24h', '7d', '30d', '90d', 'all'].includes(period || '')) return null
+  const limit = Number(item.limit)
+  if (!Number.isFinite(limit) || limit <= 0 || limit > 1_000_000_000_000) return null
+  const key = dimension === 'global' ? '*' : boundedString(item.key, 2_048)
+  const currency = metric === 'cost' ? (boundedString(item.currency, 16) || 'USD').toUpperCase() : ''
+  if (dimension !== 'global' && !key) return null
+  if (metric === 'cost' && !/^[A-Z]{3,8}$/.test(currency)) return null
+  return {
+    id,
+    dimension: dimension as UsageBudget['dimension'],
+    key,
+    label: boundedString(item.label, 256) || (dimension === 'global' ? 'All usage' : key.slice(0, 256)),
+    metric: metric as UsageBudget['metric'],
+    limit,
+    period: period as UsageBudget['period'],
+    currency,
+    enabled: item.enabled !== false,
+    createdAt: normalizedDate(item.createdAt),
+    updatedAt: normalizedDate(item.updatedAt),
+  }
+}
+
+function normalizeUsageAlert(value: unknown): UsageBudgetAlert | null {
+  if (!value || typeof value !== 'object') return null
+  const item = value as Partial<UsageBudgetAlert>
+  const id = boundedString(item.id, 160)
+  const budgetId = boundedString(item.budgetId, 80)
+  const threshold = Number(item.threshold)
+  const observed = Number(item.observed)
+  const limit = Number(item.limit)
+  if (!id || !budgetId
+    || ![0.8, 1].includes(threshold)
+    || !Number.isFinite(observed) || observed < 0
+    || !Number.isFinite(limit) || limit <= 0) {
+    return null
+  }
+  return {
+    id,
+    budgetId,
+    threshold,
+    observed,
+    limit,
+    source: USAGE_SOURCES.has(item.source as UsageSource) ? item.source as UsageSource : 'unavailable',
+    periodFrom: normalizedDate(item.periodFrom),
+    createdAt: normalizedDate(item.createdAt),
+    acknowledgedAt: item.acknowledgedAt ? normalizedDate(item.acknowledgedAt) : '',
   }
 }
 
@@ -170,7 +237,7 @@ export class SessionStateStore {
         }
       })
       this.state = {
-        version: 2,
+        version: 3,
         sessions: annotations,
         managedSessions: Array.isArray(raw.managedSessions)
           ? raw.managedSessions.map(normalizeControlSession).filter((item): item is ControlSession => item !== null)
@@ -180,6 +247,18 @@ export class SessionStateStore {
             .map(normalizeUsageEntry)
             .filter((item): item is UsageLedgerEntry => item !== null)
             .slice(0, MAX_USAGE_ENTRIES)
+          : [],
+        usageBudgets: Array.isArray(raw.usageBudgets)
+          ? raw.usageBudgets
+            .map(normalizeUsageBudget)
+            .filter((item): item is UsageBudget => item !== null)
+            .slice(0, MAX_USAGE_BUDGETS)
+          : [],
+        usageAlerts: Array.isArray(raw.usageAlerts)
+          ? raw.usageAlerts
+            .map(normalizeUsageAlert)
+            .filter((item): item is UsageBudgetAlert => item !== null)
+            .slice(0, MAX_USAGE_ALERTS)
           : [],
       }
     } catch {
@@ -274,6 +353,31 @@ export class SessionStateStore {
       .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id))
       .slice(0, MAX_USAGE_ENTRIES)
     if (JSON.stringify(this.state.usageEntries) === previousSnapshot) return
+    await this.persist()
+  }
+
+  usageBudgets(): UsageBudget[] {
+    return this.state.usageBudgets.map((budget) => ({ ...budget }))
+  }
+
+  usageAlerts(): UsageBudgetAlert[] {
+    return this.state.usageAlerts.map((alert) => ({ ...alert }))
+  }
+
+  async saveUsageBudgets(budgets: UsageBudget[]): Promise<void> {
+    this.state.usageBudgets = budgets
+      .map(normalizeUsageBudget)
+      .filter((item): item is UsageBudget => item !== null)
+      .slice(0, MAX_USAGE_BUDGETS)
+    await this.persist()
+  }
+
+  async saveUsageAlerts(alerts: UsageBudgetAlert[]): Promise<void> {
+    this.state.usageAlerts = alerts
+      .map(normalizeUsageAlert)
+      .filter((item): item is UsageBudgetAlert => item !== null)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+      .slice(0, MAX_USAGE_ALERTS)
     await this.persist()
   }
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -251,6 +251,7 @@ export interface ControlPermission {
 export interface ControlSnapshot {
   generatedAt: string
   connected: boolean
+  processId: number
   starting: boolean
   reconnecting: boolean
   reconnectAttempt: number
@@ -306,6 +307,89 @@ export interface SessionWorkbenchData {
   control: ControlSession | null
   permissions: ControlPermission[]
   managed: boolean
+}
+
+export type RuntimeProcessState = 'running' | 'sleeping' | 'stopped' | 'zombie' | 'unknown'
+export type RuntimeBindScope = 'loopback' | 'all' | 'lan' | 'unknown'
+export type RuntimeServiceKind =
+  | 'database'
+  | 'cache'
+  | 'queue'
+  | 'emulator'
+  | 'dev-server'
+  | 'web'
+  | 'other'
+export type RuntimeTestStatus = 'running' | 'passed' | 'failed' | 'interrupted' | 'unknown'
+export type ExternalCallCategory = 'network' | 'browser' | 'mcp' | 'cloud' | 'vcs'
+
+export interface RuntimeRoot {
+  pid: number
+  managed: boolean
+  sessionIds: string[]
+  workspaces: string[]
+}
+
+export interface RuntimeProcess {
+  pid: number
+  parentPid: number
+  rootPid: number
+  depth: number
+  name: string
+  state: RuntimeProcessState
+  elapsed: string
+  sessionIds: string[]
+  workspaces: string[]
+  ports: number[]
+}
+
+export interface RuntimePort {
+  pid: number
+  port: number
+  protocol: 'tcp'
+  bind: RuntimeBindScope
+}
+
+export interface RuntimeService {
+  id: string
+  pid: number
+  name: string
+  kind: RuntimeServiceKind
+  port: number
+  bind: RuntimeBindScope
+  status: 'listening' | 'running'
+}
+
+export interface RuntimeTestRun {
+  id: string
+  sessionId: string
+  title: string
+  framework: string
+  status: RuntimeTestStatus
+  startedAt: string
+  updatedAt: string
+  incomplete: boolean
+}
+
+export interface ExternalToolCall {
+  id: string
+  sessionId: string
+  title: string
+  category: ExternalCallCategory
+  status: string
+  updatedAt: string
+}
+
+export interface RuntimeSnapshot {
+  generatedAt: string
+  available: boolean
+  partial: boolean
+  error: string
+  roots: RuntimeRoot[]
+  processes: RuntimeProcess[]
+  ports: RuntimePort[]
+  services: RuntimeService[]
+  tests: RuntimeTestRun[]
+  externalCalls: ExternalToolCall[]
 }
 
 export type UsageSource = 'grok-reported' | 'derived' | 'incomplete' | 'unavailable'
@@ -364,4 +448,48 @@ export interface UsageReport {
   totals: UsageReportGroup
   groups: UsageReportGroup[]
   coverage: Record<UsageSource, number>
+}
+
+export type UsageBudgetDimension = 'global' | UsageGroupDimension
+export type UsageBudgetMetric = 'tokens' | 'cost'
+
+export interface UsageBudget {
+  id: string
+  dimension: UsageBudgetDimension
+  key: string
+  label: string
+  metric: UsageBudgetMetric
+  limit: number
+  period: UsagePeriod
+  currency: string
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UsageBudgetAlert {
+  id: string
+  budgetId: string
+  threshold: number
+  observed: number
+  limit: number
+  source: UsageSource
+  periodFrom: string
+  createdAt: string
+  acknowledgedAt: string
+}
+
+export interface UsageBudgetStatus {
+  budget: UsageBudget
+  observed: UsageMetric
+  percent: number | null
+  alertLevel: 'none' | 'warning' | 'exceeded' | 'unavailable'
+  periodFrom: string
+  periodTo: string
+}
+
+export interface UsageBudgetSnapshot {
+  generatedAt: string
+  statuses: UsageBudgetStatus[]
+  alerts: UsageBudgetAlert[]
 }

--- a/server/usage-budgets.test.ts
+++ b/server/usage-budgets.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { SessionStateStore } from './session-state.js'
+import { UsageBudgetManager } from './usage-budgets.js'
+import { usageExport } from './usage-export.js'
+import { UsageLedger } from './usage-ledger.js'
+import type { UsageLedgerEntry } from './types.js'
+
+const cleanup: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((directory) =>
+    fs.rm(directory, { recursive: true, force: true })))
+})
+
+async function setup() {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-budgets-'))
+  cleanup.push(directory)
+  const state = new SessionStateStore(directory)
+  await state.load()
+  const entry: UsageLedgerEntry = {
+    id: 'usage:test',
+    kind: 'managed-session',
+    sessionId: 'secret-session',
+    sessionTitle: 'Secret launch',
+    workflowId: '',
+    project: 'secret-project',
+    cwd: '/private/secret-project',
+    model: 'grok-code',
+    agent: 'Grok UI',
+    startedAt: '2026-07-25T10:00:00.000Z',
+    updatedAt: '2026-07-26T10:00:00.000Z',
+    inputTokens: { value: 700, source: 'grok-reported' },
+    outputTokens: { value: 300, source: 'grok-reported' },
+    totalTokens: { value: 1_000, source: 'grok-reported' },
+    cost: { value: 12, source: 'grok-reported', currency: 'USD' },
+  }
+  await state.mergeUsageEntries([entry])
+  const ledger = new UsageLedger(state)
+  return { directory, state, ledger, manager: new UsageBudgetManager(state, ledger) }
+}
+
+describe('UsageBudgetManager', () => {
+  it('persists optional budgets and deduplicates local warning and exceeded alerts', async () => {
+    const { directory, manager } = await setup()
+    const now = new Date('2026-07-26T12:00:00.000Z')
+    await manager.upsert({
+      dimension: 'global',
+      metric: 'tokens',
+      limit: 900,
+      period: '30d',
+    }, now)
+
+    const first = await manager.snapshot(now)
+    expect(first.statuses[0]).toMatchObject({
+      observed: { value: 1_000, source: 'derived' },
+      alertLevel: 'exceeded',
+    })
+    expect(first.alerts.map((alert) => alert.threshold)).toEqual([0.8, 1])
+
+    const second = await manager.snapshot(new Date('2026-07-26T12:05:00.000Z'))
+    expect(second.alerts).toHaveLength(2)
+
+    const restoredState = new SessionStateStore(directory)
+    await restoredState.load()
+    const restored = await new UsageBudgetManager(restoredState, new UsageLedger(restoredState)).snapshot(now)
+    expect(restored.statuses).toHaveLength(1)
+    expect(restored.alerts).toHaveLength(2)
+  })
+
+  it('uses workflow-agent observations for agent budgets and reports missing targets unavailable', async () => {
+    const { manager } = await setup()
+    await manager.upsert({
+      dimension: 'agent',
+      key: 'missing-agent',
+      metric: 'tokens',
+      limit: 100,
+      period: 'all',
+    })
+    const snapshot = await manager.snapshot(new Date('2026-07-26T12:00:00.000Z'))
+    expect(snapshot.statuses[0]).toMatchObject({
+      observed: { value: null, source: 'unavailable' },
+      percent: null,
+      alertLevel: 'unavailable',
+    })
+    expect(snapshot.alerts).toEqual([])
+  })
+
+  it('upgrades v2 ledger state to v3 without losing existing usage', async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-budget-v2-'))
+    cleanup.push(directory)
+    await fs.writeFile(path.join(directory, 'state.json'), JSON.stringify({
+      version: 2,
+      sessions: {},
+      managedSessions: [],
+      usageEntries: [{
+        id: 'usage:legacy',
+        kind: 'managed-session',
+        sessionId: 'legacy-session',
+        sessionTitle: 'Legacy',
+        workflowId: '',
+        project: 'legacy',
+        cwd: '/tmp/legacy',
+        model: 'grok-code',
+        agent: 'Grok UI',
+        startedAt: '2026-07-25T10:00:00.000Z',
+        updatedAt: '2026-07-26T10:00:00.000Z',
+        inputTokens: { value: 5, source: 'grok-reported' },
+        outputTokens: { value: 5, source: 'grok-reported' },
+        totalTokens: { value: 10, source: 'grok-reported' },
+        cost: { value: null, source: 'unavailable', currency: '' },
+      }],
+    }), { mode: 0o600 })
+    const state = new SessionStateStore(directory)
+    await state.load()
+    const ledger = new UsageLedger(state)
+    const manager = new UsageBudgetManager(state, ledger)
+    await manager.upsert({
+      dimension: 'global',
+      metric: 'tokens',
+      limit: 20,
+      period: 'all',
+    })
+
+    expect(ledger.report({ period: 'all' }).entries).toHaveLength(1)
+    const persisted = JSON.parse(await fs.readFile(state.file, 'utf8'))
+    expect(persisted).toMatchObject({
+      version: 3,
+      usageEntries: [{ id: 'usage:legacy' }],
+      usageBudgets: [{ metric: 'tokens', limit: 20 }],
+      usageAlerts: [],
+    })
+  })
+})
+
+describe('usageExport', () => {
+  it('redacts sensitive report dimensions before producing JSON or CSV', async () => {
+    const { ledger } = await setup()
+    const report = ledger.report({
+      period: 'all',
+      scope: 'sessions',
+      groupBy: 'project',
+      now: new Date('2026-07-26T12:00:00.000Z'),
+    })
+    const json = usageExport(report, 'json', true)
+    const csv = usageExport(report, 'csv', true)
+    expect(json.body).toContain('"privacyApplied": true')
+    expect(json.body).not.toContain('secret-project')
+    expect(json.body).not.toContain('Secret launch')
+    expect(csv.body).not.toContain('/private/secret-project')
+    expect(csv.body).toContain('Workspace ')
+  })
+})

--- a/server/usage-budgets.ts
+++ b/server/usage-budgets.ts
@@ -1,0 +1,192 @@
+import crypto from 'node:crypto'
+import type {
+  UsageBudget,
+  UsageBudgetAlert,
+  UsageBudgetDimension,
+  UsageBudgetMetric,
+  UsageBudgetSnapshot,
+  UsageMetric,
+  UsagePeriod,
+  UsageReport,
+  UsageReportGroup,
+  UsageScope,
+} from './types.js'
+import { SessionStateStore } from './session-state.js'
+import { UsageLedger } from './usage-ledger.js'
+
+export interface UsageBudgetInput {
+  id?: string
+  dimension: UsageBudgetDimension
+  key?: string
+  label?: string
+  metric: UsageBudgetMetric
+  limit: number
+  period: UsagePeriod
+  currency?: string
+  enabled?: boolean
+}
+
+function safeId(): string {
+  return `budget:${crypto.randomUUID()}`
+}
+
+function scopeFor(dimension: UsageBudgetDimension): UsageScope {
+  return dimension === 'agent' ? 'workflow-agents' : 'sessions'
+}
+
+function reportFor(ledger: UsageLedger, budget: UsageBudget, now: Date): UsageReport {
+  return ledger.report({
+    period: budget.period,
+    scope: scopeFor(budget.dimension),
+    groupBy: budget.dimension === 'global' ? 'project' : budget.dimension,
+    now,
+  })
+}
+
+function selectedGroup(report: UsageReport, budget: UsageBudget): UsageReportGroup | null {
+  if (budget.dimension === 'global') return report.totals
+  return report.groups.find((group) => group.key === budget.key) || null
+}
+
+function observedMetric(group: UsageReportGroup | null, budget: UsageBudget): UsageMetric {
+  if (!group) return { value: null, source: 'unavailable' }
+  if (budget.metric === 'tokens') return group.totalTokens
+  const cost = group.costs.find((item) => item.currency === budget.currency)
+  return cost
+    ? { value: cost.value, source: cost.source }
+    : { value: null, source: 'unavailable' }
+}
+
+function alertId(budgetId: string, threshold: number, budgetUpdatedAt: string): string {
+  const digest = crypto.createHash('sha256')
+    .update(`${budgetId}\u0000${threshold}\u0000${budgetUpdatedAt}`)
+    .digest('base64url')
+    .slice(0, 24)
+  return `alert:${digest}`
+}
+
+export class UsageBudgetManager {
+  constructor(
+    private readonly state: SessionStateStore,
+    private readonly ledger: UsageLedger,
+  ) {}
+
+  async upsert(input: UsageBudgetInput, now = new Date()): Promise<UsageBudget> {
+    const dimension = input.dimension
+    if (!['global', 'project', 'model', 'session', 'agent'].includes(dimension)) {
+      throw new Error('Budget dimension must be global, project, model, session, or agent.')
+    }
+    if (!['tokens', 'cost'].includes(input.metric)) {
+      throw new Error('Budget metric must be tokens or cost.')
+    }
+    if (!['24h', '7d', '30d', '90d', 'all'].includes(input.period)) {
+      throw new Error('Budget period must be 24h, 7d, 30d, 90d, or all.')
+    }
+    const limit = Number(input.limit)
+    if (!Number.isFinite(limit) || limit <= 0 || limit > 1_000_000_000_000) {
+      throw new Error('Budget limit must be greater than zero.')
+    }
+    const key = dimension === 'global' ? '*' : String(input.key || '').trim().slice(0, 2_048)
+    if (dimension !== 'global' && !key) throw new Error('A target key is required for this budget.')
+    const currency = input.metric === 'cost'
+      ? String(input.currency || 'USD').trim().slice(0, 16).toUpperCase()
+      : ''
+    if (input.metric === 'cost' && !/^[A-Z]{3,8}$/.test(currency)) {
+      throw new Error('Budget currency must be a 3–8 letter code.')
+    }
+    const budgets = this.state.usageBudgets()
+    const existing = input.id ? budgets.find((budget) => budget.id === input.id) : undefined
+    if (input.id && !existing) throw new Error('Budget not found.')
+    const timestamp = now.toISOString()
+    const budget: UsageBudget = {
+      id: existing?.id || safeId(),
+      dimension,
+      key,
+      label: String(input.label || '').trim().slice(0, 256)
+        || (dimension === 'global' ? 'All usage' : key.slice(0, 256)),
+      metric: input.metric,
+      limit,
+      period: input.period,
+      currency,
+      enabled: input.enabled !== false,
+      createdAt: existing?.createdAt || timestamp,
+      updatedAt: timestamp,
+    }
+    const next = existing
+      ? budgets.map((item) => item.id === budget.id ? budget : item)
+      : [budget, ...budgets]
+    await this.state.saveUsageBudgets(next)
+    return budget
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const budgets = this.state.usageBudgets()
+    if (!budgets.some((budget) => budget.id === id)) return false
+    await this.state.saveUsageBudgets(budgets.filter((budget) => budget.id !== id))
+    await this.state.saveUsageAlerts(this.state.usageAlerts().filter((alert) => alert.budgetId !== id))
+    return true
+  }
+
+  async acknowledge(alertIdToAcknowledge: string, now = new Date()): Promise<boolean> {
+    const alerts = this.state.usageAlerts()
+    if (!alerts.some((alert) => alert.id === alertIdToAcknowledge)) return false
+    await this.state.saveUsageAlerts(alerts.map((alert) =>
+      alert.id === alertIdToAcknowledge
+        ? { ...alert, acknowledgedAt: now.toISOString() }
+        : alert))
+    return true
+  }
+
+  async snapshot(now = new Date()): Promise<UsageBudgetSnapshot> {
+    const budgets = this.state.usageBudgets()
+    const statuses = budgets.map((budget) => {
+      const report = reportFor(this.ledger, budget, now)
+      const observed = observedMetric(selectedGroup(report, budget), budget)
+      const percent = observed.value === null ? null : observed.value / budget.limit
+      return {
+        budget,
+        observed,
+        percent,
+        alertLevel: observed.value === null
+          ? 'unavailable' as const
+          : percent! >= 1 ? 'exceeded' as const
+            : percent! >= 0.8 ? 'warning' as const
+              : 'none' as const,
+        periodFrom: report.from,
+        periodTo: report.to,
+      }
+    })
+
+    const existing = this.state.usageAlerts()
+    const alertsById = new Map(existing.map((alert) => [alert.id, alert]))
+    statuses.filter((status) => status.budget.enabled && status.observed.value !== null).forEach((status) => {
+      ;[0.8, 1].forEach((threshold) => {
+        if (status.percent! < threshold) return
+        const id = alertId(status.budget.id, threshold, status.budget.updatedAt)
+        if (alertsById.has(id)) return
+        const alert: UsageBudgetAlert = {
+          id,
+          budgetId: status.budget.id,
+          threshold,
+          observed: status.observed.value!,
+          limit: status.budget.limit,
+          source: status.observed.source,
+          periodFrom: status.periodFrom,
+          createdAt: now.toISOString(),
+          acknowledgedAt: '',
+        }
+        alertsById.set(id, alert)
+      })
+    })
+    const alerts = [...alertsById.values()]
+      .filter((alert) => budgets.some((budget) => budget.id === alert.budgetId))
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+    if (JSON.stringify(alerts) !== JSON.stringify(existing)) await this.state.saveUsageAlerts(alerts)
+
+    return {
+      generatedAt: now.toISOString(),
+      statuses,
+      alerts,
+    }
+  }
+}

--- a/server/usage-export.ts
+++ b/server/usage-export.ts
@@ -1,0 +1,92 @@
+import type { UsageLedgerEntry, UsageReport } from './types.js'
+
+export type UsageExportFormat = 'json' | 'csv'
+
+const MAX_EXPORT_ENTRIES = 5_000
+
+function alias(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36).slice(-3).toUpperCase().padStart(3, '0')
+}
+
+function redact(entry: UsageLedgerEntry): UsageLedgerEntry {
+  const sessionAlias = alias(entry.sessionId || entry.id)
+  const projectAlias = alias(entry.cwd || entry.project)
+  const workflowAlias = entry.workflowId ? alias(entry.workflowId) : ''
+  return {
+    ...entry,
+    id: `usage:private-${alias(entry.id).toLowerCase()}`,
+    sessionId: `session-${sessionAlias.toLowerCase()}`,
+    sessionTitle: `Session ${sessionAlias}`,
+    workflowId: workflowAlias ? `workflow-${workflowAlias.toLowerCase()}` : '',
+    project: `Workspace ${projectAlias}`,
+    cwd: `~/workspace-${projectAlias.toLowerCase()}`,
+    agent: entry.kind === 'workflow-agent' ? `Agent ${alias(entry.agent)}` : entry.agent,
+  }
+}
+
+function csvCell(value: string | number | null): string {
+  const text = value === null ? '' : String(value)
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text
+}
+
+export function usageExport(
+  report: UsageReport,
+  format: UsageExportFormat,
+  privacy: boolean,
+): { body: string; contentType: string; extension: UsageExportFormat } {
+  const entries = report.entries.slice(0, MAX_EXPORT_ENTRIES)
+    .map((entry) => privacy ? redact(entry) : entry)
+  if (format === 'json') {
+    return {
+      body: JSON.stringify({
+        generatedAt: report.generatedAt,
+        period: report.period,
+        scope: report.scope,
+        from: report.from,
+        to: report.to,
+        privacyApplied: privacy,
+        truncated: report.entries.length > MAX_EXPORT_ENTRIES,
+        entries,
+      }, null, 2),
+      contentType: 'application/json; charset=utf-8',
+      extension: 'json',
+    }
+  }
+
+  const header = [
+    'kind', 'session_id', 'session_title', 'workflow_id', 'project', 'cwd', 'model', 'agent',
+    'started_at', 'updated_at', 'input_tokens', 'input_source', 'output_tokens', 'output_source',
+    'total_tokens', 'total_source', 'cost', 'currency', 'cost_source',
+  ]
+  const rows = entries.map((entry) => [
+    entry.kind,
+    entry.sessionId,
+    entry.sessionTitle,
+    entry.workflowId,
+    entry.project,
+    entry.cwd,
+    entry.model,
+    entry.agent,
+    entry.startedAt,
+    entry.updatedAt,
+    entry.inputTokens.value,
+    entry.inputTokens.source,
+    entry.outputTokens.value,
+    entry.outputTokens.source,
+    entry.totalTokens.value,
+    entry.totalTokens.source,
+    entry.cost.value,
+    entry.cost.currency,
+    entry.cost.source,
+  ].map(csvCell).join(','))
+  return {
+    body: [header.join(','), ...rows].join('\n'),
+    contentType: 'text/csv; charset=utf-8',
+    extension: 'csv',
+  }
+}

--- a/server/usage-ledger.test.ts
+++ b/server/usage-ledger.test.ts
@@ -218,7 +218,7 @@ describe('UsageLedger', () => {
       cost: { value: 0.04, currency: 'USD' },
     })
     const persisted = JSON.parse(await fs.readFile(first.file, 'utf8'))
-    expect(persisted.version).toBe(2)
+    expect(persisted.version).toBe(3)
     expect((await fs.stat(first.file)).mode & 0o777).toBe(0o600)
   })
 
@@ -245,8 +245,10 @@ describe('UsageLedger', () => {
     await state.annotate('legacy', { archived: true })
     const upgraded = JSON.parse(await fs.readFile(state.file, 'utf8'))
     expect(upgraded).toMatchObject({
-      version: 2,
+      version: 3,
       usageEntries: [],
+      usageBudgets: [],
+      usageAlerts: [],
     })
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,15 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { getAuthStatus, getControlSnapshot, getDashboard, getLiveSnapshot, getSetupStatus, login } from './api'
+import {
+  getAuthStatus,
+  getControlSnapshot,
+  getDashboard,
+  getLiveSnapshot,
+  getRuntimeSnapshot,
+  getSetupStatus,
+  login,
+} from './api'
 import type {
   ActivityDay,
   ControlSnapshot,
@@ -43,6 +51,7 @@ import type {
   LiveFeedItem,
   LiveSnapshot,
   RankedDatum,
+  RuntimeSnapshot,
   SessionRow,
   SetupCheckState,
   SetupStatus,
@@ -54,6 +63,7 @@ import { ControlView } from './views/ControlView'
 import { SessionWorkbench } from './views/SessionWorkbench'
 import { WorkflowsView } from './views/WorkflowsView'
 import { UsageView } from './views/UsageView'
+import { RuntimeIntelligencePanels } from './views/RuntimeIntelligencePanels'
 import { PrivacyProvider, usePrivacy } from './privacy'
 import packageJson from '../package.json'
 
@@ -157,6 +167,7 @@ function App() {
   const [view, setView] = useState<ViewId>('live')
   const [data, setData] = useState<DashboardPayload | null>(null)
   const [live, setLive] = useState<LiveSnapshot | null>(null)
+  const [runtime, setRuntime] = useState<RuntimeSnapshot | null>(null)
   const [control, setControl] = useState<ControlSnapshot | null>(null)
   const [setup, setSetup] = useState<SetupStatus | null>(null)
   const [streamConnected, setStreamConnected] = useState(false)
@@ -193,12 +204,14 @@ function App() {
   const load = useCallback(async (force = false) => {
     if (force) setRefreshing(true)
     try {
-      const [payload, livePayload] = await Promise.all([
+      const [payload, livePayload, runtimePayload] = await Promise.all([
         getDashboard(force),
         getLiveSnapshot(),
+        getRuntimeSnapshot(force),
       ])
       setData(payload)
       setLive(livePayload)
+      setRuntime(runtimePayload)
       setError('')
       if (payload.stats.sessions === 0) {
         void getSetupStatus(force)
@@ -243,6 +256,10 @@ function App() {
     events.addEventListener('control', (event) => {
       setStreamConnected(true)
       setControl(JSON.parse((event as MessageEvent).data) as ControlSnapshot)
+    })
+    events.addEventListener('runtime', (event) => {
+      setStreamConnected(true)
+      setRuntime(JSON.parse((event as MessageEvent).data) as RuntimeSnapshot)
     })
     events.addEventListener('workspace', (event) => {
       setStreamConnected(true)
@@ -354,6 +371,7 @@ function App() {
             {view === 'live' && (
               <LiveView
                 live={live}
+                runtime={runtime}
                 data={data}
                 setup={setup}
                 connected={streamConnected}
@@ -656,6 +674,7 @@ function TopBar({
 
 function LiveView({
   live,
+  runtime,
   data,
   setup,
   connected,
@@ -663,6 +682,7 @@ function LiveView({
   onRefresh,
 }: {
   live: LiveSnapshot | null
+  runtime: RuntimeSnapshot | null
   data: DashboardPayload
   setup: SetupStatus | null
   connected: boolean
@@ -823,6 +843,7 @@ function LiveView({
           </section>
         </section>
       )}
+      <RuntimeIntelligencePanels runtime={runtime} />
     </>
   )
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,8 +5,13 @@ import type {
   SessionRow,
   SessionWorkbenchData,
   LiveSnapshot,
+  RuntimeSnapshot,
   SetupStatus,
   UsageGroupDimension,
+  UsageBudget,
+  UsageBudgetDimension,
+  UsageBudgetMetric,
+  UsageBudgetSnapshot,
   UsagePeriod,
   UsageReport,
   UsageScope,
@@ -33,6 +38,13 @@ export async function getLiveSnapshot(): Promise<LiveSnapshot> {
   return json<LiveSnapshot>(response, 'Live runtime request failed')
 }
 
+export async function getRuntimeSnapshot(force = false): Promise<RuntimeSnapshot> {
+  const response = await fetch(`/api/runtime${force ? '?refresh=1' : ''}`, {
+    headers: { Accept: 'application/json' },
+  })
+  return json<RuntimeSnapshot>(response, 'Runtime intelligence request failed')
+}
+
 export async function getUsageReport(input: {
   period: UsagePeriod
   scope: UsageScope
@@ -45,6 +57,79 @@ export async function getUsageReport(input: {
     }),
     'Usage ledger request failed',
   )
+}
+
+export async function getUsageBudgets(): Promise<UsageBudgetSnapshot> {
+  return json(
+    await fetch('/api/usage/budgets', { headers: { Accept: 'application/json' } }),
+    'Usage budgets request failed',
+  )
+}
+
+export async function saveUsageBudget(input: {
+  id?: string
+  dimension: UsageBudgetDimension
+  key?: string
+  label?: string
+  metric: UsageBudgetMetric
+  limit: number
+  period: UsagePeriod
+  currency?: string
+  enabled?: boolean
+}): Promise<{ budget: UsageBudget; snapshot: UsageBudgetSnapshot }> {
+  return json(
+    await fetch('/api/usage/budgets', {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }),
+    'Unable to save usage budget',
+  )
+}
+
+export async function deleteUsageBudget(id: string): Promise<void> {
+  const response = await fetch(`/api/usage/budgets/${encodeURIComponent(id)}`, { method: 'DELETE' })
+  if (!response.ok) await json(response, 'Unable to delete usage budget')
+}
+
+export async function acknowledgeUsageAlert(id: string): Promise<UsageBudgetSnapshot> {
+  return json(
+    await fetch(`/api/usage/alerts/${encodeURIComponent(id)}/acknowledge`, {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+    }),
+    'Unable to acknowledge usage alert',
+  )
+}
+
+export async function downloadUsageExport(input: {
+  period: UsagePeriod
+  scope: UsageScope
+  groupBy: UsageGroupDimension
+  format: 'json' | 'csv'
+  privacy: boolean
+}): Promise<void> {
+  const query = new URLSearchParams({
+    period: input.period,
+    scope: input.scope,
+    groupBy: input.groupBy,
+    format: input.format,
+    privacy: input.privacy ? '1' : '0',
+  })
+  const response = await fetch(`/api/usage/export?${query.toString()}`, {
+    headers: { Accept: input.format === 'json' ? 'application/json' : 'text/csv' },
+  })
+  if (!response.ok) {
+    await json(response, 'Usage export failed')
+    return
+  }
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = `grok-ui-usage.${input.format}`
+  anchor.click()
+  URL.revokeObjectURL(url)
 }
 
 export async function getSetupStatus(force = false): Promise<SetupStatus> {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7523,7 +7523,7 @@ kbd {
 
 .usage-toolbar {
   display: grid;
-  grid-template-columns: minmax(360px, 1fr) minmax(170px, .35fr) minmax(150px, .3fr);
+  grid-template-columns: minmax(330px, 1fr) minmax(150px, .34fr) minmax(140px, .3fr) minmax(170px, .38fr);
   gap: 1px;
   margin-bottom: 18px;
   border: 1px solid var(--line);
@@ -7554,6 +7554,30 @@ kbd {
   border-radius: 0;
   background: var(--surface-2);
   text-transform: capitalize;
+}
+
+.usage-export-actions > div {
+  display: flex;
+  gap: 6px;
+}
+
+.usage-export-actions button,
+.usage-budget-add {
+  min-height: 36px;
+  padding: 0 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  color: var(--paper);
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  cursor: pointer;
+}
+
+.usage-export-actions button:hover,
+.usage-budget-add:hover:not(:disabled) {
+  border-color: var(--lime);
 }
 
 .usage-segment {
@@ -7833,6 +7857,204 @@ kbd {
   line-height: 1.7;
 }
 
+.usage-budget-panel {
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.usage-budget-panel > header {
+  min-height: 78px;
+  padding: 15px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.usage-budget-panel > header > div {
+  display: grid;
+  gap: 5px;
+}
+
+.usage-budget-panel > header span {
+  color: var(--lime);
+  font-size: var(--type-meta);
+  letter-spacing: .14em;
+}
+
+.usage-budget-panel > header h2 {
+  margin: 0;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 20px;
+  font-weight: 560;
+}
+
+.usage-budget-panel > header > small {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+}
+
+.usage-budget-form {
+  padding: 14px 18px;
+  display: flex;
+  align-items: end;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.usage-budget-form label {
+  min-width: 120px;
+  flex: 1;
+  display: grid;
+  gap: 7px;
+}
+
+.usage-budget-form label > span {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.usage-budget-form input,
+.usage-budget-form select {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  color: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 0;
+  background: var(--surface-2);
+}
+
+.usage-budget-add {
+  color: var(--ink);
+  border-color: var(--lime);
+  background: var(--lime);
+  white-space: nowrap;
+}
+
+.usage-budget-add:disabled {
+  opacity: .45;
+  cursor: not-allowed;
+}
+
+.usage-budget-note {
+  margin: 0;
+  padding: 10px 18px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  font-size: var(--type-meta);
+}
+
+.usage-budget-error {
+  margin: 0;
+  padding: 10px 18px;
+  color: var(--coral);
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--coral) 6%, transparent);
+  font-size: var(--type-body);
+}
+
+.usage-budget-row {
+  min-height: 70px;
+  padding: 12px 18px;
+  display: grid;
+  grid-template-columns: minmax(170px, 1.2fr) minmax(170px, .8fr) minmax(120px, 1fr) 34px;
+  align-items: center;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.usage-budget-row > span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.usage-budget-row strong {
+  color: var(--paper);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.usage-budget-row small {
+  color: var(--muted);
+}
+
+.usage-budget-row.is-warning {
+  background: color-mix(in srgb, var(--amber) 6%, transparent);
+}
+
+.usage-budget-row.is-exceeded {
+  background: color-mix(in srgb, var(--coral) 8%, transparent);
+}
+
+.usage-budget-meter {
+  height: 5px;
+  display: block !important;
+  overflow: hidden;
+  background: var(--line);
+}
+
+.usage-budget-meter i {
+  height: 100%;
+  display: block;
+  background: var(--lime);
+}
+
+.usage-budget-row.is-warning .usage-budget-meter i {
+  background: var(--amber);
+}
+
+.usage-budget-row.is-exceeded .usage-budget-meter i {
+  background: var(--coral);
+}
+
+.usage-budget-row > button {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  background: transparent;
+  cursor: pointer;
+}
+
+.usage-budget-row > button:hover {
+  color: var(--coral);
+  border-color: var(--coral);
+}
+
+.usage-alert-list {
+  padding: 12px 18px;
+  display: grid;
+  gap: 7px;
+}
+
+.usage-alert-list button {
+  min-height: 42px;
+  padding: 8px 11px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 9px;
+  color: var(--amber);
+  border: 1px solid color-mix(in srgb, var(--amber) 35%, var(--line));
+  background: color-mix(in srgb, var(--amber) 5%, transparent);
+  text-align: left;
+  cursor: pointer;
+}
+
+.usage-alert-list small {
+  color: var(--muted);
+}
+
 @media (max-width: 1040px) {
   .usage-toolbar {
     grid-template-columns: 1fr 1fr;
@@ -7877,5 +8099,479 @@ kbd {
 
   .usage-table-row > span:nth-child(6) {
     grid-column: 2 / -1;
+  }
+
+  .usage-budget-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .usage-budget-add {
+    min-height: 40px;
+  }
+
+  .usage-budget-row {
+    grid-template-columns: 1fr auto;
+  }
+
+  .usage-budget-row > span:nth-child(2),
+  .usage-budget-meter {
+    grid-column: 1 / -1;
+  }
+}
+
+/* v0.9 bounded runtime intelligence */
+
+.runtime-intelligence {
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.runtime-intelligence-head {
+  min-height: 106px;
+  padding: 20px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid var(--line);
+  background:
+    linear-gradient(100deg, var(--lime-soft), transparent 45%),
+    color-mix(in srgb, var(--surface-2) 85%, transparent);
+}
+
+.runtime-intelligence-head > div {
+  display: grid;
+  gap: 5px;
+}
+
+.runtime-intelligence-head > div > span {
+  color: var(--lime);
+  font-size: var(--type-meta);
+  letter-spacing: .16em;
+}
+
+.runtime-intelligence-head h2 {
+  margin: 0;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: clamp(22px, 2.2vw, 32px);
+  font-weight: 560;
+}
+
+.runtime-intelligence-head p {
+  max-width: 760px;
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: var(--type-body);
+  line-height: 1.6;
+}
+
+.runtime-intelligence-head > small {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.runtime-intelligence-head > small i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted-dim);
+}
+
+.runtime-intelligence-head > small.is-live i {
+  background: var(--lime);
+  box-shadow: 0 0 10px color-mix(in srgb, var(--lime) 55%, transparent);
+}
+
+.runtime-intelligence-head > small.is-partial {
+  color: var(--amber);
+}
+
+.runtime-intelligence-head > small.is-partial i {
+  background: var(--amber);
+}
+
+.runtime-intelligence-head > small.is-unavailable {
+  color: var(--coral);
+}
+
+.runtime-intelligence-head > small.is-unavailable i {
+  background: var(--coral);
+}
+
+.runtime-intelligence-warning {
+  min-height: 42px;
+  padding: 9px 18px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--amber);
+  border-bottom: 1px solid color-mix(in srgb, var(--amber) 25%, transparent);
+  background: color-mix(in srgb, var(--amber) 6%, transparent);
+  font-size: var(--type-body);
+}
+
+.runtime-intelligence-summary {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  border-bottom: 1px solid var(--line);
+  background: var(--line);
+}
+
+.runtime-counter {
+  min-width: 0;
+  min-height: 82px;
+  padding: 13px 15px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px;
+  background: var(--surface);
+}
+
+.runtime-counter > svg {
+  color: var(--lime);
+}
+
+.runtime-counter span {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+
+.runtime-counter strong {
+  grid-column: 1 / -1;
+  color: var(--paper);
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 24px;
+  font-weight: 580;
+}
+
+.runtime-intelligence-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
+}
+
+.runtime-intelligence-panel {
+  min-width: 0;
+  min-height: 280px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.runtime-intelligence-panel:nth-child(2n) {
+  border-right: 0;
+}
+
+.runtime-intelligence-panel > header {
+  min-height: 70px;
+  padding: 13px 17px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.runtime-intelligence-panel > header > div {
+  display: grid;
+  gap: 4px;
+}
+
+.runtime-intelligence-panel > header span {
+  color: var(--lime);
+  font-size: var(--type-meta);
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+.runtime-intelligence-panel > header h3 {
+  margin: 0;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: 16px;
+  font-weight: 560;
+}
+
+.runtime-intelligence-panel > header small {
+  max-width: 170px;
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
+  line-height: 1.4;
+  text-align: right;
+}
+
+.runtime-process-list,
+.runtime-service-list,
+.runtime-signal-list {
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.runtime-process-row {
+  --process-depth: 0;
+  min-height: 53px;
+  padding: 8px 13px 8px calc(13px + var(--process-depth) * 15px);
+  display: grid;
+  grid-template-columns: 12px 8px minmax(120px, 1fr) auto minmax(48px, auto);
+  align-items: center;
+  gap: 9px;
+  border-bottom: 1px solid var(--line);
+}
+
+.runtime-process-row:last-child,
+.runtime-service-row:last-child,
+.runtime-signal-row:last-child {
+  border-bottom: 0;
+}
+
+.runtime-tree-rail {
+  position: relative;
+  align-self: stretch;
+}
+
+.runtime-tree-rail::before {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: -8px;
+  bottom: -8px;
+  width: 1px;
+  background: var(--line);
+}
+
+.runtime-tree-rail i {
+  position: absolute;
+  left: 5px;
+  top: 50%;
+  width: 8px;
+  height: 1px;
+  background: var(--line-strong);
+}
+
+.runtime-process-state {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted-dim);
+}
+
+.runtime-process-state.state-running {
+  background: var(--lime);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--lime) 45%, transparent);
+}
+
+.runtime-process-state.state-sleeping {
+  background: var(--coral);
+}
+
+.runtime-process-state.state-stopped,
+.runtime-process-state.state-zombie {
+  background: var(--amber);
+}
+
+.runtime-process-row > span:nth-child(3),
+.runtime-service-row > span:nth-child(2),
+.runtime-signal-row > span:nth-child(2) {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.runtime-process-row strong,
+.runtime-service-row strong,
+.runtime-signal-row strong {
+  overflow: hidden;
+  color: var(--paper);
+  font-size: var(--type-body);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-process-row small,
+.runtime-service-row small,
+.runtime-signal-row small {
+  color: var(--muted-dim);
+  font-size: var(--type-meta);
+  text-transform: capitalize;
+}
+
+.runtime-process-row > span:nth-child(4),
+.runtime-process-row > em,
+.runtime-service-row > span:last-child,
+.runtime-signal-row > em {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.runtime-process-row > em {
+  color: var(--coral);
+  text-align: right;
+}
+
+.runtime-service-row,
+.runtime-signal-row {
+  min-height: 60px;
+  padding: 10px 14px;
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 11px;
+  border-bottom: 1px solid var(--line);
+}
+
+.runtime-service-icon,
+.runtime-external-kind,
+.runtime-test-status {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,.02);
+}
+
+.runtime-service-icon.service-database,
+.runtime-service-icon.service-cache {
+  color: var(--lime);
+  border-color: color-mix(in srgb, var(--lime) 28%, transparent);
+  background: var(--lime-soft);
+}
+
+.runtime-service-icon.service-queue,
+.runtime-service-icon.service-emulator {
+  color: var(--amber);
+}
+
+.runtime-test-status i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted-dim);
+}
+
+.runtime-test-status.test-running i {
+  background: var(--coral);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--coral) 50%, transparent);
+  animation: pulse-dot 1.8s ease-in-out infinite;
+}
+
+.runtime-test-status.test-passed i {
+  background: var(--lime);
+}
+
+.runtime-test-status.test-failed i,
+.runtime-test-status.test-interrupted i {
+  background: var(--amber);
+}
+
+.runtime-external-kind {
+  color: var(--coral);
+}
+
+.runtime-signal-row > em {
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-list-more {
+  min-height: 40px;
+  padding: 11px 15px;
+  color: var(--muted);
+  font-size: var(--type-meta);
+  text-align: center;
+}
+
+.runtime-intelligence-empty {
+  min-height: 208px;
+  padding: 30px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: var(--type-body);
+  line-height: 1.7;
+  text-align: center;
+}
+
+.runtime-intelligence-foot {
+  min-height: 62px;
+  padding: 13px 18px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 14px;
+}
+
+.runtime-intelligence-foot span {
+  color: var(--lime);
+  font-size: var(--type-meta);
+  letter-spacing: .13em;
+}
+
+.runtime-intelligence-foot p {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--type-meta);
+  line-height: 1.6;
+}
+
+@media (max-width: 1050px) {
+  .runtime-intelligence-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .runtime-intelligence-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .runtime-intelligence-panel,
+  .runtime-intelligence-panel:nth-child(2n) {
+    border-right: 0;
+  }
+}
+
+@media (max-width: 680px) {
+  .runtime-intelligence-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .runtime-intelligence-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .runtime-process-row {
+    grid-template-columns: 10px 7px minmax(100px, 1fr) auto;
+  }
+
+  .runtime-process-row > em {
+    grid-column: 3 / -1;
+  }
+
+  .runtime-intelligence-panel > header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .runtime-intelligence-panel > header small {
+    max-width: none;
+    text-align: left;
+  }
+
+  .runtime-intelligence-foot {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,6 +252,7 @@ export interface ControlPermission {
 export interface ControlSnapshot {
   generatedAt: string
   connected: boolean
+  processId: number
   starting: boolean
   reconnecting: boolean
   reconnectAttempt: number
@@ -307,6 +308,89 @@ export interface SessionWorkbenchData {
   control: ControlSession | null
   permissions: ControlPermission[]
   managed: boolean
+}
+
+export type RuntimeProcessState = 'running' | 'sleeping' | 'stopped' | 'zombie' | 'unknown'
+export type RuntimeBindScope = 'loopback' | 'all' | 'lan' | 'unknown'
+export type RuntimeServiceKind =
+  | 'database'
+  | 'cache'
+  | 'queue'
+  | 'emulator'
+  | 'dev-server'
+  | 'web'
+  | 'other'
+export type RuntimeTestStatus = 'running' | 'passed' | 'failed' | 'interrupted' | 'unknown'
+export type ExternalCallCategory = 'network' | 'browser' | 'mcp' | 'cloud' | 'vcs'
+
+export interface RuntimeRoot {
+  pid: number
+  managed: boolean
+  sessionIds: string[]
+  workspaces: string[]
+}
+
+export interface RuntimeProcess {
+  pid: number
+  parentPid: number
+  rootPid: number
+  depth: number
+  name: string
+  state: RuntimeProcessState
+  elapsed: string
+  sessionIds: string[]
+  workspaces: string[]
+  ports: number[]
+}
+
+export interface RuntimePort {
+  pid: number
+  port: number
+  protocol: 'tcp'
+  bind: RuntimeBindScope
+}
+
+export interface RuntimeService {
+  id: string
+  pid: number
+  name: string
+  kind: RuntimeServiceKind
+  port: number
+  bind: RuntimeBindScope
+  status: 'listening' | 'running'
+}
+
+export interface RuntimeTestRun {
+  id: string
+  sessionId: string
+  title: string
+  framework: string
+  status: RuntimeTestStatus
+  startedAt: string
+  updatedAt: string
+  incomplete: boolean
+}
+
+export interface ExternalToolCall {
+  id: string
+  sessionId: string
+  title: string
+  category: ExternalCallCategory
+  status: string
+  updatedAt: string
+}
+
+export interface RuntimeSnapshot {
+  generatedAt: string
+  available: boolean
+  partial: boolean
+  error: string
+  roots: RuntimeRoot[]
+  processes: RuntimeProcess[]
+  ports: RuntimePort[]
+  services: RuntimeService[]
+  tests: RuntimeTestRun[]
+  externalCalls: ExternalToolCall[]
 }
 
 export type UsageSource = 'grok-reported' | 'derived' | 'incomplete' | 'unavailable'
@@ -365,4 +449,48 @@ export interface UsageReport {
   totals: UsageReportGroup
   groups: UsageReportGroup[]
   coverage: Record<UsageSource, number>
+}
+
+export type UsageBudgetDimension = 'global' | UsageGroupDimension
+export type UsageBudgetMetric = 'tokens' | 'cost'
+
+export interface UsageBudget {
+  id: string
+  dimension: UsageBudgetDimension
+  key: string
+  label: string
+  metric: UsageBudgetMetric
+  limit: number
+  period: UsagePeriod
+  currency: string
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface UsageBudgetAlert {
+  id: string
+  budgetId: string
+  threshold: number
+  observed: number
+  limit: number
+  source: UsageSource
+  periodFrom: string
+  createdAt: string
+  acknowledgedAt: string
+}
+
+export interface UsageBudgetStatus {
+  budget: UsageBudget
+  observed: UsageMetric
+  percent: number | null
+  alertLevel: 'none' | 'warning' | 'exceeded' | 'unavailable'
+  periodFrom: string
+  periodTo: string
+}
+
+export interface UsageBudgetSnapshot {
+  generatedAt: string
+  statuses: UsageBudgetStatus[]
+  alerts: UsageBudgetAlert[]
 }

--- a/src/views/RuntimeIntelligencePanels.tsx
+++ b/src/views/RuntimeIntelligencePanels.tsx
@@ -1,0 +1,237 @@
+import {
+  Activity,
+  Braces,
+  CircleAlert,
+  Database,
+  FlaskConical,
+  Network,
+  RadioTower,
+  Server,
+} from 'lucide-react'
+import type { CSSProperties, ReactNode } from 'react'
+import { usePrivacy } from '../privacy'
+import type {
+  ExternalToolCall,
+  RuntimeProcess,
+  RuntimeService,
+  RuntimeSnapshot,
+  RuntimeTestRun,
+} from '../types'
+
+const MAX_VISIBLE_PROCESSES = 40
+const MAX_VISIBLE_SERVICES = 20
+const MAX_VISIBLE_SIGNALS = 12
+
+export function RuntimeIntelligencePanels({ runtime }: { runtime: RuntimeSnapshot | null }) {
+  const privacy = usePrivacy()
+  if (!runtime) {
+    return (
+      <section className="runtime-intelligence section-gap">
+        <header className="runtime-intelligence-head">
+          <div><span>01B / RUNTIME INTELLIGENCE</span><h2>Inspecting local descendants.</h2></div>
+          <small><i /> Establishing bounded process view</small>
+        </header>
+      </section>
+    )
+  }
+
+  const databaseCount = runtime.services.filter((service) => service.kind === 'database').length
+  return (
+    <section className="runtime-intelligence section-gap">
+      <header className="runtime-intelligence-head">
+        <div>
+          <span>01B / RUNTIME INTELLIGENCE</span>
+          <h2>What the agents started.</h2>
+          <p>Bounded descendants, listening ports, local services, tests, and structured external calls.</p>
+        </div>
+        <small className={runtime.partial ? 'is-partial' : runtime.available ? 'is-live' : 'is-unavailable'}>
+          <i /> {runtime.partial ? 'Partial inspection' : runtime.available ? 'Local inspection live' : 'Inspection unavailable'}
+        </small>
+      </header>
+
+      {runtime.error && (
+        <div className="runtime-intelligence-warning">
+          <CircleAlert size={15} />
+          <span>{runtime.error}</span>
+        </div>
+      )}
+
+      <div className="runtime-intelligence-summary">
+        <RuntimeCounter icon={<Braces size={17} />} label="Processes" value={runtime.processes.length} />
+        <RuntimeCounter icon={<RadioTower size={17} />} label="Open ports" value={runtime.ports.length} />
+        <RuntimeCounter icon={<Database size={17} />} label="Databases" value={databaseCount} />
+        <RuntimeCounter icon={<Server size={17} />} label="Services" value={runtime.services.length} />
+        <RuntimeCounter icon={<FlaskConical size={17} />} label="Tests" value={runtime.tests.length} />
+        <RuntimeCounter icon={<Network size={17} />} label="External calls" value={runtime.externalCalls.length} />
+      </div>
+
+      <div className="runtime-intelligence-grid">
+        <RuntimePanel
+          eyebrow="Process tree"
+          title="Spawned descendants"
+          meta={`${runtime.roots.length} root${runtime.roots.length === 1 ? '' : 's'} · depth capped at 8`}
+        >
+          {runtime.processes.length ? (
+            <div className="runtime-process-list">
+              {runtime.processes.slice(0, MAX_VISIBLE_PROCESSES).map((process) => (
+                <ProcessRow key={process.pid} process={process} privacyEnabled={privacy.enabled} />
+              ))}
+              {runtime.processes.length > MAX_VISIBLE_PROCESSES && (
+                <div className="runtime-list-more">
+                  +{runtime.processes.length - MAX_VISIBLE_PROCESSES} bounded descendants
+                </div>
+              )}
+            </div>
+          ) : (
+            <RuntimeEmpty>No registered process roots are available right now.</RuntimeEmpty>
+          )}
+        </RuntimePanel>
+
+        <RuntimePanel
+          eyebrow="Discovery"
+          title="Ports and local services"
+          meta="No active network probes"
+        >
+          {runtime.services.length ? (
+            <div className="runtime-service-list">
+              {runtime.services.slice(0, MAX_VISIBLE_SERVICES).map((service) => (
+                <ServiceRow key={service.id} service={service} privacyEnabled={privacy.enabled} />
+              ))}
+              {runtime.services.length > MAX_VISIBLE_SERVICES && (
+                <div className="runtime-list-more">
+                  +{runtime.services.length - MAX_VISIBLE_SERVICES} local services
+                </div>
+              )}
+            </div>
+          ) : (
+            <RuntimeEmpty>No listening services were found inside the bounded process trees.</RuntimeEmpty>
+          )}
+        </RuntimePanel>
+
+        <RuntimePanel eyebrow="Verification" title="Test command status" meta="Structured tool lifecycle">
+          {runtime.tests.length ? (
+            <div className="runtime-signal-list">
+              {runtime.tests.slice(0, MAX_VISIBLE_SIGNALS).map((test) => (
+                <TestRow key={test.id} test={test} />
+              ))}
+            </div>
+          ) : (
+            <RuntimeEmpty>Test commands will appear when Grok reports their tool lifecycle.</RuntimeEmpty>
+          )}
+        </RuntimePanel>
+
+        <RuntimePanel eyebrow="Boundaries" title="External tool calls" meta="Titles and status only">
+          {runtime.externalCalls.length ? (
+            <div className="runtime-signal-list">
+              {runtime.externalCalls.slice(0, MAX_VISIBLE_SIGNALS).map((call) => (
+                <ExternalRow key={call.id} call={call} />
+              ))}
+            </div>
+          ) : (
+            <RuntimeEmpty>No structured external calls are visible in the recent feed.</RuntimeEmpty>
+          )}
+        </RuntimePanel>
+      </div>
+      <footer className="runtime-intelligence-foot">
+        <span>LOCAL ONLY</span>
+        <p>
+          Process inspection is capped at 160 descendants and never exposes command arguments.
+          Port discovery is limited to those PIDs; Grok UI does not connect to discovered services.
+        </p>
+      </footer>
+    </section>
+  )
+}
+
+function RuntimeCounter({ icon, label, value }: { icon: ReactNode; label: string; value: number }) {
+  return <div className="runtime-counter">{icon}<span>{label}</span><strong>{value.toLocaleString()}</strong></div>
+}
+
+function RuntimePanel({
+  eyebrow,
+  title,
+  meta,
+  children,
+}: {
+  eyebrow: string
+  title: string
+  meta: string
+  children: ReactNode
+}) {
+  return (
+    <article className="runtime-intelligence-panel">
+      <header>
+        <div><span>{eyebrow}</span><h3>{title}</h3></div>
+        <small>{meta}</small>
+      </header>
+      {children}
+    </article>
+  )
+}
+
+function ProcessRow({ process, privacyEnabled }: { process: RuntimeProcess; privacyEnabled: boolean }) {
+  const privacy = usePrivacy()
+  const style = { '--process-depth': Math.min(process.depth, 8) } as CSSProperties
+  return (
+    <div className="runtime-process-row" style={style}>
+      <span className="runtime-tree-rail"><i /></span>
+      <span className={`runtime-process-state state-${process.state}`} />
+      <span>
+        <strong>{privacyEnabled ? privacy.capability(process.name, 'Process') : process.name}</strong>
+        <small>{process.depth ? `child depth ${process.depth}` : 'session root'} · {process.elapsed}</small>
+      </span>
+      <span>{privacyEnabled ? 'PID ••••' : `PID ${process.pid}`}</span>
+      <em>{process.ports.length ? privacyEnabled ? 'PORT ••••' : process.ports.join(', ') : '—'}</em>
+    </div>
+  )
+}
+
+function ServiceRow({ service, privacyEnabled }: { service: RuntimeService; privacyEnabled: boolean }) {
+  const privacy = usePrivacy()
+  return (
+    <div className="runtime-service-row">
+      <span className={`runtime-service-icon service-${service.kind}`}>
+        {service.kind === 'database' || service.kind === 'cache'
+          ? <Database size={15} />
+          : <Server size={15} />}
+      </span>
+      <span>
+        <strong>{privacyEnabled ? privacy.capability(service.name, 'Service') : service.name}</strong>
+        <small>{service.kind.replaceAll('-', ' ')} · {service.bind} bind</small>
+      </span>
+      <span>{service.port ? privacyEnabled ? 'PORT ••••' : `:${service.port}` : service.status}</span>
+    </div>
+  )
+}
+
+function TestRow({ test }: { test: RuntimeTestRun }) {
+  const privacy = usePrivacy()
+  return (
+    <div className="runtime-signal-row">
+      <span className={`runtime-test-status test-${test.status}`}><i /></span>
+      <span>
+        <strong>{privacy.content(test.title)}</strong>
+        <small>{test.framework} · {test.incomplete ? 'incomplete outcome' : 'structured status'}</small>
+      </span>
+      <em>{test.status}</em>
+    </div>
+  )
+}
+
+function ExternalRow({ call }: { call: ExternalToolCall }) {
+  const privacy = usePrivacy()
+  return (
+    <div className="runtime-signal-row">
+      <span className={`runtime-external-kind external-${call.category}`}><Activity size={14} /></span>
+      <span>
+        <strong>{privacy.content(call.title)}</strong>
+        <small>{call.category} · safe title only</small>
+      </span>
+      <em>{call.status || 'unknown'}</em>
+    </div>
+  )
+}
+
+function RuntimeEmpty({ children }: { children: ReactNode }) {
+  return <div className="runtime-intelligence-empty">{children}</div>
+}

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -1,16 +1,30 @@
 import {
   CircleDollarSign,
   DatabaseZap,
+  Download,
+  BellRing,
+  Plus,
   RefreshCw,
   Sigma,
+  Trash2,
   WalletCards,
   type LucideIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import { getUsageReport } from '../api'
+import {
+  acknowledgeUsageAlert,
+  deleteUsageBudget,
+  downloadUsageExport,
+  getUsageBudgets,
+  getUsageReport,
+  saveUsageBudget,
+} from '../api'
 import { usePrivacy } from '../privacy'
 import type {
   UsageGroupDimension,
+  UsageBudgetDimension,
+  UsageBudgetMetric,
+  UsageBudgetSnapshot,
   UsageMetric,
   UsagePeriod,
   UsageReport,
@@ -53,6 +67,14 @@ export function UsageView() {
   const [report, setReport] = useState<UsageReport | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [budgets, setBudgets] = useState<UsageBudgetSnapshot | null>(null)
+  const [budgetDimension, setBudgetDimension] = useState<UsageBudgetDimension>('global')
+  const [budgetKey, setBudgetKey] = useState('')
+  const [budgetMetric, setBudgetMetric] = useState<UsageBudgetMetric>('tokens')
+  const [budgetLimit, setBudgetLimit] = useState('')
+  const [budgetCurrency, setBudgetCurrency] = useState('USD')
+  const [budgetBusy, setBudgetBusy] = useState(false)
+  const [budgetError, setBudgetError] = useState('')
 
   useEffect(() => {
     let cancelled = false
@@ -75,6 +97,12 @@ export function UsageView() {
     }
   }, [period, scope, groupBy])
 
+  useEffect(() => {
+    void getUsageBudgets().then(setBudgets).catch(() => {
+      // The report remains useful if optional budget state cannot be loaded.
+    })
+  }, [report?.generatedAt])
+
   const totalCost = useMemo(() => costValue(report), [report])
   const visibleLabel = (label: string, key: string) => {
     if (groupBy === 'project') return privacy.workspace(label)
@@ -82,6 +110,35 @@ export function UsageView() {
     if (groupBy === 'agent') return privacy.capability(label, 'Agent')
     return label
   }
+  const refreshBudgets = async () => setBudgets(await getUsageBudgets())
+  const createBudget = async () => {
+    const limit = Number(budgetLimit)
+    if (!Number.isFinite(limit) || limit <= 0) return
+    setBudgetBusy(true)
+    try {
+      const result = await saveUsageBudget({
+        dimension: budgetDimension,
+        key: budgetDimension === 'global' ? undefined : budgetKey,
+        label: budgetDimension === 'global'
+          ? 'All usage'
+          : report?.groups.find((group) => group.key === budgetKey)?.label || budgetKey,
+        metric: budgetMetric,
+        limit,
+        period,
+        currency: budgetMetric === 'cost' ? budgetCurrency : undefined,
+      })
+      setBudgets(result.snapshot)
+      setBudgetLimit('')
+      setBudgetKey('')
+      setBudgetError('')
+    } catch (requestError) {
+      setBudgetError(requestError instanceof Error ? requestError.message : 'Unable to save usage budget.')
+    } finally {
+      setBudgetBusy(false)
+    }
+  }
+  const exportReport = (format: 'json' | 'csv') =>
+    downloadUsageExport({ period, scope, groupBy, format, privacy: privacy.enabled })
 
   return (
     <>
@@ -120,6 +177,13 @@ export function UsageView() {
           <select value={groupBy} onChange={(event) => setGroupBy(event.target.value as UsageGroupDimension)}>
             {GROUPS.map((item) => <option key={item} value={item}>{item}</option>)}
           </select>
+        </div>
+        <div className="usage-export-actions">
+          <span>Export</span>
+          <div>
+            <button onClick={() => void exportReport('json')}><Download size={13} /> JSON</button>
+            <button onClick={() => void exportReport('csv')}><Download size={13} /> CSV</button>
+          </div>
         </div>
       </section>
 
@@ -201,6 +265,119 @@ export function UsageView() {
                       : 'Try a wider period or another observation scope.'}
                   </span>
                 </div>
+              </div>
+            )}
+          </section>
+
+          <section className="usage-budget-panel section-gap">
+            <header>
+              <div>
+                <span>08B / GUARDRAILS</span>
+                <h2>Local budgets & alerts</h2>
+              </div>
+              <small><BellRing size={13} /> {budgets?.alerts.filter((alert) => !alert.acknowledgedAt).length || 0} active alerts</small>
+            </header>
+            <div className="usage-budget-form">
+              <label>
+                <span>Scope</span>
+                <select value={budgetDimension} onChange={(event) => {
+                  const next = event.target.value as UsageBudgetDimension
+                  setBudgetDimension(next)
+                  setBudgetKey('')
+                  if (next !== 'global') setGroupBy(next)
+                }}>
+                  {(['global', 'project', 'model', 'session', 'agent'] as UsageBudgetDimension[])
+                    .map((item) => <option key={item} value={item}>{item}</option>)}
+                </select>
+              </label>
+              {budgetDimension !== 'global' && (
+                <label>
+                  <span>Target</span>
+                  <select
+                    value={budgetKey}
+                    onChange={(event) => setBudgetKey(event.target.value)}
+                  >
+                    <option value="">Select {budgetDimension}</option>
+                    {groupBy === budgetDimension && report?.groups.map((group) =>
+                      <option key={group.key} value={group.key}>{visibleLabel(group.label, group.key)}</option>)}
+                  </select>
+                </label>
+              )}
+              <label>
+                <span>Metric</span>
+                <select value={budgetMetric} onChange={(event) => setBudgetMetric(event.target.value as UsageBudgetMetric)}>
+                  <option value="tokens">Tokens</option>
+                  <option value="cost">Reported cost</option>
+                </select>
+              </label>
+              <label>
+                <span>Limit</span>
+                <input type="number" min="0.0001" step="any" value={budgetLimit} onChange={(event) => setBudgetLimit(event.target.value)} />
+              </label>
+              {budgetMetric === 'cost' && (
+                <label>
+                  <span>Currency</span>
+                  <input maxLength={16} value={budgetCurrency} onChange={(event) => setBudgetCurrency(event.target.value.toUpperCase())} />
+                </label>
+              )}
+              <button
+                className="usage-budget-add"
+                disabled={budgetBusy || !budgetLimit || (budgetDimension !== 'global' && !budgetKey)}
+                onClick={() => void createBudget()}
+              >
+                <Plus size={14} /> Add budget
+              </button>
+            </div>
+            <p className="usage-budget-note">
+              Evaluated locally against non-overlapping {budgetDimension === 'agent' ? 'workflow-agent' : 'session'} observations.
+              Alerts fire once at 80% and 100% for each reporting window.
+            </p>
+            {budgetError && <p className="usage-budget-error">{budgetError}</p>}
+            <div className="usage-budget-list">
+              {budgets?.statuses.length ? budgets.statuses.map((status) => {
+                const budgetLabel = status.budget.dimension === 'project'
+                  ? privacy.workspace(status.budget.label)
+                  : status.budget.dimension === 'session'
+                    ? privacy.sessionTitle(status.budget.label, status.budget.key)
+                    : status.budget.dimension === 'agent'
+                      ? privacy.capability(status.budget.label, 'Agent')
+                      : status.budget.label
+                const observed = status.observed.value === null
+                  ? 'Unavailable'
+                  : `${status.observed.value.toLocaleString()}${status.budget.metric === 'cost' ? ` ${status.budget.currency}` : ' tokens'}`
+                return (
+                  <article key={status.budget.id} className={`usage-budget-row is-${status.alertLevel}`}>
+                    <span>
+                      <strong>{budgetLabel}</strong>
+                      <small>{status.budget.dimension} · {status.budget.period.toUpperCase()} · {sourceLabel(status.observed.source)}</small>
+                    </span>
+                    <span>
+                      <strong>{observed}</strong>
+                      <small>of {status.budget.limit.toLocaleString()} {status.budget.metric === 'cost' ? status.budget.currency : 'tokens'}</small>
+                    </span>
+                    <span className="usage-budget-meter"><i style={{ width: `${Math.min((status.percent || 0) * 100, 100)}%` }} /></span>
+                    <button
+                      aria-label={`Delete budget ${budgetLabel}`}
+                      onClick={() => void deleteUsageBudget(status.budget.id).then(refreshBudgets)}
+                    ><Trash2 size={14} /></button>
+                  </article>
+                )
+              }) : (
+                <div className="usage-state">
+                  <BellRing size={22} />
+                  <div><strong>No budgets configured</strong><span>Budgets are optional and never leave this host.</span></div>
+                </div>
+              )}
+            </div>
+            {budgets?.alerts.some((alert) => !alert.acknowledgedAt) && (
+              <div className="usage-alert-list">
+                {budgets.alerts.filter((alert) => !alert.acknowledgedAt).map((alert) => (
+                  <button key={alert.id} onClick={() => void acknowledgeUsageAlert(alert.id).then(setBudgets)}>
+                    <BellRing size={14} />
+                    <span>{Math.round(alert.threshold * 100)}% threshold reached · {alert.observed.toLocaleString()} observed</span>
+                    <small>Acknowledge</small>
+                  </button>
+                ))}
               </div>
             )}
           </section>


### PR DESCRIPTION
## Outcome

Ships the remaining Grok UI v0.9 Runtime Intelligence milestone on top of the existing telemetry and persistence architecture:

- bounded process-tree and listening-port discovery for known Grok roots
- local database, cache, queue, emulator, and development-service classification
- structured test status and external-call inspection without raw tool input
- persistent optional budgets by global, project, model, session, or agent scope
- deduplicated local 80% and 100% usage alerts
- bounded JSON/CSV usage exports with authenticated server-side Privacy Mode redaction
- atomic state v3 migration, updated roadmap/changelog, and 0.9.0 version alignment

The inspector uses fixed timeouts, output/process/depth caps, argument-array execution, and no arbitrary endpoint probing. It preserves loopback-first behavior and existing remote authentication boundaries.

## Verification

- [x] `npm run verify`
- [x] 39 unit tests
- [x] 16 Playwright browser journeys
- [x] SSE reconnect and ACP child recovery
- [x] 75-second managed-session soak with usage-ledger and runtime-root assertions
- [x] packed-install smoke on macOS
- [x] remote bind rejection and browser security headers
- [x] Privacy Mode runtime and export redaction
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] no credentials, prompts, private source, personal names, local paths, or IP addresses added

## Release

This PR prepares v0.9.0. The tag, npm publish, and GitHub release will be created only after this PR is green and merged.