### PR TITLE
Shorten the dashboard path without removing rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- Grouped the primary nav into Work, Look back, and System so the twelve
+  destinations stay available without competing as one list.
+- Added a first-run and idle-state Start a session here action that opens
+  Control without leaving the dashboard.
+- Added a global Needs you bar and nav badges for pending approvals and live
+  attention.
+- Persisted the active view and open session in the URL hash so refresh keeps
+  place.
+- Made the command palette honor arrow keys and Enter.
+
 ## 0.11.0 — 2026-07-30
 
 - Added an explicitly enabled Remote Session Console that lets a user start a

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -225,6 +225,10 @@ test.describe.serial('public launch path', () => {
 
     await expect(page.getByText('FIRST CONTACT / READY')).toBeVisible()
     await expect(page.getByText('Environment ready.')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Start a session here' })).toBeVisible()
+    await page.getByRole('button', { name: 'Start a session here' }).click()
+    await expect(page.getByRole('heading', { name: /Run the room/ })).toBeVisible()
+    await expect(page).toHaveURL(/#\/control$/)
   })
 
   test('discovers a newly registered Grok CLI session over the live stream', async ({ page }) => {
@@ -235,6 +239,13 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('1', { exact: true }).first()).toBeVisible()
     await expect(page.getByText(/Inspect secret-client/).first()).toBeVisible()
     await expect(page.getByText(/PID \d+/).first()).toBeVisible()
+    await page.getByRole('button', { name: /Open Session/ }).click()
+    await expect(page).toHaveURL(new RegExp(`#/live/${sessionId}$`))
+    await page.locator('.session-workbench').getByRole('button', { name: 'Close session console panel' }).click()
+    await page.getByRole('navigation', { name: 'Primary navigation' }).getByRole('button', { name: /Sessions/ }).click()
+    await expect(page).toHaveURL(/#\/sessions$/)
+    await page.reload()
+    await expect(page.getByRole('heading', { name: /Nothing buried/ })).toBeVisible()
   })
 
   test('reconnects the browser event stream after a server interruption', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,14 @@ import { FleetView } from './views/FleetView'
 import { useModalFocus } from './hooks/useModalFocus'
 import { PrivacyProvider, usePrivacy } from './privacy'
 import { reconcileControlSnapshot } from './control-snapshot'
+import {
+  collectAttention,
+  NAV_GROUPS,
+  navBadgeCount,
+  parseHash,
+  writeHash,
+  type AttentionState,
+} from './navigation'
 import packageJson from '../package.json'
 
 interface NavItem {
@@ -186,8 +194,9 @@ function liveSessionStatus(session: SessionRow, live: LiveSnapshot | null): Sess
 }
 
 function App() {
+  const initialRoute = parseHash(window.location.hash)
   const [authenticated, setAuthenticated] = useState<boolean | null>(null)
-  const [view, setView] = useState<ViewId>('live')
+  const [view, setView] = useState<ViewId>(initialRoute.view)
   const [data, setData] = useState<DashboardPayload | null>(null)
   const [live, setLive] = useState<LiveSnapshot | null>(null)
   const [runtime, setRuntime] = useState<RuntimeSnapshot | null>(null)
@@ -205,7 +214,7 @@ function App() {
     id: string
     fallback: SessionRow | null
     opener: HTMLElement | null
-  } | null>(null)
+  } | null>(initialRoute.sessionId ? { id: initialRoute.sessionId, fallback: null, opener: null } : null)
   const [remoteSession, setRemoteSession] = useState<{
     host: FleetHostView
     session: SessionRow
@@ -219,6 +228,7 @@ function App() {
   const lastInteractionRef = useRef<HTMLElement | null>(null)
   const mobileNavTriggerRef = useRef<HTMLElement | null>(null)
   const mobileNavOpenRef = useRef(false)
+  const attention = useMemo(() => collectAttention(live, control), [control, live])
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme
@@ -348,6 +358,28 @@ function App() {
     lastAttentionRef.current = attention
   }, [control?.permissions, live?.attentionCount, privacyMode])
 
+  useEffect(() => {
+    writeHash({ view, sessionId: selectedSession?.id || null })
+  }, [selectedSession?.id, view])
+
+  useEffect(() => {
+    const onHashChange = () => {
+      const route = parseHash(window.location.hash)
+      setView(route.view)
+      setSelectedSession((current) => {
+        if (!route.sessionId) return null
+        if (current?.id === route.sessionId) return current
+        return {
+          id: route.sessionId,
+          fallback: data?.sessions.find((item) => item.id === route.sessionId) || null,
+          opener: null,
+        }
+      })
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [data?.sessions])
+
   const takeInteractionTarget = useCallback(() => {
     const interaction = lastInteractionRef.current?.isConnected
       ? lastInteractionRef.current
@@ -463,6 +495,7 @@ function App() {
           connected={streamConnected}
           version={data?.version || '—'}
           open={mobileNavOpen}
+          attention={attention}
           onNavigate={setActiveView}
           onClose={closeMobileNav}
         />
@@ -486,6 +519,20 @@ function App() {
           <ErrorState message={error} onRetry={() => void load(true)} />
         ) : (
           <div className="view-wrap" key={view}>
+            {!selectedSession && !remoteSession && (
+              <NeedsYouBar
+                attention={attention}
+                privacyMode={privacyMode}
+                onOpen={() => {
+                  if (!attention.primary) return
+                  if (attention.primary.kind === 'permission') {
+                    setActiveView('control')
+                    return
+                  }
+                  openSession(attention.primary.sessionId)
+                }}
+              />
+            )}
             {view === 'live' && (
               <LiveView
                 live={live}
@@ -494,6 +541,7 @@ function App() {
                 setup={setup}
                 connected={streamConnected}
                 onOpenSession={openSession}
+                onStartSession={() => setActiveView('control')}
                 onRefresh={() => void load(true)}
               />
             )}
@@ -564,6 +612,7 @@ function App() {
         {!selectedSession && !remoteSession && !paletteOpen && (
           <MobileNav
             active={view}
+            attention={attention}
             onNavigate={setActiveView}
             onMore={openMobileNav}
             suspended={mobileNavOpen}
@@ -692,6 +741,7 @@ function Sidebar({
   connected,
   version,
   open,
+  attention,
   onNavigate,
   onClose,
 }: {
@@ -699,6 +749,7 @@ function Sidebar({
   connected: boolean
   version: string
   open: boolean
+  attention: AttentionState
   onNavigate: (id: ViewId) => void
   onClose: () => void
 }) {
@@ -736,26 +787,35 @@ function Sidebar({
           </button>
         </div>
 
-        <div className="rail-label">Navigation / 01</div>
         <nav className="primary-nav" id="primary-navigation" aria-label="Primary navigation">
-          {NAV_ITEMS.map((item) => {
-            const Icon = item.icon
-            return (
-              <button
-                key={item.id}
-                className={`nav-item ${active === item.id ? 'is-active' : ''}`}
-                onClick={() => onNavigate(item.id)}
-              >
-                <span className="nav-index">{item.index}</span>
-                <Icon size={17} strokeWidth={1.7} />
-                <span className="nav-copy">
-                  <strong>{item.label}</strong>
-                  <small>{item.eyebrow}</small>
-                </span>
-                <ChevronRight className="nav-arrow" size={15} />
-              </button>
-            )
-          })}
+          {NAV_GROUPS.map((group) => (
+            <div className="nav-group" key={group.id}>
+              <div className="rail-label">{group.label}</div>
+              {group.items.map((id) => {
+                const item = NAV_ITEMS.find((entry) => entry.id === id)
+                if (!item) return null
+                const Icon = item.icon
+                const badge = navBadgeCount(item.id, attention)
+                return (
+                  <button
+                    key={item.id}
+                    className={`nav-item ${active === item.id ? 'is-active' : ''}`}
+                    onClick={() => onNavigate(item.id)}
+                  >
+                    <span className="nav-index">{item.index}</span>
+                    <Icon size={17} strokeWidth={1.7} />
+                    <span className="nav-copy">
+                      <strong>{item.label}</strong>
+                      <small>{item.eyebrow}</small>
+                    </span>
+                    {badge > 0
+                      ? <span className="nav-badge" aria-label={`${badge} need${badge === 1 ? 's' : ''} input`}>{badge}</span>
+                      : <ChevronRight className="nav-arrow" size={15} />}
+                  </button>
+                )
+              })}
+            </div>
+          ))}
         </nav>
 
         <div className="sidebar-spacer" />
@@ -845,6 +905,7 @@ function LiveView({
   setup,
   connected,
   onOpenSession,
+  onStartSession,
   onRefresh,
 }: {
   live: LiveSnapshot | null
@@ -853,6 +914,7 @@ function LiveView({
   setup: SetupStatus | null
   connected: boolean
   onOpenSession: (session: SessionRow | string) => void
+  onStartSession: () => void
   onRefresh: () => void
 }) {
   const privacy = usePrivacy()
@@ -882,7 +944,7 @@ function LiveView({
         index="01"
         eyebrow="Live runtime"
         title={<>In the loop.<br /><em>Right now.</em></>}
-        description="A direct event stream from Grok’s active-session registry, phase engine, ACP updates, and tool lifecycle."
+        description="Watch every running Grok session as it works, waits, or needs you. Start one here, or keep using the CLI — both show up in this room."
       />
       <section className="live-summary-strip">
         <LiveSummaryMetric
@@ -912,14 +974,25 @@ function LiveView({
       </section>
 
       {!selected && data.stats.sessions === 0 ? (
-        <FirstRunOnboarding connected={connected} setup={setup} onRefresh={onRefresh} />
+        <FirstRunOnboarding
+          connected={connected}
+          setup={setup}
+          onRefresh={onRefresh}
+          onStartSession={onStartSession}
+        />
       ) : !selected ? (
         <section className="no-live-agent section-gap">
           <div className="idle-radar" aria-hidden="true"><span /><span /><i /></div>
           <div className="kicker">Runtime clear</div>
           <h2>No active Grok sessions.</h2>
-          <p>Start Grok in any workspace. The session will appear here as soon as it registers under <code>~/.grok/active_sessions.json</code>.</p>
-          <code className="launch-command">grok</code>
+          <p>Start a session from the dashboard or run Grok in any workspace. Either one appears here the moment it is live.</p>
+          <div className="idle-actions">
+            <button className="launch-button" type="button" onClick={onStartSession}>
+              <span>Start a session here</span>
+              <ArrowRight size={16} />
+            </button>
+            <code className="launch-command">grok</code>
+          </div>
         </section>
       ) : (
         <section className="live-console-grid section-gap">
@@ -1018,10 +1091,12 @@ function FirstRunOnboarding({
   connected,
   setup,
   onRefresh,
+  onStartSession,
 }: {
   connected: boolean
   setup: SetupStatus | null
   onRefresh: () => void
+  onStartSession: () => void
 }) {
   const [copied, setCopied] = useState('')
   const copy = async (command: string) => {
@@ -1077,6 +1152,10 @@ function FirstRunOnboarding({
               : setup ? 'FIRST CONTACT / SETUP REQUIRED' : 'FIRST CONTACT / CHECKING'}
           </span>
           <h2>Zero to live<br /><em>in three moves.</em></h2>
+          <button className="launch-button first-run-cta" type="button" onClick={onStartSession}>
+            <span>Start a session here</span>
+            <ArrowRight size={16} />
+          </button>
         </div>
         <div className="first-run-status">
           <span className={cli?.state === 'ready' ? 'is-ready' : 'needs-action'}><i /> Grok CLI</span>
@@ -1109,7 +1188,7 @@ function FirstRunOnboarding({
       <footer>
         <span>
           {setup?.ready && connected
-            ? <>Environment ready. Start <code>grok</code> in any project.</>
+            ? <>Environment ready. Start a session here, or run <code>grok</code> in any project.</>
             : <>Need the full terminal report? Run <code>grok-ui doctor</code>.</>}
         </span>
         <button className="text-button" onClick={onRefresh}>
@@ -1833,12 +1912,28 @@ function CommandPalette({
 }) {
   const privacy = usePrivacy()
   const [value, setValue] = useState('')
+  const [selected, setSelected] = useState(0)
   const normalized = value.toLowerCase()
   const navResults = NAV_ITEMS.filter((item) => item.label.toLowerCase().includes(normalized))
   const sessionResults = (data?.sessions || []).filter((session) =>
     !session.archived
     && [session.title, session.workspace, session.model].some((item) => item.toLowerCase().includes(normalized)),
   ).slice(0, 5)
+  const results = [
+    ...navResults.map((item) => ({ kind: 'nav' as const, item })),
+    ...sessionResults.map((session) => ({ kind: 'session' as const, session })),
+  ]
+
+  useEffect(() => {
+    setSelected(0)
+  }, [value])
+
+  const openResult = (index = selected) => {
+    const result = results[index]
+    if (!result) return
+    if (result.kind === 'nav') onNavigate(result.item.id)
+    else onSession(result.session)
+  }
 
   return (
     <div className="palette-layer" role="dialog" aria-modal="true" aria-label="Command palette">
@@ -1846,31 +1941,72 @@ function CommandPalette({
       <div className="command-palette">
         <label>
           <Command size={18} />
-          <input autoFocus value={value} onChange={(event) => setValue(event.target.value)} placeholder="Jump to a view or local session…" />
+          <input
+            autoFocus
+            value={value}
+            aria-autocomplete="list"
+            aria-controls="command-palette-results"
+            aria-activedescendant={results[selected] ? `palette-result-${selected}` : undefined}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowDown') {
+                event.preventDefault()
+                setSelected((index) => (index + 1) % Math.max(results.length, 1))
+              }
+              if (event.key === 'ArrowUp') {
+                event.preventDefault()
+                setSelected((index) => (index - 1 + results.length) % Math.max(results.length, 1))
+              }
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                openResult()
+              }
+            }}
+            placeholder="Jump to a view or local session…"
+          />
           <kbd>ESC</kbd>
         </label>
-        <div className="palette-results">
+        <div className="palette-results" id="command-palette-results" role="listbox">
           {navResults.length > 0 && <div className="palette-label">Views</div>}
-          {navResults.map((item) => {
+          {navResults.map((item, index) => {
             const Icon = item.icon
             return (
-              <button key={item.id} onClick={() => onNavigate(item.id)}>
+              <button
+                id={`palette-result-${index}`}
+                key={item.id}
+                role="option"
+                aria-selected={selected === index}
+                className={selected === index ? 'is-selected' : ''}
+                onMouseEnter={() => setSelected(index)}
+                onClick={() => openResult(index)}
+              >
                 <Icon size={16} /><span><strong>{item.label}</strong><small>{item.eyebrow}</small></span><kbd>{item.shortcut}</kbd>
               </button>
             )
           })}
           {sessionResults.length > 0 && <div className="palette-label">Recent sessions</div>}
-          {sessionResults.map((session) => (
-            <button key={session.id} onClick={() => onSession(session)}>
-              <TerminalSquare size={16} />
-              <span>
-                <strong>{privacy.sessionTitle(session.title, session.id)}</strong>
-                <small>{privacy.workspace(session.cwd)} · {session.model}</small>
-              </span>
-              <ChevronRight size={15} />
-            </button>
-          ))}
-          {!navResults.length && !sessionResults.length && <EmptyInline>No matching destination.</EmptyInline>}
+          {sessionResults.map((session, sessionIndex) => {
+            const index = navResults.length + sessionIndex
+            return (
+              <button
+                id={`palette-result-${index}`}
+                key={session.id}
+                role="option"
+                aria-selected={selected === index}
+                className={selected === index ? 'is-selected' : ''}
+                onMouseEnter={() => setSelected(index)}
+                onClick={() => openResult(index)}
+              >
+                <TerminalSquare size={16} />
+                <span>
+                  <strong>{privacy.sessionTitle(session.title, session.id)}</strong>
+                  <small>{privacy.workspace(session.cwd)} · {session.model}</small>
+                </span>
+                <ChevronRight size={15} />
+              </button>
+            )
+          })}
+          {!results.length && <EmptyInline>No matching destination.</EmptyInline>}
         </div>
         <footer><span>↑↓ Navigate</span><span>↵ Open</span><span>Local metadata only</span></footer>
       </div>
@@ -1880,11 +2016,13 @@ function CommandPalette({
 
 function MobileNav({
   active,
+  attention,
   onNavigate,
   onMore,
   suspended,
 }: {
   active: ViewId
+  attention: AttentionState
   onNavigate: (view: ViewId) => void
   onMore: () => void
   suspended: boolean
@@ -1900,7 +2038,16 @@ function MobileNav({
     >
       {primaryItems.map((item) => {
         const Icon = item.icon
-        return <button key={item.id} className={active === item.id ? 'is-active' : ''} onClick={() => onNavigate(item.id)}><Icon size={18} /><span>{item.label}</span></button>
+        const badge = navBadgeCount(item.id, attention)
+        return (
+          <button key={item.id} className={active === item.id ? 'is-active' : ''} onClick={() => onNavigate(item.id)}>
+            <span className="mobile-nav-icon">
+              <Icon size={18} />
+              {badge > 0 && <i className="nav-badge-dot" aria-hidden="true" />}
+            </span>
+            <span>{item.label}</span>
+          </button>
+        )
       })}
       <button
         className={moreActive ? 'is-active' : ''}
@@ -1912,6 +2059,32 @@ function MobileNav({
         <span>More</span>
       </button>
     </nav>
+  )
+}
+
+function NeedsYouBar({
+  attention,
+  privacyMode,
+  onOpen,
+}: {
+  attention: AttentionState
+  privacyMode: boolean
+  onOpen: () => void
+}) {
+  if (!attention.primary) return null
+  const count = attention.permissionCount + attention.liveCount
+  const title = privacyMode
+    ? `${count} session${count === 1 ? '' : 's'} waiting for attention.`
+    : attention.primary.title
+  return (
+    <button className="needs-you-bar" type="button" onClick={onOpen}>
+      <span className="needs-you-pulse" aria-hidden="true" />
+      <span>
+        <small>Needs you</small>
+        <strong>{title}</strong>
+      </span>
+      <em>{attention.primary.kind === 'permission' ? 'Review approval' : 'Open session'} <ArrowRight size={14} /></em>
+    </button>
   )
 }
 

--- a/src/navigation.test.ts
+++ b/src/navigation.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectAttention,
+  formatHash,
+  navBadgeCount,
+  parseHash,
+} from './navigation'
+import type { ControlSnapshot, LiveSnapshot } from './types'
+
+function live(agents: LiveSnapshot['agents']): LiveSnapshot {
+  return {
+    generatedAt: new Date().toISOString(),
+    connected: true,
+    activeCount: agents.length,
+    workingCount: 0,
+    attentionCount: agents.filter((agent) => agent.state === 'attention').length,
+    agents,
+  } as LiveSnapshot
+}
+
+describe('hash routes', () => {
+  it('defaults an empty hash to Live', () => {
+    expect(parseHash('')).toEqual({ view: 'live', sessionId: null })
+    expect(parseHash('#')).toEqual({ view: 'live', sessionId: null })
+    expect(parseHash('#/')).toEqual({ view: 'live', sessionId: null })
+  })
+
+  it('round-trips a view and an open session', () => {
+    const route = { view: 'live' as const, sessionId: 'live-e2e-session' }
+    expect(parseHash(formatHash(route))).toEqual(route)
+    expect(formatHash({ view: 'control', sessionId: null })).toBe('#/control')
+  })
+
+  it('falls back to Live for unknown views and keeps the session id', () => {
+    expect(parseHash('#/unknown/abc')).toEqual({ view: 'live', sessionId: 'abc' })
+  })
+})
+
+describe('attention', () => {
+  it('prefers a pending permission over a live attention agent', () => {
+    const attention = collectAttention(
+      live([
+        {
+          id: 'cli-agent',
+          title: 'CLI session',
+          cwd: '/tmp',
+          workspace: 'tmp',
+          openedAt: '',
+          model: 'grok',
+          state: 'attention',
+          phase: 'waiting',
+          pid: 1,
+          turns: 1,
+          toolCalls: 0,
+          contextUsed: 0,
+          contextSize: 0,
+          contextUsage: 0,
+          costAmount: 0,
+          costCurrency: 'USD',
+          currentTool: '',
+          updatedAt: '',
+          feed: [],
+        } as unknown as LiveSnapshot['agents'][number],
+      ]),
+      {
+        generatedAt: '',
+        connected: true,
+        starting: false,
+        agentName: 'Grok',
+        agentVersion: '1',
+        error: '',
+        sessions: [],
+        permissions: [{
+          id: 'perm-1',
+          sessionId: 'managed-1',
+          title: 'Write the verified fixture',
+          toolKind: 'edit',
+          toolCallId: 'tool-1',
+          createdAt: '',
+          options: [],
+        }],
+      } as unknown as ControlSnapshot,
+    )
+
+    expect(attention.primary).toEqual({
+      kind: 'permission',
+      sessionId: 'managed-1',
+      title: 'Write the verified fixture',
+    })
+    expect(navBadgeCount('control', attention)).toBe(1)
+    expect(navBadgeCount('live', attention)).toBe(1)
+    expect(navBadgeCount('sessions', attention)).toBe(0)
+  })
+})

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,94 @@
+import type { ControlSnapshot, LiveSnapshot, ViewId } from './types'
+
+export interface AppRoute {
+  view: ViewId
+  sessionId: string | null
+}
+
+export interface AttentionTarget {
+  kind: 'permission' | 'live'
+  sessionId: string
+  title: string
+}
+
+export interface AttentionState {
+  permissionCount: number
+  liveCount: number
+  primary: AttentionTarget | null
+}
+
+export const VIEW_IDS: ViewId[] = [
+  'live',
+  'control',
+  'runs',
+  'changes',
+  'overview',
+  'sessions',
+  'activity',
+  'usage',
+  'fleet',
+  'library',
+  'memory',
+  'themes',
+]
+
+export const NAV_GROUPS: Array<{ id: string; label: string; items: ViewId[] }> = [
+  { id: 'work', label: 'Work', items: ['live', 'control', 'runs', 'changes', 'sessions'] },
+  { id: 'look-back', label: 'Look back', items: ['overview', 'activity', 'usage'] },
+  { id: 'system', label: 'System', items: ['fleet', 'library', 'memory', 'themes'] },
+]
+
+export function isViewId(value: string): value is ViewId {
+  return VIEW_IDS.includes(value as ViewId)
+}
+
+export function parseHash(hash: string): AppRoute {
+  const raw = hash.replace(/^#\/?/, '')
+  if (!raw) return { view: 'live', sessionId: null }
+
+  const slash = raw.indexOf('/')
+  const viewPart = decodeURIComponent(slash === -1 ? raw : raw.slice(0, slash))
+  const sessionPart = slash === -1 ? '' : raw.slice(slash + 1)
+  const view = isViewId(viewPart) ? viewPart : 'live'
+  const sessionId = sessionPart ? decodeURIComponent(sessionPart) : null
+  return { view, sessionId }
+}
+
+export function formatHash(route: AppRoute): string {
+  const view = isViewId(route.view) ? route.view : 'live'
+  if (!route.sessionId) return `#/${view}`
+  return `#/${view}/${encodeURIComponent(route.sessionId)}`
+}
+
+export function writeHash(route: AppRoute): void {
+  const next = formatHash(route)
+  if (window.location.hash !== next) {
+    history.replaceState(null, '', next)
+  }
+}
+
+export function collectAttention(
+  live: LiveSnapshot | null,
+  control: ControlSnapshot | null,
+): AttentionState {
+  const permissions = control?.permissions || []
+  const agents = (live?.agents || []).filter((agent) => agent.state === 'attention')
+  const permission = permissions[0]
+  const agent = agents[0]
+
+  return {
+    permissionCount: permissions.length,
+    liveCount: live?.attentionCount || agents.length,
+    primary: permission
+      ? { kind: 'permission', sessionId: permission.sessionId, title: permission.title }
+      : agent
+        ? { kind: 'live', sessionId: agent.id, title: agent.title }
+        : null,
+  }
+}
+
+export function navBadgeCount(view: ViewId, attention: AttentionState): number {
+  if (view === 'live') return attention.liveCount
+  if (view === 'control') return attention.permissionCount
+  return 0
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -289,6 +289,7 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
   padding: 26px 18px 17px;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
   border-right: 1px solid var(--line);
   background: rgba(9, 10, 8, .94);
   backdrop-filter: blur(24px);
@@ -394,7 +395,24 @@ html[data-theme='event-horizon'] .access-screen .brand-logo {
 
 .primary-nav {
   display: grid;
+  gap: 16px;
+}
+
+.nav-group {
+  display: grid;
   gap: 2px;
+}
+
+.nav-badge {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: grid;
+  place-items: center;
+  color: var(--ink);
+  background: var(--coral);
+  font-size: 8px;
+  font-weight: 700;
 }
 
 .nav-item {
@@ -655,6 +673,75 @@ kbd {
   margin: 0 auto;
   padding: 50px clamp(20px, 4vw, 56px) 72px;
   animation: reveal .45s cubic-bezier(.2,.8,.2,1) both;
+}
+
+.needs-you-bar {
+  width: 100%;
+  min-height: 54px;
+  margin-bottom: 22px;
+  padding: 10px 16px;
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  color: inherit;
+  border: 1px solid color-mix(in srgb, var(--coral) 42%, var(--line));
+  background: var(--coral-soft);
+  cursor: pointer;
+  text-align: left;
+}
+
+.needs-you-bar small {
+  display: block;
+  color: var(--coral);
+  font-size: 8px;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.needs-you-bar strong {
+  display: block;
+  margin-top: 3px;
+  overflow: hidden;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.needs-you-bar em {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--coral);
+  font-style: normal;
+  font-size: 10px;
+  letter-spacing: .04em;
+  white-space: nowrap;
+}
+
+.needs-you-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--coral);
+  box-shadow: 0 0 0 4px rgba(255, 101, 79, .16);
+  animation: pulse-dot 1.6s ease-in-out infinite;
+}
+
+.mobile-nav-icon {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.nav-badge-dot {
+  position: absolute;
+  top: -2px;
+  right: -3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--coral);
 }
 
 @keyframes reveal {
@@ -1275,6 +1362,21 @@ kbd {
 
 .no-live-agent code {
   color: var(--lime);
+}
+
+.idle-actions {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.idle-actions .launch-button {
+  min-width: 220px;
+}
+
+.idle-actions .launch-command {
+  margin-top: 0;
 }
 
 .launch-command {
@@ -3018,7 +3120,8 @@ kbd {
   cursor: pointer;
 }
 
-.palette-results button:hover {
+.palette-results button:hover,
+.palette-results button.is-selected {
   color: var(--paper);
   background: var(--lime-soft);
 }
@@ -6715,6 +6818,13 @@ kbd {
   gap: 32px;
   padding: clamp(28px, 5vw, 62px);
   border-bottom: 1px solid var(--line);
+}
+
+.first-run-cta {
+  width: fit-content;
+  min-height: 42px;
+  margin-top: 22px;
+  padding: 0 18px;
 }
 
 .first-run-head h2 {


### PR DESCRIPTION
## Outcome

Same features, shorter path. The twelve destinations stay available. First-run can start a session in the dashboard, pending approvals follow the customer, and refresh keeps the open room.

## Summary
- Group primary nav into Work, Look back, and System
- Add Start a session here on first-run and idle Live
- Add a Needs you bar plus Live/Control badges for attention
- Persist view and open session in the URL hash
- Honor ↑↓ and Enter in the command palette

## Verification
- [x] Relevant automated tests added or updated
- [x] Desktop behavior checked
- [x] Mobile behavior checked when UI changed
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added
- [ ] `npm run verify`

## Test plan
- [ ] Fresh install: first-run shows Start a session here and opens Control
- [ ] CLI `grok` still appears on Live when a process registers
- [ ] Pending approval shows Needs you and a Control badge
- [ ] Refresh on `#/sessions` or an open session keeps place
- [ ] ⌘K then arrow keys and Enter open the selected view
- [ ] Mobile still shows Live, Control, Runs, Fleet, and More
- [ ] Runs, Fleet, Usage, Library, Memory, and Themes still open


Made with [Cursor](https://cursor.com)