### PR TITLE
release: prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — v0.11 secure remote sessions
+## 0.11.0 — 2026-07-30
 
 - Added an explicitly enabled Remote Session Console that lets a user start a
   managed Grok session on a trusted host, receive live structured updates, send
@@ -25,6 +25,13 @@
   process logs, and desktop, tablet, and mobile preview widths.
 - Added the Minimal Calm theme with a neutral light palette and restrained
   decorative motion across the complete Runs, Usage, Fleet, and session UI.
+- Optimized the complete remote-control journey for phones, including the
+  navigation rail, host setup, session controls, permission dialogs, safe-area
+  spacing, focus restoration, and keyboard-only dialog containment.
+- Hardened the release candidate against duplicate cross-process delivery,
+  lost acknowledgements, host restarts, expired and malformed command IDs,
+  stale permission state, cross-host receipt substitution, traversal payloads,
+  oversized requests, and reconnect races.
 
 ## 0.10.0 — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Hardened the release candidate against duplicate cross-process delivery,
   lost acknowledgements, host restarts, expired and malformed command IDs,
   stale permission state, cross-host receipt substitution, traversal payloads,
-  oversized requests, and reconnect races.
+  oversized requests, and out-of-order refresh/stream races.
 
 ## 0.10.0 — 2026-07-28
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ Keep the server loopback-only during development. Tests must not depend on real 
 - Keep changes focused and explain the user-facing impact.
 - Add tests for parsing, permissions, path validation, and security boundaries.
 - For fleet changes, test protocol compatibility, authentication failures,
-  bounded timeouts, disconnect and reconnect, freshness transitions, and the
-  absence of remote mutation controls.
+  bounded timeouts, disconnect and reconnect, freshness transitions, strict
+  monitoring/control credential separation, exact route and capability gates,
+  idempotent delivery, and honest unknown outcomes.
 - Include desktop and mobile verification for UI changes.
 - Never commit `.env`, `~/.grok` data, session transcripts, credentials, or screenshots containing private source or prompts.
 - Keep package contents under the release-check size and privacy limits.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and move through your complete local history without leaving the browser.
 <img src="docs/grok-ui-dashboard.png" width="900" alt="Grok UI Event Horizon dashboard with live runtime telemetry"/>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.10.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.10.0)
+· [**See what’s new in v0.11.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.11.0)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 
@@ -462,10 +462,11 @@ invariants live in [docs/AGENT_GUIDE.md](docs/AGENT_GUIDE.md).
 ## Project status
 
 Grok UI is a community project. Its local monitor, control, workbench, runtime,
-usage, and Git inspection paths are functional and covered by automated tests.
-v0.10 multi-machine monitoring is released. Packed releases are installed and
-launched in isolation on macOS and Linux CI. Grok Build, ACP, and the fleet
-protocol can evolve, so compatibility fixes may be needed for future releases.
+usage, Git inspection, multi-machine monitoring, and secure remote-session
+paths are functional and covered by automated tests. Packed releases are
+installed and launched in isolation on macOS and Linux CI. Grok Build, ACP, and
+the fleet protocol can evolve, so compatibility fixes may be needed for future
+releases.
 
 ## License
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,8 +1,9 @@
 # Agent guide
 
 Read `README.md`, `docs/architecture.md`, and the milestone document for the
-version being changed before editing. For v0.10, also read
-`docs/v0.10-multi-machine-monitoring.md`.
+version being changed before editing. Fleet or remote-session changes also
+require `docs/v0.10-multi-machine-monitoring.md` and
+`docs/v0.11-secure-remote-sessions.md`.
 
 ## Edit routing
 
@@ -24,9 +25,11 @@ version being changed before editing. For v0.10, also read
 ## Invariants
 
 - Local state and controls remain authoritative on each machine.
-- v0.10 remote behavior is read-only. Do not add remote prompts, approvals,
-  start/pause/resume/interrupt/stop actions, shell execution, arbitrary fetches,
-  endpoint discovery, or destructive routes.
+- The v0.10 monitoring plane remains read-only. The separate v0.11 control
+  plane is limited to managed-session Start, Follow up, advertised permission
+  choices, and Interrupt. Do not add arbitrary shell execution, fetches, file
+  mutation, endpoint discovery, workflow Pause/Resume/Stop, or destructive
+  routes.
 - Remote credentials remain server-side. Never return tokens through browser
   APIs, SSE, errors, diagnostics, screenshots, fixtures, or committed state.
 - Keep registry persistence transactional and separate from
@@ -40,9 +43,10 @@ version being changed before editing. For v0.10, also read
 ## Risk and approval boundaries
 
 Merging, tagging, publishing to npm, and creating a GitHub release require
-explicit user approval. Remote-control work belongs to v0.11 and requires a
-separate security design. Do not use destructive Git commands to clean a dirty
-worktree or overwrite an existing state file to repair it.
+explicit user approval. Any expansion beyond the v0.11 managed-session control
+contract requires a separate security design. Do not use destructive Git
+commands to clean a dirty worktree or overwrite an existing state file to
+repair it.
 
 ## Expected checks
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,6 +47,12 @@ read-only. A passing build or unit suite alone is not release evidence.
 v0.10 passed these gates and received explicit approval before its tag,
 npm publication, and GitHub release were created.
 
