### PR TITLE
feat(windows): one-click desktop launcher with durable supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ accepts natural-language follow-ups, presents Grok's exact permission choices,
 and can interrupt the current turn. It is not a remote terminal and exposes no
 arbitrary shell.
 
+### Windows desktop launcher
+
+On Windows you can install a one-click Desktop / Start Menu icon that starts the
+local server (via a durable Scheduled Task), opens the browser, and survives
+short-lived terminal or agent shells:
+
+```powershell
+npm install -g grok-ui
+powershell -ExecutionPolicy Bypass -File "$env:APPDATA\npm\node_modules\grok-ui\scripts\windows\Install-DesktopLauncher.ps1"
+```
+
+Full options, uninstall, logs, and taskbar-pin notes:
+[docs/windows-desktop-launcher.md](docs/windows-desktop-launcher.md).
+
+
 ### Run from source
 
 ```bash

--- a/docs/windows-desktop-launcher.md
+++ b/docs/windows-desktop-launcher.md
@@ -1,0 +1,101 @@
+# Windows desktop launcher
+
+One-click start for Grok UI on Windows: ensure the local server is running, open the browser, and keep the process alive outside short-lived terminal/agent shells.
+
+## What you get
+
+| Piece | Role |
+| --- | --- |
+| **Desktop / Start Menu shortcut** | “Grok UI” with package icon |
+| **`GrokUI.exe` stub** (when .NET Framework compilers are available) | Pin-friendly target (not raw `powershell.exe`) |
+| **Scheduled Task `GrokUI`** | Runs the supervisor outside job objects that kill child processes when a tool shell exits |
+| **Supervisor** | Starts `grok-ui`, restarts on crash, logs under `%USERPROFILE%\.grok-ui\logs` |
+
+Loopback-only by default (`127.0.0.1:4310`). Credentials never enter the browser.
+
+## Prerequisites
+
+- Windows 10/11
+- PowerShell 5.1+
+- Node.js 22+
+- Grok UI installed (`npm install -g grok-ui`) **or** a built source checkout of this repository
+- Working Grok Build CLI + auth (`grok-ui doctor`)
+
+## Install
+
+### From a global npm install
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:APPDATA\npm\node_modules\grok-ui\scripts\windows\Install-DesktopLauncher.ps1"
+```
+
+### From a source checkout
+
+```powershell
+npm ci
+npm run build
+powershell -ExecutionPolicy Bypass -File .\scripts\windows\Install-DesktopLauncher.ps1
+```
+
+### Options
+
+| Flag | Meaning |
+| --- | --- |
+| `-Port 4310` | Local port (default `4310`) |
+| `-SkipShortcuts` | Register the task only |
+| `-SkipExe` | Skip building `GrokUI.exe` (shortcut targets PowerShell) |
+
+## Use
+
+1. Double-click **Grok UI** on the Desktop or Start Menu.
+2. If the server is already up, the browser opens immediately.
+3. If not, the scheduled supervisor starts it, waits until ready, then opens `http://127.0.0.1:4310`.
+
+**Pin to taskbar:** Start → type `Grok UI` → right-click → **Pin to taskbar**.
+
+## Logs and state
+
+| Path | Contents |
+| --- | --- |
+| `%USERPROFILE%\.grok-ui\logs\service.log` | Supervisor lifecycle |
+| `%USERPROFILE%\.grok-ui\logs\server-stdout.log` | Last server stdout |
+| `%USERPROFILE%\.grok-ui\logs\server-stderr.log` | Last server stderr |
+| `%USERPROFILE%\.grok-ui\package-root.txt` | Package root remembered at install time |
+
+## Uninstall
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$env:APPDATA\npm\node_modules\grok-ui\scripts\windows\Uninstall-DesktopLauncher.ps1"
+```
+
+Remove copied stubs (keep logs):
+
+```powershell
+... Uninstall-DesktopLauncher.ps1 -RemoveState
+```
+
+Remove stubs and logs:
+
+```powershell
+... Uninstall-DesktopLauncher.ps1 -RemoveState -RemoveLogs
+```
+
+This does **not** uninstall the npm package or touch `~/.grok` session history.
+
+## Manual controls
+
+```powershell
+# Start / stop the supervisor task
+Start-ScheduledTask -TaskName GrokUI
+Stop-ScheduledTask -TaskName GrokUI
+
+# Open the dashboard only (starts if needed)
+powershell -ExecutionPolicy Bypass -File "$env:USERPROFILE\.grok-ui\Start-GrokUI.ps1"
+```
+
+## Design notes
+
+- **Why a Scheduled Task?** Processes started from agent shells or some IDE terminals often run inside a Windows job object that kills children when the parent ends. The task runs outside that tree.
+- **Why copy scripts to `~\.grok-ui`?** Global npm paths change across installs; a stable path keeps the task registration valid.
+- **Why an `.exe` stub?** Shortcuts that target `powershell.exe` pin poorly. A tiny WinForms host that launches the start script pins as its own app.
+- **Security:** Still binds loopback by default. Remote binds still require `GROK_UI_TOKEN` as documented in [SECURITY.md](../SECURITY.md).

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dist/",
     "dist-server/",
     "scripts/doctor.mjs",
+    "scripts/windows/",
     "CHANGELOG.md",
     "LICENSE",
     "README.md",

--- a/scripts/windows/Install-DesktopLauncher.ps1
+++ b/scripts/windows/Install-DesktopLauncher.ps1
@@ -1,0 +1,229 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Install a one-click Windows desktop launcher for Grok UI.
+
+.DESCRIPTION
+  - Copies supervisor scripts into %USERPROFILE%\.grok-ui
+  - Registers a Scheduled Task that keeps the server running
+  - Builds a small GrokUI.exe stub (when .NET csc is available) for taskbar pinning
+  - Creates Desktop and Start Menu shortcuts with the package favicon
+
+  Prerequisites: Node.js 22+, grok-ui installed (npm i -g grok-ui) or this repo built.
+
+.EXAMPLE
+  # From a global install
+  powershell -ExecutionPolicy Bypass -File "$env:APPDATA\npm\node_modules\grok-ui\scripts\windows\Install-DesktopLauncher.ps1"
+
+.EXAMPLE
+  # From a source checkout
+  powershell -ExecutionPolicy Bypass -File .\scripts\windows\Install-DesktopLauncher.ps1
+#>
+param(
+  [int]$Port = 4310,
+  [switch]$SkipShortcuts,
+  [switch]$SkipExe
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-PackageRoot {
+  if ($PSScriptRoot) {
+    $candidate = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    if (Test-Path (Join-Path $candidate 'bin\grok-ui.mjs')) { return $candidate }
+    if (Test-Path (Join-Path $candidate 'package.json')) { return $candidate }
+  }
+  $global = Join-Path $env:APPDATA 'npm\node_modules\grok-ui'
+  if (Test-Path (Join-Path $global 'bin\grok-ui.mjs')) { return $global }
+  throw 'Could not locate the grok-ui package root. Install with: npm install -g grok-ui'
+}
+
+function ConvertTo-Ico {
+  param([string]$PngPath, [string]$IcoPath)
+  Add-Type -AssemblyName System.Drawing
+  $srcImg = [System.Drawing.Image]::FromFile($PngPath)
+  try {
+    $sizes = @(16, 32, 48, 256)
+    $ms = New-Object System.IO.MemoryStream
+    $bw = New-Object System.IO.BinaryWriter $ms
+    $bw.Write([uint16]0)
+    $bw.Write([uint16]1)
+    $bw.Write([uint16]$sizes.Count)
+    $imageData = @()
+    foreach ($size in $sizes) {
+      $bmp = New-Object System.Drawing.Bitmap $size, $size
+      $g = [System.Drawing.Graphics]::FromImage($bmp)
+      $g.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+      $g.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::HighQuality
+      $g.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+      $g.Clear([System.Drawing.Color]::Transparent)
+      $g.DrawImage($srcImg, 0, 0, $size, $size)
+      $g.Dispose()
+      $pngMs = New-Object System.IO.MemoryStream
+      $bmp.Save($pngMs, [System.Drawing.Imaging.ImageFormat]::Png)
+      $imageData += , $pngMs.ToArray()
+      $pngMs.Dispose()
+      $bmp.Dispose()
+    }
+    $offset = 6 + (16 * $sizes.Count)
+    for ($i = 0; $i -lt $sizes.Count; $i++) {
+      $size = $sizes[$i]
+      $bytes = $imageData[$i]
+      $w = if ($size -ge 256) { 0 } else { $size }
+      $h = if ($size -ge 256) { 0 } else { $size }
+      $bw.Write([byte]$w)
+      $bw.Write([byte]$h)
+      $bw.Write([byte]0)
+      $bw.Write([byte]0)
+      $bw.Write([uint16]1)
+      $bw.Write([uint16]32)
+      $bw.Write([uint32]$bytes.Length)
+      $bw.Write([uint32]$offset)
+      $offset += $bytes.Length
+    }
+    foreach ($bytes in $imageData) { $bw.Write($bytes) }
+    $bw.Flush()
+    [System.IO.File]::WriteAllBytes($IcoPath, $ms.ToArray())
+    $bw.Dispose()
+    $ms.Dispose()
+  } finally {
+    $srcImg.Dispose()
+  }
+}
+
+function New-LauncherExe {
+  param([string]$ExePath, [string]$StartScriptPath)
+  $csc = @(
+    (Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'),
+    (Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319\csc.exe')
+  ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+  if (-not $csc) { return $false }
+
+  $escaped = $StartScriptPath.Replace('\', '\\').Replace('"', '\"')
+  $src = @"
+using System;
+using System.Diagnostics;
+using System.Windows.Forms;
+
+internal static class Program
+{
+    [STAThread]
+    static void Main()
+    {
+        string script = "$escaped";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"" + script + "\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+        try { using (Process.Start(psi)) { } }
+        catch (Exception ex)
+        {
+            MessageBox.Show("Could not start Grok UI:\n" + ex.Message, "Grok UI",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}
+"@
+  $tmp = Join-Path $env:TEMP 'GrokUI-Launcher.cs'
+  Set-Content -Path $tmp -Value $src -Encoding UTF8
+  & $csc /nologo /target:winexe /r:System.Windows.Forms.dll /out:"$ExePath" "$tmp" | Out-Null
+  return ($LASTEXITCODE -eq 0 -and (Test-Path $ExePath))
+}
+
+$packageRoot = Get-PackageRoot
+$stateDir = Join-Path $env:USERPROFILE '.grok-ui'
+$logDir = Join-Path $stateDir 'logs'
+New-Item -ItemType Directory -Force -Path $stateDir, $logDir | Out-Null
+
+Write-Host "Package root: $packageRoot"
+Write-Host "State dir:    $stateDir"
+
+# Remember package root for the supervisor (helps when npm global path changes)
+[System.IO.File]::WriteAllText((Join-Path $stateDir 'package-root.txt'), $packageRoot)
+
+$windowsScripts = Join-Path $packageRoot 'scripts\windows'
+foreach ($name in @('Run-GrokUI-Service.ps1', 'Start-GrokUI.ps1')) {
+  $src = Join-Path $windowsScripts $name
+  if (-not (Test-Path $src)) { throw "Missing $src" }
+  Copy-Item $src (Join-Path $stateDir $name) -Force
+}
+
+# Icon from packaged favicon
+$icoPath = Join-Path $stateDir 'grok-ui.ico'
+$pngCandidates = @(
+  (Join-Path $packageRoot 'dist\favicon.png'),
+  (Join-Path $packageRoot 'public\favicon.png')
+) | Where-Object { Test-Path $_ }
+if ($pngCandidates.Count -gt 0) {
+  try {
+    ConvertTo-Ico -PngPath $pngCandidates[0] -IcoPath $icoPath
+    Write-Host "Icon: $icoPath"
+  } catch {
+    Write-Warning "Could not build .ico from favicon: $($_.Exception.Message)"
+  }
+}
+
+$startScript = Join-Path $stateDir 'Start-GrokUI.ps1'
+$serviceScript = Join-Path $stateDir 'Run-GrokUI-Service.ps1'
+$exePath = Join-Path $stateDir 'GrokUI.exe'
+$targetPath = $null
+$targetArgs = $null
+
+if (-not $SkipExe) {
+  if (New-LauncherExe -ExePath $exePath -StartScriptPath $startScript) {
+    Write-Host "Launcher exe: $exePath"
+    $targetPath = $exePath
+  } else {
+    Write-Warning 'csc.exe not found; shortcuts will invoke PowerShell directly.'
+  }
+}
+
+if (-not $targetPath) {
+  $targetPath = Join-Path $env:WINDIR 'System32\WindowsPowerShell\v1.0\powershell.exe'
+  $targetArgs = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$startScript`""
+}
+
+# Scheduled task for durable supervisor
+$ps = Join-Path $env:WINDIR 'System32\WindowsPowerShell\v1.0\powershell.exe'
+$action = New-ScheduledTaskAction -Execute $ps -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$serviceScript`" -Port $Port"
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -StartWhenAvailable `
+  -ExecutionTimeLimit ([TimeSpan]::Zero) `
+  -RestartCount 5 `
+  -RestartInterval (New-TimeSpan -Minutes 1)
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+Register-ScheduledTask -TaskName 'GrokUI' -Action $action -Settings $settings -Principal $principal -Force | Out-Null
+Write-Host "Scheduled task: GrokUI"
+
+if (-not $SkipShortcuts) {
+  $desktop = [Environment]::GetFolderPath('Desktop')
+  $startMenu = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+  $wsh = New-Object -ComObject WScript.Shell
+  foreach ($lnkPath in @(
+    (Join-Path $desktop 'Grok UI.lnk'),
+    (Join-Path $startMenu 'Grok UI.lnk')
+  )) {
+    $sc = $wsh.CreateShortcut($lnkPath)
+    $sc.TargetPath = $targetPath
+    if ($targetArgs) { $sc.Arguments = $targetArgs }
+    $sc.WorkingDirectory = $stateDir
+    if (Test-Path $icoPath) { $sc.IconLocation = "$icoPath,0" }
+    $sc.Description = 'Start Grok UI and open the browser'
+    $sc.WindowStyle = 7
+    $sc.Save()
+    Write-Host "Shortcut: $lnkPath"
+  }
+}
+
+Write-Host ''
+Write-Host 'Done. Double-click "Grok UI" on the Desktop (or Start Menu) to launch.'
+Write-Host "Dashboard: http://127.0.0.1:$Port"
+Write-Host "Logs:      $logDir"
+Write-Host ''
+Write-Host 'Pin to taskbar: Start -> type "Grok UI" -> right-click -> Pin to taskbar'

