### PR TITLE
perf: bound dashboard scans under large ~/.grok installs

### DIFF
--- a/server/grok-store.test.ts
+++ b/server/grok-store.test.ts
@@ -131,12 +131,14 @@ describe('GrokStore', () => {
       timestamp: 1784887264,
       params: { update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'Pushed by watcher' } } },
     })}`
+    // updates.jsonl is not chokidar-watched (high churn); live feed refreshes
+    // on the liveness timer. Append + wait for the next live emission.
     const nextSnapshotPromise = new Promise<ReturnType<LiveMonitor['snapshot']>>((resolve, reject) => {
       const retry = setInterval(() => void fs.appendFile(path.join(sessionDir, 'updates.jsonl'), pushedLine), 250)
       const timeout = setTimeout(() => {
         clearInterval(retry)
-        reject(new Error('Live watcher did not emit'))
-      }, 5_000)
+        reject(new Error('Live monitor did not emit after updates.jsonl append'))
+      }, 10_000)
       monitor.once('live', (nextSnapshot) => {
         clearInterval(retry)
         clearTimeout(timeout)

--- a/server/grok-store.ts
+++ b/server/grok-store.ts
@@ -77,6 +77,19 @@ async function listFilesNamed(root: string, fileName: string, depth = 4): Promis
   return found
 }
 
+// Installer/cache bulk under ~/.grok (bin, downloads, …) can dominate I/O when
+// sizing the whole home. Skip those top-level dirs so dashboard rebuilds stay
+// bounded to session/library data (keeps the event loop responsive under load).
+const DIRECTORY_SIZE_SKIP = new Set([
+  'bin',
+  'downloads',
+  'vendor',
+  'marketplace-cache',
+  'bundled',
+  'node_modules',
+  '.git',
+])
+
 async function directorySize(root: string, depth = 5): Promise<number> {
   let total = 0
   async function walk(current: string, level: number) {
@@ -89,8 +102,10 @@ async function directorySize(root: string, depth = 5): Promise<number> {
     }
     await Promise.all(entries.map(async (entry) => {
       const full = path.join(current, entry.name)
-      if (entry.isDirectory()) await walk(full, level + 1)
-      else if (entry.isFile()) {
+      if (entry.isDirectory()) {
+        if (level === 0 && DIRECTORY_SIZE_SKIP.has(entry.name)) return
+        await walk(full, level + 1)
+      } else if (entry.isFile()) {
         try {
           const stat = await fs.stat(full)
           const allocatedBytes = Number(stat.blocks || 0) * 512
@@ -325,7 +340,10 @@ export class GrokStore {
   }
 
   async dashboard(force = false): Promise<DashboardPayload> {
-    if (!force && this.cache && Date.now() - this.cache.at < 2_000) return this.cache.payload
+    // 5s cache — full rebuild walks sessions + library + memory + data size.
+    // 2s was short enough that the live-monitor liveness timer kept the
+    // event loop busy under multi-session load.
+    if (!force && this.cache && Date.now() - this.cache.at < 5_000) return this.cache.payload
 
     const sessionsRoot = path.join(this.grokHome, 'sessions')
     const summaryFiles = await listFilesNamed(sessionsRoot, 'summary.json', 3)

--- a/server/live-monitor.ts
+++ b/server/live-monitor.ts
@@ -319,10 +319,16 @@ export class LiveMonitor extends EventEmitter {
       path.join(this.store.grokHome, 'agents'),
     ], {
       ignoreInitial: true,
+      // Heavy write paths during agent turns - watching them floods refresh.
+      // Live feed still tails updates/events on the liveness timer below.
       ignored: [
         /[/\\]terminal[/\\]/,
         /[/\\]rewind_points/,
         /[/\\]chat_history/,
+        /[/\\]recap_requests[/\\]/,
+        /[/\\]memtrace[/\\]/,
+        '**/updates.jsonl',
+        '**/events.jsonl',
       ],
     })
     this.watcher.on('all', (_event, changedPath) => {
@@ -332,7 +338,8 @@ export class LiveMonitor extends EventEmitter {
       }
     })
     await new Promise<void>((resolve) => this.watcher?.once('ready', () => resolve()))
-    this.livenessTimer = setInterval(() => this.scheduleRefresh(), 2_000)
+    // Live feed still tails updates/events on this timer; no need for 2s under load.
+    this.livenessTimer = setInterval(() => this.scheduleRefresh(), 4_000)
   }
 
   async stop(): Promise<void> {
@@ -350,7 +357,7 @@ export class LiveMonitor extends EventEmitter {
 
   private scheduleRefresh() {
     if (this.refreshTimer) clearTimeout(this.refreshTimer)
-    this.refreshTimer = setTimeout(() => void this.refresh(), 80)
+    this.refreshTimer = setTimeout(() => void this.refresh(), 250)
   }
 
   private scheduleDashboard() {


### PR DESCRIPTION
## Summary

Under multi-session load with a large `~/.grok` tree (installer `bin`/`downloads` bulk + active session JSONL writes), the dashboard event loop could stall: static `GET /` took multi-second responses in one Windows repro.

This keeps live reads bounded (matches the project design principle) without changing the ACP/browser contract.

### Changes
- **`server/grok-store.ts`**: skip installer/cache top-level dirs (`bin`, `downloads`, `vendor`, `marketplace-cache`, `bundled`, `node_modules`, `.git`) when sizing `grokHome`; raise dashboard cache from 2s → 5s
- **`server/live-monitor.ts`**: ignore high-churn paths (`updates.jsonl`, `events.jsonl`, `recap_requests`, `memtrace`); liveness poll 2s → 4s; refresh debounce 80ms → 250ms. Live feed still tails updates/events on the timer.
- **`server/grok-store.test.ts`**: wait for liveness emission after `updates.jsonl` append (no longer chokidar-driven); timeout 10s

### Measured impact (local, multi-session)
| Metric | Before | After |
|--------|--------|-------|
| `GET /` under load | 0.5–3.6s | ~60–90ms |
| `/api/dashboard` | 0.6–1.8s | ~100ms |

Note: some perceived UI lag was also display/TV input lag; the I/O-bound server scans remain a real issue with large `~/.grok` homes.

## Test plan
- [x] `npx vitest run server/grok-store.test.ts` (includes live feed append case)
- [x] `npm run check` / `npm run build` (TypeScript + client/server build)
- [x] CI `npm run verify` on Linux (full suite; some Windows-only failures exist pre-existing around file modes / `spawn` and are unrelated)
- [x] Manual: start UI with several live Grok sessions and a large `~/.grok`, confirm dashboard stays responsive and live agents still update within ~4s

## Tradeoff
Live feed updates from `updates.jsonl`/`events.jsonl` now arrive on the liveness poll (~4s) rather than immediate chokidar events. Summary/signals/active_sessions still trigger faster refresh via the watcher.