+For v0.11, the release gate must additionally prove that remote commands are
+authenticated, capability- and freshness-gated, idempotent across concurrent
+processes, honest after lost acknowledgements and restarts, and constrained to
+the documented control routes. The browser matrix must cover the complete
+remote session journey and mobile failure behavior in Chromium and WebKit.
+
 To publish an existing GitHub tag that predates npm publication, open the
 Release workflow in GitHub Actions, choose **Run workflow**, and enter the
 existing `vX.Y.Z` tag. The manual path publishes npm only and does not recreate

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,9 +1,9 @@
 # Grok UI roadmap
 
-Grok UI v0.9.0 provides local session discovery, ACP control, confirmed
+Grok UI v0.11.0 provides local session discovery, ACP control, confirmed
 interruption, workflow orchestration, Git and runtime inspection, a persistent
-usage ledger, budgets, and privacy-aware exports. The roadmap extends those
-foundations instead of replacing them.
+usage ledger, multi-machine monitoring, and secure managed remote sessions.
+The roadmap extends those foundations instead of replacing them.
 
 ## v0.8.2 — Release and recovery
 
@@ -36,8 +36,8 @@ The staged design, security constraints, and release gate are tracked in
 - Introduce a lightweight host agent and transactional central host registry.
 - Support authenticated SSH-forwarded and Tailscale-oriented connectivity
   without invoking a shell or probing arbitrary endpoints. SSH readiness,
-  duplicate local-forward prevention, fixed-path parsing, and bounded reads are
-  implemented on the unreleased v0.10 branch.
+  duplicate local-forward prevention, fixed-path parsing, and bounded reads
+  shipped in v0.10.0.
 - Report host identity, Grok UI and agent versions, capabilities, health,
   latency, last seen, and freshness.
 - Make connecting, healthy, degraded, stale, offline, incompatible,
@@ -76,6 +76,8 @@ than widening the initial trust boundary.
 The product contract, failure behavior, security boundaries, and staged
 acceptance matrix are tracked in
 [`v0.11-secure-remote-sessions.md`](./v0.11-secure-remote-sessions.md).
