### PR TITLE
Keep work on one session path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- Fixed Windows `npm start` by loading the server through a `file:` URL so
+  drive letters are not treated as ESM schemes.
+- Needs you now opens the session console for both live attention and
+  approvals, instead of sending people to Control.
+- Narrowed the primary nav to Live, Runs, Changes, Sessions, history, and
+  Fleet. Control, Library, Memory, and Themes stay on hash routes and the
+  command palette; Themes also sits next to Privacy.
+- Library and Memory lists are inspectable metadata, not dead inventories.
+- Quiet first-run and control copy: Setup needed, Ready to start, Control
+  connected.
 - Start a session from empty Live instead of leaving for Control. The same
   launch form stays on Control for multi-lane work.
 - Isolated session previews on `preview.localhost` behind a cookie-stripping

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -210,20 +210,20 @@ test.describe.serial('public launch path', () => {
     })
     await page.goto('/')
     await expect(page.getByRole('heading', { name: /Zero to live/ })).toBeVisible()
-    await expect(page.getByText('FIRST CONTACT / SETUP REQUIRED')).toBeVisible()
+    await expect(page.getByText('Setup needed')).toBeVisible()
     await expect(page.getByText('Grok CLI is missing or cannot run.')).toBeVisible()
 
     await fs.writeFile(path.join(grokHome, 'e2e-cli-ready'), 'unauthenticated\n')
     await page.getByRole('button', { name: /Recheck setup/ }).click()
 
-    await expect(page.getByText('FIRST CONTACT / SETUP REQUIRED')).toBeVisible()
+    await expect(page.getByText('Setup needed')).toBeVisible()
     await expect(page.getByText('Grok Build e2e')).toBeVisible()
     await expect(page.getByText('Authentication is required.')).toBeVisible()
 
     await fs.writeFile(path.join(grokHome, 'e2e-cli-ready'), 'ready\n')
     await page.getByRole('button', { name: /Recheck setup/ }).click()
 
-    await expect(page.getByText('FIRST CONTACT / READY')).toBeVisible()
+    await expect(page.getByText('Ready to start')).toBeVisible()
     await expect(page.getByText('Environment ready.')).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Start a session' })).toBeVisible()
     await expect(page.getByLabel('WORKSPACE')).toBeVisible()
