### PR TITLE
fix: Windows ESM import for start script

### DIFF
--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const clientEntry = path.join(projectRoot, 'dist', 'index.html')
@@ -17,4 +17,4 @@ if (!existsSync(clientEntry) || !existsSync(serverEntry)) {
   if (build.status !== 0) process.exit(build.status || 1)
 }
 
-await import(serverEntry)
+await import(pathToFileURL(serverEntry).href)


### PR DESCRIPTION
## Summary
- Convert the production server path with `pathToFileURL` before dynamic `import()` in `scripts/start.mjs`.
- Fixes `npm start` on Windows where absolute paths like `E:\...` are not valid ESM module specifiers (the drive letter is treated as a URL scheme).

## Test plan
- [ ] On Windows 11: run the start path after build and confirm the server loads
- [ ] On macOS/Linux: confirm start still works (file URLs are valid there too)