### PR TITLE
Open live agents in the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Opening a live agent goes straight to the session. Live keeps the roster
+  and no longer duplicates the transcript.
+- Dropped the `/ 12` page counts that implied twelve peer rooms.
+- Quieter customer copy: Start session, Sign in, Session, Live updates.
 - Fixed Windows `npm start` by loading the server through a `file:` URL so
   drive letters are not treated as ESM schemes.
 - Needs you now opens the session console for both live attention and

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -228,8 +228,10 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByRole('heading', { name: 'Start a session' })).toBeVisible()
     await expect(page.getByLabel('WORKSPACE')).toBeVisible()
     await expect(page.getByLabel('INSTRUCTION')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'LAUNCH AGENT' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Start session' })).toBeVisible()
     await expect(page).toHaveURL(/#\/live$/)
+    await expect(page.getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('button', { name: /Control/ })).toHaveCount(0)
   })
 
   test('discovers a newly registered Grok CLI session over the live stream', async ({ page }) => {
@@ -238,7 +240,7 @@ test.describe.serial('public launch path', () => {
 
     await expect(page.getByText('Confidential Launch').first()).toBeVisible({ timeout: 10_000 })
     await expect(page.getByText('1', { exact: true }).first()).toBeVisible()
-    await expect(page.getByText(/Inspect secret-client/).first()).toBeVisible()
+    await expect(page.getByText(/secret-client/).first()).toBeVisible()
     await expect(page.getByText(/PID \d+/).first()).toBeVisible()
     await page.getByRole('button', { name: /Open Session/ }).click()
     await expect(page).toHaveURL(new RegExp(`#/live/${sessionId}$`))
@@ -252,14 +254,14 @@ test.describe.serial('public launch path', () => {
   test('reconnects the browser event stream after a server interruption', async ({ page }) => {
     await page.goto('/')
     await page.getByRole('button', { name: /Overview/ }).click()
-    await expect(page.getByText('EVENT STREAM LINKED')).toBeVisible()
+    await expect(page.getByText('Updates connected')).toBeVisible()
 
     const disconnected = await page.request.post('/api/test/disconnect-events')
     expect(disconnected.ok()).toBe(true)
     expect((await disconnected.json()).disconnected).toBeGreaterThan(0)
-    await expect(page.getByText('EVENT STREAM RECONNECTING')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Updates reconnecting')).toBeVisible({ timeout: 10_000 })
 
-    await expect(page.getByText('EVENT STREAM LINKED')).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByText('Updates connected')).toBeVisible({ timeout: 15_000 })
   })
 
   test('shows bounded process, test, and external-call runtime intelligence', async ({ page }) => {
@@ -301,7 +303,7 @@ test.describe.serial('public launch path', () => {
 
     const dialog = page.getByRole('dialog', { name: /Session console:/ })
     await expect(dialog).toBeVisible()
-    await expect(page.getByText(/SESSION CONSOLE/)).toBeVisible()
+    await expect(page.getByText(/^Session · /)).toBeVisible()
     await expect(page.getByText('Chat with this agent, review its activity, and inspect changes.')).toBeVisible()
     await expect(page.getByRole('navigation', { name: 'Session console sections' })).toBeVisible()
     const prompt = page.getByPlaceholder('Send a follow-up to this session…')
@@ -323,7 +325,9 @@ test.describe.serial('public launch path', () => {
   test('redacts sensitive runtime data and persists Privacy Mode', async ({ page }) => {
     await page.goto('/')
     await expect(page.getByText('Confidential Launch').first()).toBeVisible()
+    await page.getByRole('button', { name: 'Open Session' }).click()
     await expect(page.getByText(/192\.168\.1\.42/)).toBeVisible()
+    await page.getByRole('button', { name: 'Close session console panel' }).click()
 
     await page.getByRole('button', { name: 'Privacy' }).click()
     await expect(page.getByRole('button', { name: 'Privacy on' })).toHaveAttribute('aria-pressed', 'true')
@@ -371,7 +375,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill(instruction)
-    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+    await page.getByRole('button', { name: 'Start session' }).click()
 
     await expect(page.getByText('New Grok lane launched.')).toBeVisible()
     const lane = page.locator('.lane-card').filter({ hasText: instruction })
@@ -451,7 +455,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Start workflow fixture')
-    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+    await page.getByRole('button', { name: 'Start session' }).click()
 
     await page.getByRole('button', { name: /Runs/ }).click()
     await expect(page.getByRole('heading', { name: /Every run/ })).toBeVisible()
@@ -494,7 +498,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Start scaled workflow fixture')
-    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+    await page.getByRole('button', { name: 'Start session' }).click()
 
     await page.getByRole('button', { name: /Runs/ }).click()
     await expect(page.getByText('scale-check').first()).toBeVisible({ timeout: 10_000 })
@@ -562,7 +566,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Hold for permission cancellation')
-    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+    await page.getByRole('button', { name: 'Start session' }).click()
 
     const lane = page.locator('.lane-card').filter({ hasText: 'Hold for permission cancellation' })
     await expect(lane.locator('.lane-state')).toContainText('attention')
@@ -581,7 +585,7 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Control connected')).toBeVisible({ timeout: 10_000 })
     await page.getByLabel('WORKSPACE').fill(workspace)
     await page.getByLabel('INSTRUCTION').fill('Run the long-running cancellation verification')
-    await page.getByRole('button', { name: 'LAUNCH AGENT' }).click()
+    await page.getByRole('button', { name: 'Start session' }).click()
 
     const lane = page.locator('.lane-card').filter({ hasText: 'Run the long-running cancellation verification' })
     await expect(lane.locator('.lane-state')).toContainText('working')
@@ -642,7 +646,7 @@ test.describe.serial('public launch path', () => {
 
     await page.getByRole('button', { name: 'Open Session' }).click()
     await expect(page.getByRole('dialog', { name: /Session console:/ })).toBeVisible()
-    await expect(page.getByText(/SESSION CONSOLE/)).toBeVisible()
+    await expect(page.getByText(/^Session · /)).toBeVisible()
     const consoleOverflow = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
       clientWidth: document.documentElement.clientWidth,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,6 @@ import type {
   FleetSnapshot,
   FleetHostView,
   LiveAgent,
-  LiveFeedItem,
   LiveSnapshot,
   RankedDatum,
   RuntimeSnapshot,
@@ -830,7 +829,7 @@ function Sidebar({
         </div>
         <div className="sidebar-foot">
           <span>UI / {packageJson.version}</span>
-          <span>Control</span>
+          <span>Local</span>
         </div>
       </aside>
     </>
@@ -867,7 +866,7 @@ function TopBar({
         <button className="icon-button mobile-menu" onClick={onMenu} aria-label="Open navigation">
           <Menu size={19} />
         </button>
-        <span className="topbar-path">GROK / HUD /</span>
+        <span className="topbar-path">GROK /</span>
         <strong>{activeItem.label}</strong>
       </div>
       <div className="topbar-actions">
@@ -931,7 +930,6 @@ function LiveView({
 }) {
   const privacy = usePrivacy()
   const [selectedId, setSelectedId] = useState(live?.agents[0]?.id || '')
-  const feedRef = useRef<HTMLDivElement>(null)
   const agents = live?.agents || []
 
   useEffect(() => {
@@ -943,12 +941,11 @@ function LiveView({
   }, [agents, selectedId])
 
   const selected = agents.find((agent) => agent.id === selectedId) || agents[0]
-  const selectedSession = selected ? data.sessions.find((session) => session.id === selected.id) : null
 
-  useEffect(() => {
-    const feed = feedRef.current
-    if (feed) feed.scrollTop = feed.scrollHeight
-  }, [selected?.id, selected?.feed.at(-1)?.id])
+  const openAgent = (agent: LiveAgent) => {
+    const session = data.sessions.find((row) => row.id === agent.id)
+    onOpenSession(session || agent.id)
+  }
 
   return (
     <>
@@ -1024,7 +1021,10 @@ function LiveView({
                 <button
                   key={agent.id}
                   className={selected.id === agent.id ? 'is-active' : ''}
-                  onClick={() => setSelectedId(agent.id)}
+                  onClick={() => {
+                    setSelectedId(agent.id)
+                    openAgent(agent)
+                  }}
                 >
                   <span className="agent-number">A{String(index + 1).padStart(2, '0')}</span>
                   <AgentStateGlyph state={agent.state} />
@@ -1035,10 +1035,6 @@ function LiveView({
                   <ChevronRight size={15} />
                 </button>
               ))}
-            </div>
-            <div className="roster-foot">
-              <span>Registry source</span>
-              <strong>active_sessions.json</strong>
             </div>
           </aside>
 
@@ -1053,50 +1049,12 @@ function LiveView({
               </div>
               <div className="runtime-actions">
                 <AgentStatePill agent={selected} />
-                <button className="text-button" onClick={() => onOpenSession(selectedSession || selected.id)}>
+                <button className="text-button" onClick={() => openAgent(selected)}>
                   Open Session <ArrowRight size={14} />
                 </button>
               </div>
             </header>
-
-            <div className="runtime-instruments">
-              <RuntimeInstrument label="Phase" value={selected.phase.replaceAll('_', ' ')} />
-              <RuntimeInstrument label="Turns" value={formatNumber(selected.turns)} />
-              <RuntimeInstrument label="Tool calls" value={formatNumber(selected.toolCalls)} />
-              <RuntimeInstrument
-                label="Context"
-                value={selected.contextSize
-                  ? `${formatNumber(selected.contextUsed)} / ${formatNumber(selected.contextSize)}`
-                  : `${Math.round(selected.contextUsage * 100)}%`}
-              />
-              <RuntimeInstrument
-                label="Cost"
-                value={selected.costAmount
-                  ? `${selected.costAmount.toFixed(3)} ${selected.costCurrency}`
-                  : '—'}
-              />
-              <RuntimeInstrument label="Process" value={privacy.enabled ? 'PID ••••' : `PID ${selected.pid}`} />
-            </div>
-
-            {selected.currentTool && (
-              <div className="current-operation">
-                <span className="operation-pulse" />
-                <span>CURRENT OPERATION</span>
-                <strong>{privacy.content(selected.currentTool)}</strong>
-              </div>
-            )}
-
-            <div className="live-feed-head">
-              <span>Structured session stream</span>
-              <span>{selected.feed.length} recent events</span>
-            </div>
-            <div className="live-feed" aria-live="polite" ref={feedRef}>
-              {selected.feed.length ? selected.feed.map((item, index) => (
-                <LiveFeedRow item={item} index={index} key={item.id} />
-              )) : (
-                <EmptyInline>The session is open and idle. New ACP updates will appear here instantly.</EmptyInline>
-              )}
-            </div>
+            <p className="live-open-hint">Chat, approve, and inspect changes in the session.</p>
           </section>
         </section>
       )}
@@ -1271,37 +1229,6 @@ function AgentStatePill({ agent }: { agent: LiveAgent }) {
   return <span className={`agent-state-pill state-pill-${agent.state}`}><i />{label}</span>
 }
 
-function RuntimeInstrument({ label, value }: { label: string; value: string }) {
-  return <div><span>{label}</span><strong>{value}</strong></div>
-}
-
-function LiveFeedRow({ item, index }: { item: LiveFeedItem; index: number }) {
-  const privacy = usePrivacy()
-  const labels: Record<LiveFeedItem['type'], string> = {
-    user: 'YOU',
-    assistant: 'GROK',
-    thought: 'THOUGHT',
-    tool: 'TOOL',
-    plan: 'PLAN',
-    system: 'SYSTEM',
-  }
-  return (
-    <article className={`live-feed-row feed-${item.type}`}>
-      <span className="feed-sequence">{String(index + 1).padStart(2, '0')}</span>
-      <div className="feed-rail"><i /></div>
-      <div className="feed-content">
-        <header>
-          <span>{labels[item.type]}</span>
-          <strong>{privacy.content(item.title)}</strong>
-          {item.status && <em className={`tool-status status-${item.status}`}>{item.status}</em>}
-          <time>{item.timestamp && item.timestamp !== new Date(0).toISOString() ? timeAgo(item.timestamp) : 'live'}</time>
-        </header>
-        {item.text && <p>{privacy.content(item.text)}</p>}
-      </div>
-    </article>
-  )
-}
-
 function Overview({
   data,
   live,
@@ -1437,7 +1364,7 @@ function SystemCard({
       <div className="system-footer">
         <span>
           <span className={`status-dot ${connected ? 'is-live' : ''}`} />
-          {connected ? 'EVENT STREAM LINKED' : 'EVENT STREAM RECONNECTING'}
+          {connected ? 'Updates connected' : 'Updates reconnecting'}
         </span>
         <span>{privacy.path(data.grokHome)}</span>
       </div>
@@ -1942,7 +1869,7 @@ function PageIntro({
 }) {
   return (
     <header className="page-intro">
-      <div className="intro-index">{index} / 12</div>
+      <div className="intro-index">{index}</div>
       <div>
         <div className="kicker">{eyebrow}</div>
         <h1>{title}</h1>
@@ -2217,7 +2144,7 @@ function AuthScreen({ onAuthenticated }: { onAuthenticated: () => void }) {
         </label>
         {error && <div className="access-error">{error}</div>}
         <button className="launch-button" disabled={submitting}>
-          <span>{submitting ? 'VERIFYING' : 'OPEN COMMAND DECK'}</span>
+          <span>{submitting ? 'Checking…' : 'Sign in'}</span>
           <ArrowRight size={16} />
         </button>
       </form>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1041,6 +1041,12 @@ kbd {
   border-bottom: 1px solid var(--line);
 }
 
+.live-open-hint {
+  margin: 0;
+  padding: 16px 19px 22px;
+  color: var(--muted);
+}
+
 .runtime-identity {
   min-width: 0;
   display: flex;

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -92,7 +92,7 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
   return (
     <>
       <section className="page-intro changes-intro">
-        <div className="page-intro-index">04 / 12</div>
+        <div className="page-intro-index">04</div>
         <div className="page-intro-copy">
           <div className="kicker"><Braces size={14} /> Change surface</div>
           <h1>See the work.<br /><em>Before it lands.</em></h1>

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -101,9 +101,9 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
   return (
     <>
       <section className="page-intro command-intro">
-        <div className="page-intro-index">02 / 12</div>
+        <div className="page-intro-index">02</div>
         <div className="page-intro-copy">
-          <div className="kicker"><Command size={14} /> Command deck</div>
+          <div className="kicker"><Command size={14} /> Control</div>
           <h1>Don’t just watch.<br /><em>Run the room.</em></h1>
         </div>
         <p>Launch concurrent Grok agents, resume any conversation, approve sensitive work, and stop a turn without returning to the terminal.</p>
@@ -202,7 +202,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
       <section className="managed-lanes section-gap">
         <header>
           <div><span className="panel-index">03</span><h2>Managed lanes</h2></div>
-          <span>PARALLEL ACP SESSIONS</span>
+          <span>PARALLEL SESSIONS</span>
         </header>
         {control?.sessions.length ? (
           <div className="lane-grid">
@@ -314,7 +314,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
                 </div>
               </article>
             )) : (
-              <div className="stream-empty">Waiting for the first ACP session update.</div>
+              <div className="stream-empty">Waiting for the first session update.</div>
             )}
           </div>
         </section>

--- a/src/views/FleetView.tsx
+++ b/src/views/FleetView.tsx
@@ -151,7 +151,7 @@ export function FleetView({
   return (
     <>
       <header className="page-intro fleet-intro">
-        <div className="intro-index">09 / 12</div>
+        <div className="intro-index">09</div>
         <div>
           <div className="kicker"><Network size={14} /> Multi-machine monitoring</div>
           <h1>Every host.<br /><em>One quiet orbit.</em></h1>

--- a/src/views/SessionLaunchForm.tsx
+++ b/src/views/SessionLaunchForm.tsx
@@ -212,13 +212,13 @@ export function SessionLaunchForm({
         className="launch-button"
         disabled={submitting || !control?.connected || (mode === 'new' && !cwd)}
       >
-        <span>{submitting ? 'Starting…' : mode === 'new' ? 'LAUNCH AGENT' : 'SEND PROMPT'}</span>
+        <span>{submitting ? 'Starting…' : mode === 'new' ? 'Start session' : 'Send'}</span>
         <CornerDownLeft size={17} />
       </button>
       <p className="composer-note">
         {control?.connected
           ? 'Tool executions still pass through Grok’s native permission system. Nothing is silently auto-approved.'
-          : 'Control is offline. The dashboard can still watch CLI sessions, but it cannot start one until ACP reconnects.'}
+          : 'Control is offline. The dashboard can still watch CLI sessions, but it cannot start one until control reconnects.'}
       </p>
     </form>
   )

--- a/src/views/SessionWorkbench.tsx
+++ b/src/views/SessionWorkbench.tsx
@@ -242,7 +242,7 @@ export function SessionWorkbench({
     try {
       await promptControlSession(session.id, { cwd: session.cwd, prompt })
       setPrompt('')
-      setMessage(data?.managed ? 'Follow-up sent.' : 'Session attached to ACP control and resumed.')
+      setMessage(data?.managed ? 'Follow-up sent.' : 'Session attached and resumed.')
       await refresh(true)
     } catch (sendError) {
       setError(sendError instanceof Error ? sendError.message : 'Unable to send the follow-up.')
@@ -377,7 +377,7 @@ export function SessionWorkbench({
             ) : (
               <div className="workbench-title">
                 <div>
-                  <span>SESSION CONSOLE / {privacy.identifier(sessionId)}</span>
+                  <span>Session · {privacy.identifier(sessionId)}</span>
                   <h1>{privacy.sessionTitle(session?.title || `Session ${sessionId.slice(0, 8)}`, sessionId)}</h1>
                 </div>
                 <button onClick={() => setRenaming(true)} aria-label="Rename session"><Pencil size={15} /></button>
@@ -489,7 +489,7 @@ export function SessionWorkbench({
         <form className="workbench-composer" onSubmit={send}>
           <div className="composer-mode">
             {data?.managed ? <Bot size={16} /> : <Sparkles size={16} />}
-            <span>{data?.managed ? 'CONTINUE MANAGED SESSION' : 'ATTACH TO ACP + RESUME'}</span>
+            <span>{data?.managed ? 'Continue session' : 'Attach and resume'}</span>
           </div>
           <textarea
             value={prompt}
@@ -504,9 +504,9 @@ export function SessionWorkbench({
           />
           <button disabled={sending || !control?.connected || !prompt.trim() || data?.control?.state === 'stopping'}>
             {sending ? <LoaderCircle className="is-spinning" size={17} /> : <CornerDownLeft size={17} />}
-            <span>{sending ? 'SENDING' : data?.managed ? 'SEND' : 'ATTACH'}</span>
+            <span>{sending ? 'Sending' : data?.managed ? 'Send' : 'Attach'}</span>
           </button>
-          <small>{control?.connected ? '⌘ ↵ to send' : 'ACP control offline'}</small>
+          <small>{control?.connected ? '⌘ ↵ to send' : 'Control offline'}</small>
         </form>
       </section>
     </div>
@@ -776,7 +776,7 @@ function Details({ session, data }: { session: SessionRow | null; data: SessionW
     ['Sandbox', session.sandboxProfile],
     ['Created', new Date(session.createdAt).toLocaleString()],
     ['Updated', new Date(session.updatedAt).toLocaleString()],
-    ['Runtime source', data?.live ? privacy.enabled ? 'CLI PID ••••' : `CLI PID ${data.live.pid}` : data?.managed ? 'Grok UI ACP' : 'Local archive'],
+    ['Runtime source', data?.live ? privacy.enabled ? 'CLI PID ••••' : `CLI PID ${data.live.pid}` : data?.managed ? 'Grok UI control' : 'Local archive'],
     ['Managed', data?.managed ? 'Yes — durable control record' : 'No — attach with a follow-up'],
     ['Archive state', session.archived ? 'Archived in Grok UI' : 'Active'],
     ['Disk footprint', `${compact(session.diskBytes)} bytes`],

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -143,7 +143,7 @@ export function UsageView() {
   return (
     <>
       <header className="page-intro">
-        <div className="intro-index">08 / 12</div>
+        <div className="intro-index">08</div>
         <div>
           <div className="kicker">Persistent usage ledger</div>
           <h1>Know what was used,<br /><em>and how we know.</em></h1>

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -170,7 +170,7 @@ export function WorkflowsView({
   return (
     <>
       <header className="page-intro">
-        <div className="intro-index">03 / 12</div>
+        <div className="intro-index">03</div>
         <div>
           <div className="kicker">Cross-session orchestration</div>
           <h1>Every run.<br /><em>One command field.</em></h1>


### PR DESCRIPTION
## Outcome

- Clicking a live agent opens the session. Live keeps the roster and no longer duplicates the transcript.
- Page indexes no longer say `/ 12`, which implied twelve peer rooms after the rail was narrowed.
- Customer copy is quieter: Start session, Sign in, Session, Updates connected. ACP/HUD/LAUNCH AGENT are off the customer path.

## Verification

- [x] `npm test` and `npm run check`
- [x] `npx playwright test e2e/launch.spec.ts` (20 passed)
- [x] Desktop: Live start form, no `/ 12` or HUD, Overview still opens a session
- [x] Existing Control, preview, privacy, and first-run journeys kept in e2e
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added

## Test plan

- [ ] Empty Live still starts a session in place
- [ ] A live agent opens the session from the roster or Open Session
- [ ] Closing the session returns to Live without a broken feed
- [ ] First-run still shows Setup needed / Ready to start / Start session


Made with [Cursor](https://cursor.com)