### PR TITLE
Start a session from Live without leaving the room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Start a session from empty Live instead of leaving for Control. The same
+  launch form stays on Control for multi-lane work.
 - Isolated session previews on `preview.localhost` behind a cookie-stripping
   proxy so dashboard session cookies are not sent to generated applications.
 - Serialized preview start and stop, then terminate with SIGTERM followed by
@@ -11,8 +13,6 @@
   console error banner.
 - Grouped the primary nav into Work, Look back, and System so the twelve
   destinations stay available without competing as one list.
-- Added a first-run and idle-state Start a session here action that opens
-  Control without leaving the dashboard.
 - Added a global Needs you bar and nav badges for pending approvals and live
   attention.
 - Persisted the active view and open session in the URL hash so refresh keeps

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -225,10 +225,11 @@ test.describe.serial('public launch path', () => {
 
     await expect(page.getByText('FIRST CONTACT / READY')).toBeVisible()
     await expect(page.getByText('Environment ready.')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Start a session here' })).toBeVisible()
-    await page.getByRole('button', { name: 'Start a session here' }).click()
-    await expect(page.getByRole('heading', { name: /Run the room/ })).toBeVisible()
-    await expect(page).toHaveURL(/#\/control$/)
+    await expect(page.getByRole('heading', { name: 'Start a session' })).toBeVisible()
+    await expect(page.getByLabel('WORKSPACE')).toBeVisible()
+    await expect(page.getByLabel('INSTRUCTION')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'LAUNCH AGENT' })).toBeVisible()
+    await expect(page).toHaveURL(/#\/live$/)
   })
 
   test('discovers a newly registered Grok CLI session over the live stream', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ import type {
 } from './types'
 import { ChangesView } from './views/ChangesView'
 import { ControlView } from './views/ControlView'
+import { SessionLaunchForm } from './views/SessionLaunchForm'
 import { SessionWorkbench } from './views/SessionWorkbench'
 import { RemoteSessionWorkbench } from './views/RemoteSessionWorkbench'
 import { WorkflowsView } from './views/WorkflowsView'
@@ -538,11 +539,12 @@ function App() {
                 live={live}
                 runtime={runtime}
                 data={data}
+                control={control}
                 setup={setup}
                 connected={streamConnected}
                 onOpenSession={openSession}
-                onStartSession={() => setActiveView('control')}
                 onRefresh={() => void load(true)}
+                onRefreshControl={refreshControl}
               />
             )}
             {view === 'control' && (
@@ -902,20 +904,22 @@ function LiveView({
   live,
   runtime,
   data,
+  control,
   setup,
   connected,
   onOpenSession,
-  onStartSession,
   onRefresh,
+  onRefreshControl,
 }: {
   live: LiveSnapshot | null
   runtime: RuntimeSnapshot | null
   data: DashboardPayload
+  control: ControlSnapshot | null
   setup: SetupStatus | null
   connected: boolean
   onOpenSession: (session: SessionRow | string) => void
-  onStartSession: () => void
   onRefresh: () => void
+  onRefreshControl: () => Promise<void>
 }) {
   const privacy = usePrivacy()
   const [selectedId, setSelectedId] = useState(live?.agents[0]?.id || '')
@@ -977,22 +981,28 @@ function LiveView({
         <FirstRunOnboarding
           connected={connected}
           setup={setup}
+          data={data}
+          live={live}
+          control={control}
           onRefresh={onRefresh}
-          onStartSession={onStartSession}
+          onRefreshControl={onRefreshControl}
+          onOpenSession={onOpenSession}
         />
       ) : !selected ? (
         <section className="no-live-agent section-gap">
           <div className="idle-radar" aria-hidden="true"><span /><span /><i /></div>
           <div className="kicker">Runtime clear</div>
           <h2>No active Grok sessions.</h2>
-          <p>Start a session from the dashboard or run Grok in any workspace. Either one appears here the moment it is live.</p>
-          <div className="idle-actions">
-            <button className="launch-button" type="button" onClick={onStartSession}>
-              <span>Start a session here</span>
-              <ArrowRight size={16} />
-            </button>
-            <code className="launch-command">grok</code>
-          </div>
+          <p>Start one here, or run Grok in any workspace. Either one appears here the moment it is live.</p>
+          <SessionLaunchForm
+            data={data}
+            live={live}
+            control={control}
+            heading="Start a session"
+            index="01"
+            onRefresh={onRefreshControl}
+            onLaunched={(session) => onOpenSession(session.id)}
+          />
         </section>
       ) : (
         <section className="live-console-grid section-gap">
@@ -1090,13 +1100,21 @@ function LiveView({
 function FirstRunOnboarding({
   connected,
   setup,
+  data,
+  live,
+  control,
   onRefresh,
-  onStartSession,
+  onRefreshControl,
+  onOpenSession,
 }: {
   connected: boolean
   setup: SetupStatus | null
+  data: DashboardPayload
+  live: LiveSnapshot | null
+  control: ControlSnapshot | null
   onRefresh: () => void
-  onStartSession: () => void
+  onRefreshControl: () => Promise<void>
+  onOpenSession: (session: SessionRow | string) => void
 }) {
   const [copied, setCopied] = useState('')
   const copy = async (command: string) => {
@@ -1136,8 +1154,8 @@ function FirstRunOnboarding({
       index: '03',
       label: 'Start the first session',
       copy: state?.state === 'ready'
-        ? 'Open any project and run Grok. The live agent will register here automatically.'
-        : state?.detail || 'Open any project and start a normal Grok CLI session.',
+        ? 'Start a session above, or run grok in any project. Either one registers here automatically.'
+        : state?.detail || 'Start a session above, or open any project and run grok.',
       command: 'grok',
       state: 'action',
     },
@@ -1152,16 +1170,23 @@ function FirstRunOnboarding({
               : setup ? 'FIRST CONTACT / SETUP REQUIRED' : 'FIRST CONTACT / CHECKING'}
           </span>
           <h2>Zero to live<br /><em>in three moves.</em></h2>
-          <button className="launch-button first-run-cta" type="button" onClick={onStartSession}>
-            <span>Start a session here</span>
-            <ArrowRight size={16} />
-          </button>
         </div>
         <div className="first-run-status">
           <span className={cli?.state === 'ready' ? 'is-ready' : 'needs-action'}><i /> Grok CLI</span>
           <span className={auth?.state === 'ready' ? 'is-ready' : 'needs-action'}><i /> Account</span>
           <span><i /> First session</span>
         </div>
+      </div>
+      <div className="first-run-launch">
+        <SessionLaunchForm
+          data={data}
+          live={live}
+          control={control}
+          heading="Start a session"
+          index="01"
+          onRefresh={onRefreshControl}
+          onLaunched={(session) => onOpenSession(session.id)}
+        />
       </div>
       <div className="first-run-steps">
         {steps.map((step) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -6826,7 +6826,7 @@ kbd {
 }
 
 .first-run-head {
-  min-height: 255px;
+  min-height: 210px;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
@@ -6835,11 +6835,31 @@ kbd {
   border-bottom: 1px solid var(--line);
 }
 
-.first-run-cta {
-  width: fit-content;
-  min-height: 42px;
+.first-run-launch {
+  padding: 22px clamp(28px, 5vw, 62px) 4px;
+}
+
+.first-run-launch .composer-panel,
+.no-live-agent .composer-panel {
+  width: min(760px, 100%);
+  text-align: left;
+}
+
+.no-live-agent .composer-panel {
   margin-top: 22px;
-  padding: 0 18px;
+}
+
+.launch-form-status {
+  margin: 0 0 14px;
+  font-size: 13px;
+}
+
+.launch-form-status.is-error {
+  color: var(--coral);
+}
+
+.launch-form-status.is-success {
+  color: var(--lime);
 }
 
 .first-run-head h2 {

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -4,20 +4,13 @@ import {
   Check,
   CircleStop,
   Command,
-  CornerDownLeft,
   FolderGit2,
   Radio,
   ShieldAlert,
-  Sparkles,
   X,
 } from 'lucide-react'
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
-import {
-  cancelControlSession,
-  createControlSession,
-  promptControlSession,
-  resolveControlPermission,
-} from '../api'
+import { useEffect, useState } from 'react'
+import { cancelControlSession, resolveControlPermission } from '../api'
 import type {
   ControlSession,
   ControlSnapshot,
@@ -25,6 +18,7 @@ import type {
   LiveSnapshot,
 } from '../types'
 import { usePrivacy } from '../privacy'
+import { SessionLaunchForm } from './SessionLaunchForm'
 
 interface ControlViewProps {
   data: DashboardPayload
@@ -36,13 +30,6 @@ interface ControlViewProps {
 
 function compact(value: number): string {
   return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value)
-}
-
-function uniqueWorkspaces(data: DashboardPayload, live: LiveSnapshot | null): string[] {
-  return [...new Set([
-    ...(live?.agents.map((agent) => agent.cwd) || []),
-    ...data.sessions.map((session) => session.cwd),
-  ].filter(Boolean))]
 }
 
 function cancellationTime(session: ControlSession): string {
@@ -67,32 +54,10 @@ function lastCompletedTool(session: ControlSession): string {
 
 export function ControlView({ data, live, control, onRefresh, onOpenSession }: ControlViewProps) {
   const privacy = usePrivacy()
-  const workspaces = useMemo(() => uniqueWorkspaces(data, live), [data, live])
-  const resumable = useMemo(() => {
-    const seen = new Set<string>()
-    return [
-      ...(control?.sessions || []).map((session) => ({
-        id: session.id,
-        title: session.title,
-        cwd: session.cwd,
-      })),
-      ...data.sessions.filter((session) => !session.archived),
-    ].filter((session) => {
-      if (seen.has(session.id)) return false
-      seen.add(session.id)
-      return true
-    })
-  }, [control, data.sessions])
-  const [mode, setMode] = useState<'new' | 'resume'>('new')
-  const [cwd, setCwd] = useState(workspaces[0] || '')
-  const [sessionId, setSessionId] = useState('')
-  const [prompt, setPrompt] = useState('')
-  const [model, setModel] = useState('')
-  const [reasoningEffort, setReasoningEffort] = useState('medium')
-  const [submitting, setSubmitting] = useState(false)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
   const [selectedLane, setSelectedLane] = useState(control?.sessions[0]?.id || '')
+  const [resumeRequest, setResumeRequest] = useState({ id: '', token: 0 })
 
   useEffect(() => {
     if (!control?.sessions.length) {
@@ -106,31 +71,6 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
 
   const activeLane = control?.sessions.find((session) => session.id === selectedLane)
 
-  const submit = async (event: FormEvent) => {
-    event.preventDefault()
-    if (!prompt.trim()) return
-    setSubmitting(true)
-    setError('')
-    setMessage('')
-    try {
-      if (mode === 'resume') {
-        const selected = resumable.find((session) => session.id === sessionId)
-        if (!selected) throw new Error('Choose a session to resume.')
-        await promptControlSession(selected.id, { cwd: selected.cwd, prompt })
-        setMessage(`Prompt sent to ${privacy.sessionTitle(selected.title, selected.id)}.`)
-      } else {
-        await createControlSession({ cwd, prompt, model, reasoningEffort })
-        setMessage('New Grok lane launched.')
-      }
-      setPrompt('')
-      await onRefresh()
-    } catch (submitError) {
-      setError(submitError instanceof Error ? submitError.message : 'Command failed.')
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
   const cancel = async (id: string) => {
     setError('')
     try {
@@ -143,9 +83,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
   }
 
   const resume = (session: ControlSession) => {
-    setMode('resume')
-    chooseSession(session.id)
-    setMessage(`Ready to resume ${privacy.sessionTitle(session.title, session.id)}.`)
+    setResumeRequest({ id: session.id, token: Date.now() })
     window.requestAnimationFrame(() => {
       document.querySelector('.composer-panel')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
     })
@@ -158,12 +96,6 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
     } catch (decisionError) {
       setError(decisionError instanceof Error ? decisionError.message : 'Unable to resolve permission.')
     }
-  }
-
-  const chooseSession = (id: string) => {
-    setSessionId(id)
-    const selected = resumable.find((session) => session.id === id)
-    if (selected) setCwd(selected.cwd)
   }
 
   return (
@@ -209,92 +141,14 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
       {message && <div className="control-banner is-success"><Check size={17} /><span>{message}</span></div>}
 
       <section className="command-deck-grid section-gap">
-        <form className="composer-panel panel-cut" onSubmit={submit}>
-          <header>
-            <div>
-              <span className="panel-index">01</span>
-              <h2>Issue a command</h2>
-            </div>
-            <span className="composer-shortcut">⌘ ↵</span>
-          </header>
-
-          <div className="mode-switch" role="tablist" aria-label="Command target">
-            <button type="button" className={mode === 'new' ? 'is-active' : ''} onClick={() => setMode('new')}>
-              <Sparkles size={15} /> New agent
-            </button>
-            <button type="button" className={mode === 'resume' ? 'is-active' : ''} onClick={() => setMode('resume')}>
-              <Radio size={15} /> Resume session
-            </button>
-          </div>
-
-          {mode === 'resume' ? (
-            <label className="control-field">
-              <span>SESSION</span>
-              <select value={sessionId} onChange={(event) => chooseSession(event.target.value)} required>
-                <option value="">Choose a recorded session…</option>
-                {resumable.map((session) => (
-                  <option value={session.id} key={session.id}>
-                    {privacy.sessionTitle(session.title, session.id)} — {privacy.identifier(session.id)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : (
-            <>
-              <label className="control-field">
-                <span>WORKSPACE</span>
-                <input
-                  list="grok-workspaces"
-                  value={privacy.enabled ? '' : cwd}
-                  onChange={(event) => setCwd(event.target.value)}
-                  placeholder={privacy.enabled ? 'Workspace path hidden — turn Privacy Mode off to edit' : '/absolute/path/to/project'}
-                  readOnly={privacy.enabled}
-                  required={!privacy.enabled}
-                />
-                <datalist id="grok-workspaces">
-                  {!privacy.enabled && workspaces.map((workspace) => <option value={workspace} key={workspace} />)}
-                </datalist>
-              </label>
-              <div className="control-field-row">
-                <label className="control-field">
-                  <span>MODEL <em>optional</em></span>
-                  <input value={model} onChange={(event) => setModel(event.target.value)} placeholder="Use Grok default" />
-                </label>
-                <label className="control-field">
-                  <span>REASONING</span>
-                  <select value={reasoningEffort} onChange={(event) => setReasoningEffort(event.target.value)}>
-                    {['low', 'medium', 'high', 'xhigh', 'max'].map((effort) => <option key={effort}>{effort}</option>)}
-                  </select>
-                </label>
-              </div>
-            </>
-          )}
-
-          <label className="prompt-field">
-            <span>INSTRUCTION</span>
-            <textarea
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') event.currentTarget.form?.requestSubmit()
-              }}
-              placeholder="What should Grok do next?"
-              rows={7}
-              maxLength={32_000}
-              required
-            />
-            <small>{compact(prompt.length)} / 32K</small>
-          </label>
-
-          <button
-            className="launch-button"
-            disabled={submitting || !control?.connected || (mode === 'new' && !cwd)}
-          >
-            <span>{submitting ? 'DISPATCHING' : mode === 'new' ? 'LAUNCH AGENT' : 'SEND PROMPT'}</span>
-            <CornerDownLeft size={17} />
-          </button>
-          <p className="composer-note">Tool executions still pass through Grok’s native permission system. Nothing is silently auto-approved.</p>
-        </form>
+        <SessionLaunchForm
+          data={data}
+          live={live}
+          control={control}
+          requestedResumeId={resumeRequest.id}
+          resumeToken={resumeRequest.token}
+          onRefresh={onRefresh}
+        />
 
         <aside className="approval-panel">
           <header>

--- a/src/views/SessionLaunchForm.test.ts
+++ b/src/views/SessionLaunchForm.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { listResumable, uniqueWorkspaces } from './SessionLaunchForm'
+import type { ControlSnapshot, DashboardPayload, LiveSnapshot, SessionRow } from '../types'
+
+function session(id: string, cwd: string, archived = false): SessionRow {
+  return {
+    id,
+    title: id,
+    summary: '',
+    cwd,
+    workspace: cwd,
+    createdAt: '',
+    updatedAt: '',
+    model: 'grok',
+    agent: 'default',
+    reasoningEffort: 'medium',
+    sandboxProfile: 'default',
+    messages: 0,
+    chatMessages: 0,
+    archived,
+  } as SessionRow
+}
+
+function dashboard(sessions: SessionRow[]): DashboardPayload {
+  return { sessions } as DashboardPayload
+}
+
+describe('session launch helpers', () => {
+  it('deduplicates workspaces from live agents and recorded sessions', () => {
+    expect(uniqueWorkspaces(
+      dashboard([session('a', '/repo/alpha'), session('b', '/repo/alpha'), session('c', '/repo/beta')]),
+      {
+        agents: [{ cwd: '/repo/alpha' }, { cwd: '/repo/gamma' }],
+      } as LiveSnapshot,
+    )).toEqual(['/repo/alpha', '/repo/gamma', '/repo/beta'])
+  })
+
+  it('lists resumable sessions once and skips the archive', () => {
+    const rows = listResumable(
+      dashboard([
+        session('cli', '/repo/cli'),
+        session('managed', '/repo/managed'),
+        session('old', '/repo/old', true),
+      ]),
+      {
+        sessions: [{ id: 'managed', title: 'Managed', cwd: '/repo/managed' }],
+      } as ControlSnapshot,
+    )
+
+    expect(rows.map((row) => row.id)).toEqual(['managed', 'cli'])
+  })
+})

--- a/src/views/SessionLaunchForm.tsx
+++ b/src/views/SessionLaunchForm.tsx
@@ -1,0 +1,225 @@
+import { CornerDownLeft, Radio, Sparkles } from 'lucide-react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { createControlSession, promptControlSession } from '../api'
+import { usePrivacy } from '../privacy'
+import type {
+  ControlSession,
+  ControlSnapshot,
+  DashboardPayload,
+  LiveSnapshot,
+} from '../types'
+
+export type LaunchMode = 'new' | 'resume'
+
+export interface ResumableSession {
+  id: string
+  title: string
+  cwd: string
+}
+
+export function uniqueWorkspaces(data: DashboardPayload, live: LiveSnapshot | null): string[] {
+  return [...new Set([
+    ...(live?.agents.map((agent) => agent.cwd) || []),
+    ...data.sessions.map((session) => session.cwd),
+  ].filter(Boolean))]
+}
+
+export function listResumable(
+  data: DashboardPayload,
+  control: ControlSnapshot | null,
+): ResumableSession[] {
+  const seen = new Set<string>()
+  return [
+    ...(control?.sessions || []).map((session) => ({
+      id: session.id,
+      title: session.title,
+      cwd: session.cwd,
+    })),
+    ...data.sessions.filter((session) => !session.archived),
+  ].filter((session) => {
+    if (seen.has(session.id)) return false
+    seen.add(session.id)
+    return true
+  })
+}
+
+function compact(value: number): string {
+  return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+}
+
+interface SessionLaunchFormProps {
+  data: DashboardPayload
+  live: LiveSnapshot | null
+  control: ControlSnapshot | null
+  heading?: string
+  index?: string
+  requestedResumeId?: string
+  resumeToken?: number
+  onRefresh: () => Promise<void>
+  onLaunched?: (session: ControlSession) => void
+}
+
+export function SessionLaunchForm({
+  data,
+  live,
+  control,
+  heading = 'Issue a command',
+  index = '01',
+  requestedResumeId = '',
+  resumeToken = 0,
+  onRefresh,
+  onLaunched,
+}: SessionLaunchFormProps) {
+  const privacy = usePrivacy()
+  const workspaces = useMemo(() => uniqueWorkspaces(data, live), [data, live])
+  const resumable = useMemo(() => listResumable(data, control), [control, data.sessions])
+  const [mode, setMode] = useState<LaunchMode>('new')
+  const [cwd, setCwd] = useState(workspaces[0] || '')
+  const [sessionId, setSessionId] = useState('')
+  const [prompt, setPrompt] = useState('')
+  const [model, setModel] = useState('')
+  const [reasoningEffort, setReasoningEffort] = useState('medium')
+  const [submitting, setSubmitting] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!requestedResumeId) return
+    const selected = resumable.find((session) => session.id === requestedResumeId)
+    if (!selected) return
+    setMode('resume')
+    setSessionId(selected.id)
+    setCwd(selected.cwd)
+    setMessage(`Ready to resume ${privacy.sessionTitle(selected.title, selected.id)}.`)
+  }, [privacy, requestedResumeId, resumeToken, resumable])
+
+  const chooseSession = (id: string) => {
+    setSessionId(id)
+    const selected = resumable.find((session) => session.id === id)
+    if (selected) setCwd(selected.cwd)
+  }
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!prompt.trim()) return
+    setSubmitting(true)
+    setError('')
+    setMessage('')
+    try {
+      if (mode === 'resume') {
+        const selected = resumable.find((session) => session.id === sessionId)
+        if (!selected) throw new Error('Choose a session to resume.')
+        await promptControlSession(selected.id, { cwd: selected.cwd, prompt })
+        setMessage(`Prompt sent to ${privacy.sessionTitle(selected.title, selected.id)}.`)
+      } else {
+        const created = await createControlSession({ cwd, prompt, model, reasoningEffort })
+        setMessage('New Grok lane launched.')
+        onLaunched?.(created)
+      }
+      setPrompt('')
+      await onRefresh()
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Command failed.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form className="composer-panel panel-cut" onSubmit={submit}>
+      <header>
+        <div>
+          <span className="panel-index">{index}</span>
+          <h2>{heading}</h2>
+        </div>
+        <span className="composer-shortcut">⌘ ↵</span>
+      </header>
+
+      {error && <p className="launch-form-status is-error" role="alert">{privacy.content(error)}</p>}
+      {message && <p className="launch-form-status is-success">{message}</p>}
+
+      {resumable.length > 0 && (
+        <div className="mode-switch" role="tablist" aria-label="Command target">
+          <button type="button" className={mode === 'new' ? 'is-active' : ''} onClick={() => setMode('new')}>
+            <Sparkles size={15} /> New agent
+          </button>
+          <button type="button" className={mode === 'resume' ? 'is-active' : ''} onClick={() => setMode('resume')}>
+            <Radio size={15} /> Resume session
+          </button>
+        </div>
+      )}
+
+      {mode === 'resume' && resumable.length > 0 ? (
+        <label className="control-field">
+          <span>SESSION</span>
+          <select value={sessionId} onChange={(event) => chooseSession(event.target.value)} required>
+            <option value="">Choose a recorded session…</option>
+            {resumable.map((session) => (
+              <option value={session.id} key={session.id}>
+                {privacy.sessionTitle(session.title, session.id)} — {privacy.identifier(session.id)}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : (
+        <>
+          <label className="control-field">
+            <span>WORKSPACE</span>
+            <input
+              list="grok-workspaces"
+              value={privacy.enabled ? '' : cwd}
+              onChange={(event) => setCwd(event.target.value)}
+              placeholder={privacy.enabled ? 'Workspace path hidden — turn Privacy Mode off to edit' : '/absolute/path/to/project'}
+              readOnly={privacy.enabled}
+              required={!privacy.enabled}
+            />
+            <datalist id="grok-workspaces">
+              {!privacy.enabled && workspaces.map((workspace) => <option value={workspace} key={workspace} />)}
+            </datalist>
+          </label>
+          <div className="control-field-row">
+            <label className="control-field">
+              <span>MODEL <em>optional</em></span>
+              <input value={model} onChange={(event) => setModel(event.target.value)} placeholder="Use Grok default" />
+            </label>
+            <label className="control-field">
+              <span>REASONING</span>
+              <select value={reasoningEffort} onChange={(event) => setReasoningEffort(event.target.value)}>
+                {['low', 'medium', 'high', 'xhigh', 'max'].map((effort) => <option key={effort}>{effort}</option>)}
+              </select>
+            </label>
+          </div>
+        </>
+      )}
+
+      <label className="prompt-field">
+        <span>INSTRUCTION</span>
+        <textarea
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') event.currentTarget.form?.requestSubmit()
+          }}
+          placeholder="What should Grok do next?"
+          rows={7}
+          maxLength={32_000}
+          required
+        />
+        <small>{compact(prompt.length)} / 32K</small>
+      </label>
+
+      <button
+        className="launch-button"
+        disabled={submitting || !control?.connected || (mode === 'new' && !cwd)}
+      >
+        <span>{submitting ? 'Starting…' : mode === 'new' ? 'LAUNCH AGENT' : 'SEND PROMPT'}</span>
+        <CornerDownLeft size={17} />
+      </button>
+      <p className="composer-note">
+        {control?.connected
+          ? 'Tool executions still pass through Grok’s native permission system. Nothing is silently auto-approved.'
+          : 'Control is offline. The dashboard can still watch CLI sessions, but it cannot start one until ACP reconnects.'}
+      </p>
+    </form>
+  )
+}


### PR DESCRIPTION
## Outcome

Empty Live now starts a session in place. First-run and idle Live use the same launch form as Control, then open the session console. Control stays for multi-lane work, approvals, and resume.

## Summary
- Extract a shared session launch form
- Replace the Live “go to Control” hop with the form itself
- Keep Control reachable and unchanged in capability
- Update first-run e2e so `#/live` is the start path

## Test plan
- [x] `npm test` — 113 passed
- [x] `npm run check`
- [x] Desktop: first-run Live shows WORKSPACE / INSTRUCTION / LAUNCH AGENT on `#/live`
- [x] Desktop: Control still has Issue a command, approval queue, and managed lanes
- [ ] CI verify + browser-e2e
- [ ] Mobile: empty Live still shows the launch form in the command rail layout

## Verification
- [x] Relevant automated tests added or updated
- [ ] `npm run verify`
- [x] Desktop behavior checked
- [ ] Mobile behavior checked when UI changed
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added

Made with [Cursor](https://cursor.com)