@@ -367,10 +367,8 @@ test.describe.serial('public launch path', () => {
 
   test('launches and approves a managed ACP control session', async ({ page }, testInfo) => {
     const instruction = `Run the public release verification attempt ${testInfo.repeatEachIndex + 1}-${testInfo.retry + 1}`
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill(instruction)
     await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
@@ -407,10 +405,8 @@ test.describe.serial('public launch path', () => {
   })
 
   test('recovers the ACP control channel after its child process exits', async ({ page }) => {
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     const response = await page.request.post('/api/control/sessions', {
       data: {
         cwd: workspace,
@@ -451,10 +447,8 @@ test.describe.serial('public launch path', () => {
   })
 
   test('surfaces workflow telemetry and recovers a failed run across sessions', async ({ page }) => {
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Start workflow fixture')
     await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
@@ -496,10 +490,8 @@ test.describe.serial('public launch path', () => {
   })
 
   test('pages and searches a large workflow agent roster', async ({ page }) => {
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Start scaled workflow fixture')
     await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
@@ -566,10 +558,8 @@ test.describe.serial('public launch path', () => {
   })
 
   test('cancels cleanly while a permission decision is pending', async ({ page }) => {
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Hold for permission cancellation')
     await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
@@ -587,10 +577,8 @@ test.describe.serial('public launch path', () => {
   })
 
   test('cancels an active tool and records a confirmed post-stop result', async ({ page }) => {
-    await page.goto('/')
-    await page.getByRole('button', { name: /Control/ }).click()
-
-    await expect(page.getByText('ACP CONTROL LINKED')).toBeVisible({ timeout: 10_000 })
+    await page.goto('/#/control')
+    await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Run the long-running cancellation verification')
     await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
@@ -725,7 +713,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.locator('.sidebar-close')).toBeFocused()
     await page.keyboard.press('Shift+Tab')
     await expect(page.getByRole('navigation', { name: 'Primary navigation' })
-      .getByRole('button', { name: /Themes/ })).toBeFocused()
+      .getByRole('button', { name: /Fleet/ })).toBeFocused()
     await page.keyboard.press('Tab')
     await expect(page.locator('.sidebar-close')).toBeFocused()
     await page.locator('.sidebar-close').click()
@@ -791,18 +779,18 @@ test.describe.serial('public launch path', () => {
     await page.goto('/')
 
     for (const section of [
-      'Live',
-      'Control',
-      'Runs',
-      'Changes',
-      'Overview',
-      'Sessions',
-      'Activity',
-      'Library',
-      'Memory',
-      'Themes',
+      'live',
+      'control',
+      'runs',
+      'changes',
+      'overview',
+      'sessions',
+      'activity',
+      'library',
+      'memory',
+      'themes',
     ]) {
-      await page.getByRole('button', { name: new RegExp(section, 'i') }).first().click()
+      await page.goto(`/#/${section}`)
       expect(await unreadableVisibleText(page), `${section} contains text below 8px`).toEqual([])
     }
   })

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const clientEntry = path.join(projectRoot, 'dist', 'index.html')
@@ -17,4 +17,4 @@ if (!existsSync(clientEntry) || !existsSync(serverEntry)) {
   if (build.status !== 0) process.exit(build.status || 1)
 }
 
-await import(serverEntry)
+await import(pathToFileURL(serverEntry).href)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'themes', index: '12', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '0' },
 ]
 
-const MOBILE_NAV_IDS: ViewId[] = ['live', 'control', 'runs', 'fleet']
+const MOBILE_NAV_IDS: ViewId[] = ['live', 'runs', 'sessions', 'fleet']
 
 type ThemeId = 'operator' | 'event-horizon' | 'minimal-calm'
 
@@ -511,6 +511,7 @@ function App() {
             onMenu={openMobileNav}
             onPalette={() => setPaletteOpen(true)}
             onRefresh={() => void load(true)}
+            onOpenThemes={() => setActiveView('themes')}
             onTogglePrivacy={() => setPrivacyMode((enabled) => !enabled)}
           />
 
@@ -526,10 +527,6 @@ function App() {
                 privacyMode={privacyMode}
                 onOpen={() => {
                   if (!attention.primary) return
-                  if (attention.primary.kind === 'permission') {
-                    setActiveView('control')
-                    return
-                  }
                   openSession(attention.primary.sessionId)
                 }}
               />
@@ -833,7 +830,7 @@ function Sidebar({
         </div>
         <div className="sidebar-foot">
           <span>UI / {packageJson.version}</span>
-          <span>ACP CONTROL</span>
+          <span>Control</span>
         </div>
       </aside>
     </>
@@ -849,6 +846,7 @@ function TopBar({
   onMenu,
   onPalette,
   onRefresh,
+  onOpenThemes,
   onTogglePrivacy,
 }: {
   active: ViewId
@@ -859,6 +857,7 @@ function TopBar({
   onMenu: () => void
   onPalette: () => void
   onRefresh: () => void
+  onOpenThemes: () => void
   onTogglePrivacy: () => void
 }) {
   const activeItem = NAV_ITEMS.find((item) => item.id === active)!
@@ -874,7 +873,7 @@ function TopBar({
       <div className="topbar-actions">
         <div className="sync-state">
           <span className={`status-dot ${connected ? 'is-live' : ''}`} />
-          <span className="sync-copy">{connected ? 'Event stream' : 'Reconnecting'}</span>
+          <span className="sync-copy">{connected ? 'Live updates' : 'Reconnecting'}</span>
           <span className="sync-time">{generatedAt ? timeAgo(generatedAt) : '—'}</span>
         </div>
         <button
@@ -886,6 +885,15 @@ function TopBar({
         >
           <ShieldCheck size={15} />
           <span>{privacyMode ? 'Privacy on' : 'Privacy'}</span>
+        </button>
+        <button
+          className={`privacy-toggle ${active === 'themes' ? 'is-active' : ''}`}
+          type="button"
+          aria-pressed={active === 'themes'}
+          onClick={onOpenThemes}
+        >
+          <Palette size={15} />
+          <span>Themes</span>
         </button>
         <button className="command-trigger" onClick={onPalette}>
           <Search size={15} />
@@ -970,9 +978,9 @@ function LiveView({
           tone={live?.attentionCount ? 'coral' : 'paper'}
         />
         <LiveSummaryMetric
-          label="Transport"
-          value={connected ? 'SSE' : '—'}
-          detail="filesystem events → browser"
+          label="Updates"
+          value={connected ? 'Live' : '—'}
+          detail="local session changes"
           tone={connected ? 'lime' : 'coral'}
         />
       </section>
@@ -1166,8 +1174,8 @@ function FirstRunOnboarding({
         <div>
           <span className="kicker">
             {setup?.ready
-              ? 'FIRST CONTACT / READY'
-              : setup ? 'FIRST CONTACT / SETUP REQUIRED' : 'FIRST CONTACT / CHECKING'}
+              ? 'Ready to start'
+              : setup ? 'Setup needed' : 'Checking setup'}
           </span>
           <h2>Zero to live<br /><em>in three moves.</em></h2>
         </div>
@@ -1806,18 +1814,21 @@ function LibraryView({
 }) {
   const privacy = usePrivacy()
   const filtered = data.library.filter((item) => item.name.toLowerCase().includes(query.trim().toLowerCase()))
+  const [selectedKey, setSelectedKey] = useState('')
   const groups = [
     { kind: 'skill' as const, label: 'Skills', icon: Sparkles, copy: 'Reusable instruction packages available to Grok.' },
     { kind: 'agent' as const, label: 'Agent profiles', icon: Bot, copy: 'Specialized operating roles for delegated work.' },
     { kind: 'plugin' as const, label: 'Marketplace manifests', icon: Box, copy: 'Plugin packages discovered in the local cache.' },
   ]
+  const ordered = groups.flatMap((group) => filtered.filter((item) => item.kind === group.kind))
+  const selected = ordered.find((item) => `${item.kind}:${item.source}:${item.name}` === selectedKey) || ordered[0] || null
   return (
     <>
       <PageIntro
         index="10"
         eyebrow="Capability library"
         title={<>What Grok can<br /><em>reach for.</em></>}
-        description="The local skills, agent profiles, and marketplace packages shaping every run."
+        description="Inspect a local skill, agent profile, or marketplace package. Bodies stay on disk."
       />
       <div className="view-toolbar">
         <SearchField value={query} onChange={onQuery} placeholder="Filter the capability index…" />
@@ -1831,18 +1842,33 @@ function LibraryView({
             <Panel key={group.kind} index={`04${String.fromCharCode(65 + groupIndex)}`} title={group.label} meta={`${items.length} found`}>
               <div className="library-intro"><Icon size={20} /><p>{group.copy}</p></div>
               <div className="capability-list">
-                {items.length ? items.map((item) => (
-                  <div key={`${item.kind}:${item.source}:${item.name}`}>
-                    <span className="capability-icon">{item.kind === 'skill' ? 'S' : item.kind === 'agent' ? 'A' : 'P'}</span>
-                    <strong>{privacy.capability(item.name, group.label.slice(0, -1))}</strong>
-                    <span className={`source-tag source-${item.source}`}>{item.source}</span>
-                  </div>
-                )) : <EmptyInline>No matching {group.label.toLowerCase()}.</EmptyInline>}
+                {items.length ? items.map((item) => {
+                  const key = `${item.kind}:${item.source}:${item.name}`
+                  return (
+                    <button
+                      type="button"
+                      key={key}
+                      className={selected && `${selected.kind}:${selected.source}:${selected.name}` === key ? 'is-selected' : ''}
+                      onClick={() => setSelectedKey(key)}
+                    >
+                      <span className="capability-icon">{item.kind === 'skill' ? 'S' : item.kind === 'agent' ? 'A' : 'P'}</span>
+                      <strong>{privacy.capability(item.name, group.label.slice(0, -1))}</strong>
+                      <span className={`source-tag source-${item.source}`}>{item.source}</span>
+                    </button>
+                  )
+                }) : <EmptyInline>No matching {group.label.toLowerCase()}.</EmptyInline>}
               </div>
             </Panel>
           )
         })}
       </section>
+      {selected && (
+        <section className="inventory-detail section-gap" aria-live="polite">
+          <small>Selected capability</small>
+          <strong>{privacy.capability(selected.name, selected.kind)}</strong>
+          <p>{selected.kind} from {selected.source} source. The file body is not loaded into the dashboard.</p>
+        </section>
+      )}
     </>
   )
 }
@@ -1850,20 +1876,22 @@ function LibraryView({
 function MemoryView({ data }: { data: DashboardPayload }) {
   const privacy = usePrivacy()
   const scopes = ['global', 'workspace', 'session']
+  const [selectedName, setSelectedName] = useState(data.memory[0]?.name || '')
+  const selected = data.memory.find((item) => item.name === selectedName) || data.memory[0] || null
   return (
     <>
       <PageIntro
         index="11"
         eyebrow="Durable recall"
         title={<>Memory without<br /><em>the mystery.</em></>}
-        description="A privacy-conscious inventory of Grok’s durable Markdown memory. Content stays on disk and is not rendered here."
+        description="Inspect which memory files Grok can see. File bodies stay on disk and are not rendered here."
       />
       <section className="memory-hero">
         <div className="memory-symbol"><BrainCircuit size={44} strokeWidth={1.2} /><span /></div>
         <div>
-          <span className="kicker">Experimental memory index</span>
+          <span className="kicker">Local memory index</span>
           <strong>{data.memory.length}</strong>
-          <p>local artifacts across {new Set(data.memory.map((item) => item.scope)).size} scopes</p>
+          <p>files across {new Set(data.memory.map((item) => item.scope)).size} scopes</p>
         </div>
         <div className="privacy-badge"><ShieldCheck size={18} /><span><strong>Metadata only</strong><small>Prompts and memory body text stay hidden.</small></span></div>
       </section>
@@ -1874,17 +1902,29 @@ function MemoryView({ data }: { data: DashboardPayload }) {
             <Panel key={scope} index={`05${String.fromCharCode(65 + scopeIndex)}`} title={`${scope[0].toUpperCase()}${scope.slice(1)} memory`} meta={`${items.length} files`}>
               <div className="memory-file-list">
                 {items.length ? items.map((item) => (
-                  <div key={item.name}>
+                  <button
+                    type="button"
+                    key={item.name}
+                    className={selected?.name === item.name ? 'is-selected' : ''}
+                    onClick={() => setSelectedName(item.name)}
+                  >
                     <Archive size={15} />
                     <span><strong>{privacy.memory(item.name)}</strong><small>{timeAgo(item.updatedAt)}</small></span>
                     <em>{formatBytes(item.bytes)}</em>
-                  </div>
+                  </button>
                 )) : <EmptyInline>No {scope} memory files found.</EmptyInline>}
               </div>
             </Panel>
           )
         })}
       </section>
+      {selected && (
+        <section className="inventory-detail section-gap" aria-live="polite">
+          <small>Selected memory file</small>
+          <strong>{privacy.memory(selected.name)}</strong>
+          <p>{selected.scope} scope · {formatBytes(selected.bytes)} · updated {timeAgo(selected.updatedAt)}. The Markdown body is not loaded into the dashboard.</p>
+        </section>
+      )}
     </>
   )
 }

--- a/src/navigation.test.ts
+++ b/src/navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   collectAttention,
   formatHash,
+  NAV_GROUPS,
   navBadgeCount,
   parseHash,
 } from './navigation'
@@ -33,6 +34,22 @@ describe('hash routes', () => {
 
   it('falls back to Live for unknown views and keeps the session id', () => {
     expect(parseHash('#/unknown/abc')).toEqual({ view: 'live', sessionId: 'abc' })
+  })
+})
+
+describe('primary nav', () => {
+  it('keeps Control, Library, Memory, and Themes off the primary rail', () => {
+    const items = NAV_GROUPS.flatMap((group) => group.items)
+    expect(items).toEqual([
+      'live',
+      'runs',
+      'changes',
+      'sessions',
+      'overview',
+      'activity',
+      'usage',
+      'fleet',
+    ])
   })
 })
 
@@ -87,8 +104,8 @@ describe('attention', () => {
       sessionId: 'managed-1',
       title: 'Write the verified fixture',
     })
-    expect(navBadgeCount('control', attention)).toBe(1)
-    expect(navBadgeCount('live', attention)).toBe(1)
+    expect(navBadgeCount('live', attention)).toBe(2)
+    expect(navBadgeCount('control', attention)).toBe(0)
     expect(navBadgeCount('sessions', attention)).toBe(0)
   })
 })

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -33,9 +33,9 @@ export const VIEW_IDS: ViewId[] = [
 ]
 
 export const NAV_GROUPS: Array<{ id: string; label: string; items: ViewId[] }> = [
-  { id: 'work', label: 'Work', items: ['live', 'control', 'runs', 'changes', 'sessions'] },
+  { id: 'work', label: 'Work', items: ['live', 'runs', 'changes', 'sessions'] },
   { id: 'look-back', label: 'Look back', items: ['overview', 'activity', 'usage'] },
-  { id: 'system', label: 'System', items: ['fleet', 'library', 'memory', 'themes'] },
+  { id: 'system', label: 'System', items: ['fleet'] },
 ]
 
 export function isViewId(value: string): value is ViewId {
@@ -88,7 +88,6 @@ export function collectAttention(
 }
 
 export function navBadgeCount(view: ViewId, attention: AttentionState): number {
-  if (view === 'live') return attention.liveCount
-  if (view === 'control') return attention.permissionCount
+  if (view === 'live') return attention.permissionCount + attention.liveCount
   return 0
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2659,13 +2659,26 @@ kbd {
   overflow: auto;
 }
 
-.capability-list > div {
+.capability-list > div,
+.capability-list > button {
+  width: 100%;
   min-height: 43px;
+  padding: 0;
   display: grid;
   grid-template-columns: 25px 1fr auto;
   align-items: center;
   gap: 8px;
+  border: 0;
   border-bottom: 1px solid rgba(255,255,255,.055);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.capability-list > button.is-selected,
+.memory-file-list > button.is-selected {
+  background: color-mix(in srgb, var(--lime) 8%, transparent);
 }
 
 .capability-list strong {
@@ -2798,13 +2811,21 @@ kbd {
   gap: 1px;
 }
 
-.memory-file-list > div {
+.memory-file-list > div,
+.memory-file-list > button {
+  width: 100%;
   min-height: 53px;
+  padding: 0;
   display: grid;
   grid-template-columns: 20px 1fr auto;
   align-items: center;
   gap: 7px;
+  border: 0;
   border-bottom: 1px solid var(--line);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
 .memory-file-list svg {
@@ -2830,6 +2851,28 @@ kbd {
   color: var(--muted);
   font-size: var(--type-label);
   font-style: normal;
+}
+
+.inventory-detail {
+  padding: 18px 20px;
+  border: 1px solid var(--line);
+  background: rgba(13, 15, 12, .72);
+}
+
+.inventory-detail small {
+  color: var(--muted);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.inventory-detail strong {
+  display: block;
+  margin: 8px 0 6px;
+}
+
+.inventory-detail p {
+  margin: 0;
+  color: var(--muted);
 }
 
 .drawer-layer,

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -113,12 +113,12 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
         <div>
           <span className={`status-dot ${control?.connected ? 'is-live' : ''}`} />
           <strong>{control?.connected
-            ? 'ACP CONTROL LINKED'
+            ? 'Control connected'
             : control?.reconnecting
-              ? `RECONNECTING CONTROL · ${control.reconnectAttempt}`
+              ? `Reconnecting · ${control.reconnectAttempt}`
               : control?.starting
-                ? 'STARTING CONTROL'
-                : 'CONTROL OFFLINE'}</strong>
+                ? 'Starting control'
+                : 'Control offline'}</strong>
           <small>{control?.agentName || 'Grok'} {control?.agentVersion}</small>
         </div>
         <div><span>MANAGED LANES</span><strong>{control?.sessions.length || 0}</strong></div>


### PR DESCRIPTION
## Outcome

- Needs you always opens the session console, including pending approvals, so answering Grok no longer hops to Control.
- Primary nav is Live, Runs, Changes, Sessions, history, and Fleet. Control, Library, Memory, and Themes stay on hash routes and the command palette; Themes also sits next to Privacy.
- Library and Memory lists are inspectable metadata instead of dead inventories.
- First-run and control copy is quieter: Setup needed, Ready to start, Control connected.
- Windows `npm start` loads the server through a `file:` URL so drive letters are not treated as ESM schemes. This includes the fix from #26.

## Verification

- [x] `npm test` and `npm run check`
- [x] `npx playwright test e2e/launch.spec.ts` (20 passed)
- [x] Desktop: Live starts in place, Control off the rail, Themes in the header, `#/control` / `#/library` / `#/memory` still work, palette still reaches Control
- [x] Mobile: bottom nav is Live / Runs / Sessions / Fleet
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added

## Test plan

- [ ] Empty Live still starts a session without leaving the room
- [ ] Click Needs you on a permission and confirm the session console, not Control
- [ ] Confirm Control, Library, Memory, and Themes are gone from the sidebar and still open from the palette or hash
- [ ] On Windows, `npm start` after a local build reaches the dashboard


Made with [Cursor](https://cursor.com)