--- a/scripts/windows/Run-GrokUI-Service.ps1
+++ b/scripts/windows/Run-GrokUI-Service.ps1
@@ -1,0 +1,224 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Long-running Grok UI supervisor for Windows: keep the local server up, log crashes, auto-restart.
+
+.DESCRIPTION
+  Intended to run via Scheduled Task (see Install-DesktopLauncher.ps1) so the process is not
+  killed when a terminal or agent shell job ends. Logs live under %USERPROFILE%\.grok-ui\logs.
+#>
+param(
+  [int]$Port = 4310,
+  [string]$HostAddress = '127.0.0.1'
+)
+
+$ErrorActionPreference = 'Continue'
+$base = Join-Path $env:USERPROFILE '.grok-ui'
+$logDir = Join-Path $base 'logs'
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+$logFile = Join-Path $logDir 'service.log'
+$stdoutFile = Join-Path $logDir 'server-stdout.log'
+$stderrFile = Join-Path $logDir 'server-stderr.log'
+$pidFile = Join-Path $base 'service.pid'
+$serverPidFile = Join-Path $base 'server.pid'
+
+function Write-Log {
+  param([string]$Message)
+  try {
+    $stamp = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+    [System.IO.File]::AppendAllText($logFile, ($stamp + ' ' + $Message + [Environment]::NewLine))
+  } catch {}
+}
+
+function Test-Ready {
+  try {
+    $req = [System.Net.HttpWebRequest]::Create("http://${HostAddress}:$Port/")
+    $req.Timeout = 2000
+    $req.ReadWriteTimeout = 2000
+    $req.Method = 'GET'
+    $resp = $req.GetResponse()
+    $code = [int]$resp.StatusCode
+    $resp.Close()
+    return ($code -ge 200 -and $code -lt 500)
+  } catch {
+    return $false
+  }
+}
+
+function Resolve-NodePath {
+  $candidates = @(
+    (Get-Command node -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source),
+    (Join-Path $env:ProgramFiles 'nodejs\node.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'nodejs\node.exe')
+  ) | Where-Object { $_ }
+  foreach ($c in $candidates) {
+    if (Test-Path $c) { return $c }
+  }
+  return $null
+}
+
+function Resolve-GrokUiEntry {
+  if ($env:GROK_UI_ENTRY -and (Test-Path $env:GROK_UI_ENTRY)) {
+    return (Resolve-Path $env:GROK_UI_ENTRY).Path
+  }
+
+  $cmd = Get-Command grok-ui.cmd -ErrorAction SilentlyContinue
+  if ($cmd) {
+    $npmGrok = Join-Path $env:APPDATA 'npm\node_modules\grok-ui\bin\grok-ui.mjs'
+    if (Test-Path $npmGrok) { return $npmGrok }
+  }
+
+  $global = Join-Path $env:APPDATA 'npm\node_modules\grok-ui\bin\grok-ui.mjs'
+  if (Test-Path $global) { return $global }
+
+  # Running from a source checkout / local install of this package
+  $here = $PSScriptRoot
+  if ($here) {
+    $fromScripts = Join-Path $here '..\..\bin\grok-ui.mjs'
+    if (Test-Path $fromScripts) { return (Resolve-Path $fromScripts).Path }
+  }
+
+  $localState = Join-Path $base 'package-root.txt'
+  if (Test-Path $localState) {
+    $root = (Get-Content $localState -Raw).Trim()
+    $entry = Join-Path $root 'bin\grok-ui.mjs'
+    if (Test-Path $entry) { return $entry }
+  }
+
+  return $null
+}
+
+function Stop-PortHolders {
+  try {
+    $lines = netstat -ano | Select-String (":$Port\s+.*LISTENING")
+    foreach ($line in $lines) {
+      $parts = @(($line.ToString() -split '\s+') | Where-Object { $_ })
+      $listenPid = $parts[-1]
+      if ($listenPid -match '^\d+$' -and [int]$listenPid -gt 0) {
+        Write-Log ("Killing listener PID {0} on :{1}" -f $listenPid, $Port)
+        Stop-Process -Id ([int]$listenPid) -Force -ErrorAction SilentlyContinue
+      }
+    }
+  } catch {
+    Write-Log ("Stop-PortHolders: {0}" -f $_.Exception.Message)
+  }
+}
+
+try {
+  Write-Log ("Supervisor boot PID={0}" -f $PID)
+
+  if (Test-Path $pidFile) {
+    $old = 0
+    $raw = [string](Get-Content $pidFile -Raw)
+    [void][int]::TryParse($raw.Trim(), [ref]$old)
+    if ($old -gt 0 -and $old -ne $PID) {
+      $existing = Get-Process -Id $old -ErrorAction SilentlyContinue
+      if ($existing) {
+        Write-Log ("Another supervisor is running (PID {0}) - exit" -f $old)
+        exit 0
+      }
+    }
+  }
+  [System.IO.File]::WriteAllText($pidFile, "$PID")
+
+  $node = Resolve-NodePath
+  $entry = Resolve-GrokUiEntry
+  Write-Log ("node={0} exists={1}" -f $node, [bool]($node -and (Test-Path $node)))
+  Write-Log ("entry={0} exists={1}" -f $entry, [bool]($entry -and (Test-Path $entry)))
+
+  if (-not $node) { Write-Log 'FATAL: node.exe missing'; exit 1 }
+  if (-not $entry) { Write-Log 'FATAL: grok-ui.mjs not found (install with npm i -g grok-ui)'; exit 1 }
+
+  $restartTimes = New-Object System.Collections.ArrayList
+
+  while ($true) {
+    $cutoff = (Get-Date).AddMinutes(-10)
+    for ($i = $restartTimes.Count - 1; $i -ge 0; $i--) {
+      if ($restartTimes[$i] -lt $cutoff) { [void]$restartTimes.RemoveAt($i) }
+    }
+    if ($restartTimes.Count -ge 30) {
+      Write-Log ('Too many restarts ({0} in 10 min) - sleep 60s' -f $restartTimes.Count)
+      Start-Sleep -Seconds 60
+      continue
+    }
+
+    if (Test-Ready) {
+      Write-Log ("Already serving on :{0} - monitor" -f $Port)
+      while (Test-Ready) { Start-Sleep -Seconds 5 }
+      Write-Log 'Stopped responding - restarting'
+    }
+
+    Stop-PortHolders
+    Start-Sleep -Milliseconds 500
+
+    Write-Log ("Starting server: {0} {1}" -f $node, $entry)
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $node
+    $psi.Arguments = ('"{0}" start --no-open --host {1} --port {2}' -f $entry, $HostAddress, $Port)
+    $psi.WorkingDirectory = $base
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.RedirectStandardInput = $true
+
+    try {
+      $proc = New-Object System.Diagnostics.Process
+      $proc.StartInfo = $psi
+      [void]$proc.Start()
+    } catch {
+      Write-Log ("Start failed: {0}" -f $_.Exception.Message)
+      Start-Sleep -Seconds 5
+      continue
+    }
+
+    [System.IO.File]::WriteAllText($serverPidFile, "$($proc.Id)")
+    Write-Log ("Server PID={0}" -f $proc.Id)
+
+    $outTask = $proc.StandardOutput.ReadToEndAsync()
+    $errTask = $proc.StandardError.ReadToEndAsync()
+
+    $ready = $false
+    for ($i = 0; $i -lt 80; $i++) {
+      if ($proc.HasExited) { break }
+      if (Test-Ready) { $ready = $true; break }
+      Start-Sleep -Milliseconds 250
+    }
+    if ($ready) {
+      Write-Log ("Ready http://{0}:{1}" -f $HostAddress, $Port)
+    } else {
+      Write-Log 'Not ready yet; waiting on process'
+    }
+
+    $proc.WaitForExit()
+    $code = $proc.ExitCode
+    try {
+      $outText = $outTask.Result
+      $errText = $errTask.Result
+      if ($outText) { [System.IO.File]::WriteAllText($stdoutFile, $outText) }
+      if ($errText) { [System.IO.File]::WriteAllText($stderrFile, $errText) }
+      if ($errText) {
+        Write-Log ('stderr: {0}' -f $errText.Substring(0, [Math]::Min(500, $errText.Length)))
+      }
+      if ($outText) {
+        Write-Log ('stdout: {0}' -f $outText.Substring(0, [Math]::Min(300, $outText.Length)))
+      }
+    } catch {
+      Write-Log ("log drain error: {0}" -f $_.Exception.Message)
+    }
+
+    Write-Log ("Server exited code={0}" -f $code)
+    [void]$restartTimes.Add((Get-Date))
+    Start-Sleep -Seconds 2
+  }
+}
+catch {
+  Write-Log ("SUPERVISOR CRASH: {0}" -f $_.Exception.Message)
+  if ($_.ScriptStackTrace) { Write-Log $_.ScriptStackTrace }
+  exit 1
+}
+finally {
+  Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/windows/Start-GrokUI.ps1
+++ b/scripts/windows/Start-GrokUI.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Ensure the Grok UI local server is running, then open the dashboard in a browser.
+
+.DESCRIPTION
+  Uses the Windows Scheduled Task registered by Install-DesktopLauncher.ps1 so the
+  server survives terminal/agent job cleanup. Safe to double-click while already up.
+#>
+param(
+  [int]$Port = 4310,
+  [switch]$NoBrowser
+)
+
+$ErrorActionPreference = 'Stop'
+$Url = "http://127.0.0.1:$Port"
+$taskName = 'GrokUI'
+$stateDir = Join-Path $env:USERPROFILE '.grok-ui'
+$logDir = Join-Path $stateDir 'logs'
+$serviceScript = Join-Path $stateDir 'Run-GrokUI-Service.ps1'
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+function Test-Ready {
+  try {
+    $req = [System.Net.HttpWebRequest]::Create($Url)
+    $req.Timeout = 2000
+    $req.Method = 'GET'
+    $resp = $req.GetResponse()
+    $code = [int]$resp.StatusCode
+    $resp.Close()
+    return ($code -ge 200 -and $code -lt 500)
+  } catch {
+    return $false
+  }
+}
+
+function Ensure-Task {
+  if (-not (Test-Path $serviceScript)) {
+    throw "Supervisor script missing at $serviceScript. Run Install-DesktopLauncher.ps1 first."
+  }
+  $ps = Join-Path $env:WINDIR 'System32\WindowsPowerShell\v1.0\powershell.exe'
+  $action = New-ScheduledTaskAction -Execute $ps -Argument "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$serviceScript`" -Port $Port"
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -RestartCount 5 `
+    -RestartInterval (New-TimeSpan -Minutes 1)
+  $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+  Register-ScheduledTask -TaskName $taskName -Action $action -Settings $settings -Principal $principal -Force | Out-Null
+}
+
+if (-not (Test-Ready)) {
+  Ensure-Task
+  $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+  if ($task -and $task.State -eq 'Running') {
+    # Task claims Running but port is dead - bounce it
+    Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 500
+    Remove-Item (Join-Path $stateDir 'service.pid') -Force -ErrorAction SilentlyContinue
+  }
+  Start-ScheduledTask -TaskName $taskName
+
+  $deadline = (Get-Date).AddSeconds(45)
+  while (-not (Test-Ready)) {
+    if ((Get-Date) -gt $deadline) {
+      Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+      [System.Windows.Forms.MessageBox]::Show(
+        "Grok UI did not become ready within 45s.`nURL: $Url`n`nLogs: $logDir",
+        'Grok UI',
+        'OK',
+        'Error'
+      ) | Out-Null
+      exit 1
+    }
+    Start-Sleep -Milliseconds 400
+  }
+}
+
+if (-not $NoBrowser) {
+  Start-Process $Url
+}
+exit 0