+The managed-session MVP shipped in v0.11.0; workflow lifecycle controls and
+shared/team access remain later additions.
 
 ## v0.12 — VS Code
 

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -187,7 +187,19 @@ test.describe.serial('public launch path', () => {
   })
 
   test('guides a clean installation through missing CLI and ready states', async ({ page }) => {
-    await fs.rm(path.join(grokHome, 'e2e-cli-ready'), { force: true })
+    await Promise.all([
+      fs.rm(path.join(grokHome, 'e2e-cli-ready'), { force: true }),
+      fs.rm(path.join(grokHome, 'active_sessions.json'), { force: true }),
+      fs.rm(path.join(grokHome, 'sessions'), { recursive: true, force: true }),
+    ])
+    await expect.poll(async () => {
+      const dashboard = await (await page.request.get('/api/dashboard?refresh=1')).json()
+      const live = await (await page.request.get('/api/live')).json()
+      return {
+        sessions: dashboard.stats.sessions,
+        active: live.activeCount,
+      }
+    }, { timeout: 10_000 }).toEqual({ sessions: 0, active: 0 })
     const reset = await page.request.get('/api/setup?refresh=1')
     expect(reset.ok()).toBe(true)
     const resetStatus = await reset.json()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import { RuntimeIntelligencePanels } from './views/RuntimeIntelligencePanels'
 import { FleetView } from './views/FleetView'
 import { useModalFocus } from './hooks/useModalFocus'
 import { PrivacyProvider, usePrivacy } from './privacy'
+import { reconcileControlSnapshot } from './control-snapshot'
 import packageJson from '../package.json'
 
 interface NavItem {
@@ -260,7 +261,7 @@ function App() {
         setSetup(null)
       }
       void getControlSnapshot()
-        .then(setControl)
+        .then((next) => setControl((current) => reconcileControlSnapshot(current, next)))
         .catch(() => {
           // Dashboard and onboarding stay available if ACP is not ready yet.
         })
@@ -302,7 +303,8 @@ function App() {
     })
     events.addEventListener('control', (event) => {
       setStreamConnected(true)
-      setControl(JSON.parse((event as MessageEvent).data) as ControlSnapshot)
+      const next = JSON.parse((event as MessageEvent).data) as ControlSnapshot
+      setControl((current) => reconcileControlSnapshot(current, next))
     })
     events.addEventListener('runtime', (event) => {
       setStreamConnected(true)
@@ -418,7 +420,8 @@ function App() {
   }
 
   const refreshControl = useCallback(async () => {
-    setControl(await getControlSnapshot())
+    const next = await getControlSnapshot()
+    setControl((current) => reconcileControlSnapshot(current, next))
   }, [])
 
   const refreshFleet = useCallback(async () => {

--- a/src/control-snapshot.test.ts
+++ b/src/control-snapshot.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileControlSnapshot } from './control-snapshot'
+import type { ControlSession, ControlSnapshot } from './types'
+
+function session(updatedAt: string, feedItems: number): ControlSession {
+  return {
+    id: 'managed-session',
+    cwd: '/workspace',
+    title: 'Managed session',
+    model: 'grok',
+    state: 'idle',
+    createdAt: '2026-07-30T00:00:00.000Z',
+    updatedAt,
+    lastPrompt: '',
+    stopReason: 'end_turn',
+    error: '',
+    cancellationStatus: 'none',
+    cancelRequestedAt: '',
+    cancelledAt: '',
+    inputTokens: 1,
+    outputTokens: 1,
+    totalTokens: 2,
+    tokenTelemetryAvailable: true,
+    costAmount: 0,
+    costCurrency: '',
+    costTelemetryAvailable: false,
+    feed: Array.from({ length: feedItems }, (_, index) => ({
+      id: `event-${index}`,
+      type: 'assistant',
+      title: 'Grok',
+      text: `Update ${index}`,
+      status: 'completed',
+      timestamp: updatedAt,
+    })),
+    workflows: [],
+  }
+}
+
+function snapshot(
+  generatedAt: string,
+  sessionUpdatedAt: string,
+  feedItems: number,
+): ControlSnapshot {
+  return {
+    generatedAt,
+    connected: true,
+    processId: 42,
+    starting: false,
+    reconnecting: false,
+    reconnectAttempt: 0,
+    lastDisconnectedAt: '',
+    agentName: 'grok',
+    agentVersion: '1',
+    error: '',
+    sessions: [session(sessionUpdatedAt, feedItems)],
+    workflows: [],
+    permissions: [],
+  }
+}
+
+describe('reconcileControlSnapshot', () => {
+  it('does not let an older refresh overwrite a newer streamed result', () => {
+    const streamed = snapshot(
+      '2026-07-30T00:00:02.000Z',
+      '2026-07-30T00:00:02.000Z',
+      3,
+    )
+    const staleRefresh = snapshot(
+      '2026-07-30T00:00:01.000Z',
+      '2026-07-30T00:00:01.000Z',
+      1,
+    )
+
+    expect(reconcileControlSnapshot(streamed, staleRefresh)).toBe(streamed)
+  })
+
+  it('uses session progress when snapshots share a generated timestamp', () => {
+    const timestamp = '2026-07-30T00:00:02.000Z'
+    const completed = snapshot(timestamp, timestamp, 3)
+    const stale = snapshot(timestamp, timestamp, 1)
+
+    expect(reconcileControlSnapshot(completed, stale)).toBe(completed)
+    expect(reconcileControlSnapshot(stale, completed)).toBe(completed)
+  })
+
+  it('accepts a newer snapshot even when bounded history becomes smaller', () => {
+    const current = snapshot(
+      '2026-07-30T00:00:01.000Z',
+      '2026-07-30T00:00:01.000Z',
+      3,
+    )
+    const newer = snapshot(
+      '2026-07-30T00:00:02.000Z',
+      '2026-07-30T00:00:02.000Z',
+      1,
+    )
+
+    expect(reconcileControlSnapshot(current, newer)).toBe(newer)
+  })
+})

--- a/src/control-snapshot.ts
+++ b/src/control-snapshot.ts
@@ -1,0 +1,28 @@
+import type { ControlSnapshot } from './types'
+
+function latestSessionUpdate(snapshot: ControlSnapshot): string {
+  return snapshot.sessions.reduce(
+    (latest, session) => session.updatedAt > latest ? session.updatedAt : latest,
+    '',
+  )
+}
+
+function feedItems(snapshot: ControlSnapshot): number {
+  return snapshot.sessions.reduce((total, session) => total + session.feed.length, 0)
+}
+
+export function reconcileControlSnapshot(
+  current: ControlSnapshot | null,
+  incoming: ControlSnapshot,
+): ControlSnapshot {
+  if (!current) return incoming
+  if (incoming.generatedAt > current.generatedAt) return incoming
+  if (incoming.generatedAt < current.generatedAt) return current
+
+  const currentSessionUpdate = latestSessionUpdate(current)
+  const incomingSessionUpdate = latestSessionUpdate(incoming)
+  if (incomingSessionUpdate > currentSessionUpdate) return incoming
+  if (incomingSessionUpdate < currentSessionUpdate) return current
+
+  return feedItems(incoming) < feedItems(current) ? current : incoming
+}


### PR DESCRIPTION
## Summary

- set package and lockfile versions to 0.11.0
- finalize the v0.11 secure remote sessions changelog and release documentation
- align roadmap, README, contributor guidance, and remote-control safety invariants

## Release evidence

- 99 unit/server tests passed
- 24 Chromium and 24 WebKit end-to-end journeys passed
- 75-second control soak passed
- packed-install smoke passed with real CLI, server, host agent, and Fleet integration
- release tag/version and package privacy checks passed
- production npm audit found 0 vulnerabilities

The user explicitly approved merge, tag, npm publication, and GitHub release creation for v0.11.0.