### PR TITLE
docs: mark v0.10.0 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.0 — Unreleased
+## 0.10.0 — 2026-07-28
 
 - Added a lightweight, bearer-authenticated host agent that reuses the existing
   session, workflow, runtime, and usage projections through a versioned
@@ -37,10 +37,6 @@
   surfaced preserved registry-load failures directly in the Fleet experience.
 - Split the Fleet experience into focused status, editor, selector, telemetry,
   and stylesheet modules with an agent-facing ownership and verification guide.
-
-v0.10 remains unreleased. It must not be merged, tagged, published, or released
-until the completion matrix passes and the user explicitly approves those
-actions.
 
 ## 0.9.0 — 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and move through your complete local history without leaving the browser.
 <img src="docs/grok-ui-dashboard.png" width="900" alt="Grok UI Event Horizon dashboard with live runtime telemetry"/>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.9.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.9.0)
+· [**See what’s new in v0.10.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.10.0)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 
@@ -401,11 +401,9 @@ invariants live in [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md).
 
 Grok UI is a community project. Its local monitor, control, workbench, runtime,
 usage, and Git inspection paths are functional and covered by automated tests.
-v0.10 multi-machine monitoring is under verification and remains unreleased
-until its completion matrix passes and the user explicitly approves merge,
-tag, and publication. Packed releases are installed and launched in isolation
-on macOS and Linux CI. Grok Build, ACP, and the fleet protocol can evolve, so
-compatibility fixes may be needed for future releases.
+v0.10 multi-machine monitoring is released. Packed releases are installed and
+launched in isolation on macOS and Linux CI. Grok Build, ACP, and the fleet
+protocol can evolve, so compatibility fixes may be needed for future releases.
 
 ## License
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -44,8 +44,8 @@ central fleet monitor interoperate, that configured hosts can disconnect and
 recover during the 75-second soak, and that every remote surface remains
 read-only. A passing build or unit suite alone is not release evidence.
 
-Do not merge, tag, publish, or create a v0.10 release until the user explicitly
-approves those actions.
+v0.10 passed these gates and received explicit approval before its tag,
+npm publication, and GitHub release were created.
 
 To publish an existing GitHub tag that predates npm publication, open the
 Release workflow in GitHub Actions, choose **Run workflow**, and enter the


### PR DESCRIPTION
## Summary

- date the v0.10.0 changelog entry
- link the README to the v0.10.0 release
- update project and release documentation to reflect completed publication

## Verification

- `git diff --check`
- `npm run release:check`
- public npm package `grok-ui@0.10.0` verified
- GitHub release `v0.10.0` verified
- npm and GitHub release tarballs confirmed byte-for-byte identical