--- a/scripts/windows/Uninstall-DesktopLauncher.ps1
+++ b/scripts/windows/Uninstall-DesktopLauncher.ps1
@@ -1,0 +1,51 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Remove the Windows desktop launcher, scheduled task, and optional local stubs.
+
+.DESCRIPTION
+  Does not uninstall the npm package or delete session history under ~/.grok.
+  By default keeps %USERPROFILE%\.grok-ui\logs for troubleshooting.
+#>
+param(
+  [switch]$RemoveState,
+  [switch]$RemoveLogs
+)
+
+$ErrorActionPreference = 'Continue'
+$taskName = 'GrokUI'
+$stateDir = Join-Path $env:USERPROFILE '.grok-ui'
+
+Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+Write-Host "Removed scheduled task (if present): $taskName"
+
+$desktop = [Environment]::GetFolderPath('Desktop')
+$startMenu = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+foreach ($lnk in @(
+  (Join-Path $desktop 'Grok UI.lnk'),
+  (Join-Path $startMenu 'Grok UI.lnk')
+)) {
+  if (Test-Path $lnk) {
+    Remove-Item $lnk -Force
+    Write-Host "Removed $lnk"
+  }
+}
+
+if ($RemoveState -and (Test-Path $stateDir)) {
+  if ($RemoveLogs) {
+    Remove-Item $stateDir -Recurse -Force
+    Write-Host "Removed $stateDir"
+  } else {
+    Get-ChildItem $stateDir -Force | Where-Object {
+      $_.Name -ne 'logs' -and $_.Name -ne 'state.json'
+    } | ForEach-Object {
+      Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+      Write-Host "Removed $($_.FullName)"
+    }
+    Write-Host "Kept logs and state.json under $stateDir"
+  }
+} else {
+  Write-Host "Left $stateDir in place (use -RemoveState to clean stubs)."
+}
+
+Write-Host 'Uninstall complete. The grok-ui npm package was not removed.'


### PR DESCRIPTION
## Summary

Windows users often lose the Grok UI process when it is started from a short-lived terminal or agent shell (job-object cleanup). This PR adds an **optional** one-click desktop experience:

- Desktop + Start Menu **Grok UI** shortcuts (package favicon)
- Optional pin-friendly **`GrokUI.exe`** stub (built at install time via `csc` when available)
- **Scheduled Task `GrokUI`** supervisor that starts `grok-ui`, restarts on crash, and logs under `%USERPROFILE%\.grok-ui\logs`
- Uninstall script that removes the task/shortcuts without touching `~/.grok` history

### Layout
| Path | Role |
|------|------|
| `scripts/windows/Install-DesktopLauncher.ps1` | One-shot setup |
| `scripts/windows/Start-GrokUI.ps1` | Ensure up + open browser |
| `scripts/windows/Run-GrokUI-Service.ps1` | Durable supervisor |
| `scripts/windows/Uninstall-DesktopLauncher.ps1` | Clean removal |
| `docs/windows-desktop-launcher.md` | Full guide |
| `package.json` `files` | Ship `scripts/windows/` in the npm package |
| `README.md` | Quickstart link |

### Design choices
- Scripts are **copied** into `~\.grok-ui` at install so the scheduled task path stays stable across npm upgrades.
- Server still loopback-only by default; no change to auth/token model.
- No compiled binaries committed; `.exe` is generated locally when the .NET Framework compiler is present.
- Does not alter the default `npx grok-ui` / macOS / Linux paths.

## Test plan
- [x] PowerShell parser accepts all four scripts
- [ ] On Windows 10/11: `npm i -g grok-ui` (or `npm run build` in checkout) then run `Install-DesktopLauncher.ps1`
- [ ] Double-click Desktop **Grok UI** → dashboard opens at `http://127.0.0.1:4310`
- [ ] Kill the node server process → supervisor restarts it (see `~\.grok-ui\logs\service.log`)
- [ ] Pin from Start Menu works when `GrokUI.exe` was built
- [ ] `Uninstall-DesktopLauncher.ps1` removes task + shortcuts
- [ ] CI package/release checks still pass (scripts are small text assets)

Related: performance PR #22 (separate concern).