### PR TITLE
Put two-week activity on Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Overview now holds the two-week activity matrix. Activity stays on the
+  hash route and command palette instead of competing in the primary nav.
+- Hidden the dead Start session button while control is offline so first-run
+  does not look broken.
 - Opening a live agent goes straight to the session. Live keeps the roster
   and no longer duplicates the transcript.
 - Dropped the `/ 12` page counts that implied twelve peer rooms.

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -232,6 +232,8 @@ test.describe.serial('public launch path', () => {
     await expect(page).toHaveURL(/#\/live$/)
     await expect(page.getByRole('navigation', { name: 'Primary navigation' })
       .getByRole('button', { name: /Control/ })).toHaveCount(0)
+    await expect(page.getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('button', { name: /Activity/ })).toHaveCount(0)
   })
 
   test('discovers a newly registered Grok CLI session over the live stream', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1243,6 +1243,12 @@ function Overview({
   onNavigate: (view: ViewId) => void
 }) {
   const recent = data.sessions.filter((session) => !session.archived).slice(0, 6)
+  const activityTotals = data.activity.reduce((acc, day) => ({
+    turns: acc.turns + day.turns,
+    tools: acc.tools + day.toolCalls,
+    errors: acc.errors + day.errors,
+    lines: acc.lines + day.linesChanged,
+  }), { turns: 0, tools: 0, errors: 0, lines: 0 })
   return (
     <>
       <PageIntro
@@ -1288,24 +1294,19 @@ function Overview({
         />
       </section>
 
-      <section className="two-col-grid section-gap">
-        <Panel
-          className="activity-panel"
-          index="02"
-          title="Fourteen-day signal"
-          action={<button className="text-button" onClick={() => onNavigate('activity')}>Full telemetry <ArrowRight size={14} /></button>}
-        >
-          <ActivityChart days={data.activity} />
-        </Panel>
-        <Panel index="03" title="Tool signature" meta={`${data.tools.length} detected`}>
-          <RankedBars data={data.tools.slice(0, 6)} empty="No tool signals recorded yet." />
-        </Panel>
+      <section className="signal-metrics section-gap">
+        <SignalMetric label="Turns" value={formatNumber(activityTotals.turns)} icon={TimerReset} />
+        <SignalMetric label="Tool calls" value={formatNumber(activityTotals.tools)} icon={ToolCase} />
+        <SignalMetric label="Lines moved" value={formatNumber(activityTotals.lines)} icon={FileCode2} />
+        <SignalMetric label="Errors" value={formatNumber(activityTotals.errors)} icon={CircleAlert} warning={activityTotals.errors > 0} />
       </section>
-
+      <Panel className="wide-activity section-gap" index="02" title="Last 14 days">
+        <ActivityMatrix days={data.activity} />
+      </Panel>
       <section className="two-col-grid section-gap lower-grid">
         <Panel
           className="recent-panel"
-          index="04"
+          index="03"
           title="Recent sessions"
           meta={`${live?.activeCount || 0} live now`}
           action={<button className="text-button" onClick={() => onNavigate('sessions')}>View archive <ArrowRight size={14} /></button>}
@@ -1313,6 +1314,9 @@ function Overview({
           <SessionList sessions={recent} onOpen={onOpenSession} />
         </Panel>
         <div className="side-stack">
+          <Panel index="04" title="Tool signature" meta={`${data.tools.length} detected`}>
+            <RankedBars data={data.tools.slice(0, 6)} empty="No tool signals recorded yet." />
+          </Panel>
           <Panel index="05" title="Model mix" meta={`${data.models.length} in rotation`}>
             <ModelMix data={data.models} />
           </Panel>
@@ -1343,7 +1347,7 @@ function SystemCard({
       <div className="system-card-copy">
         <div className="kicker"><Zap size={14} fill="currentColor" /> Runtime corpus</div>
         <div className="hero-number">{formatNumber(data.stats.sessions)}</div>
-        <div className="hero-label">SESSIONS ON RECORD</div>
+        <div className="hero-label">Sessions recorded</div>
         <div className="system-readouts">
           <div><span>Live agents</span><strong>{live?.activeCount || 0}</strong></div>
           <div><span>Capabilities</span><strong>{data.stats.skills}</strong></div>
@@ -1355,7 +1359,7 @@ function SystemCard({
         <div className="orbit orbit-two" />
         <div className="orbit-center">
           <span>{Math.round(health)}</span>
-          <small title="Calculated from recorded errors per turn">DERIVED HEALTH</small>
+          <small title="Calculated from recorded errors per turn">Health</small>
         </div>
         <div className="orbit-node node-one" />
         <div className="orbit-node node-two" />
@@ -1432,38 +1436,6 @@ function Panel({
       </header>
       <div className="panel-body">{children}</div>
     </section>
-  )
-}
-
-function ActivityChart({ days }: { days: ActivityDay[] }) {
-  const max = Math.max(1, ...days.map((day) => day.toolCalls))
-  const total = days.reduce((sum, day) => sum + day.toolCalls, 0)
-  const peak = [...days].sort((a, b) => b.toolCalls - a.toolCalls)[0]
-  return (
-    <div className="activity-chart">
-      <div className="chart-summary">
-        <div><strong>{formatNumber(total)}</strong><span>tool events</span></div>
-        <div><strong>{formatNumber(days.reduce((sum, day) => sum + day.turns, 0))}</strong><span>turns</span></div>
-        <div><strong>{peak?.label || '—'}</strong><span>peak day</span></div>
-      </div>
-      <div className="bar-chart" role="img" aria-label="Tool calls by day over the last fourteen days">
-        {days.map((day, index) => (
-          <div className="bar-column" key={day.date} title={`${day.date}: ${day.toolCalls} tool calls`}>
-            <div className="bar-track">
-              <div
-                className={`bar-fill ${day.errors ? 'has-error' : ''}`}
-                style={{ height: `${Math.max(4, (day.toolCalls / max) * 100)}%`, animationDelay: `${index * 35}ms` }}
-              />
-            </div>
-            <span>{day.label}</span>
-          </div>
-        ))}
-      </div>
-      <div className="chart-legend">
-        <span><i className="legend-lime" /> Tool volume</span>
-        <span><i className="legend-coral" /> Error present</span>
-      </div>
-    </div>
   )
 }
 

--- a/src/navigation.test.ts
+++ b/src/navigation.test.ts
@@ -38,7 +38,7 @@ describe('hash routes', () => {
 })
 
 describe('primary nav', () => {
-  it('keeps Control, Library, Memory, and Themes off the primary rail', () => {
+  it('keeps Control, Activity, Library, Memory, and Themes off the primary rail', () => {
     const items = NAV_GROUPS.flatMap((group) => group.items)
     expect(items).toEqual([
       'live',
@@ -46,7 +46,6 @@ describe('primary nav', () => {
       'changes',
       'sessions',
       'overview',
-      'activity',
       'usage',
       'fleet',
     ])

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -34,7 +34,7 @@ export const VIEW_IDS: ViewId[] = [
 
 export const NAV_GROUPS: Array<{ id: string; label: string; items: ViewId[] }> = [
   { id: 'work', label: 'Work', items: ['live', 'runs', 'changes', 'sessions'] },
-  { id: 'look-back', label: 'Look back', items: ['overview', 'activity', 'usage'] },
+  { id: 'look-back', label: 'Look back', items: ['overview', 'usage'] },
   { id: 'system', label: 'System', items: ['fleet'] },
 ]
 

--- a/src/views/SessionLaunchForm.test.ts
+++ b/src/views/SessionLaunchForm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { listResumable, uniqueWorkspaces } from './SessionLaunchForm'
+import { canLaunchSession, listResumable, uniqueWorkspaces } from './SessionLaunchForm'
 import type { ControlSnapshot, DashboardPayload, LiveSnapshot, SessionRow } from '../types'
 
 function session(id: string, cwd: string, archived = false): SessionRow {
@@ -48,5 +48,11 @@ describe('session launch helpers', () => {
     )
 
     expect(rows.map((row) => row.id)).toEqual(['managed', 'cli'])
+  })
+
+  it('only launches when control is connected', () => {
+    expect(canLaunchSession(null)).toBe(false)
+    expect(canLaunchSession({ connected: false } as ControlSnapshot)).toBe(false)
+    expect(canLaunchSession({ connected: true } as ControlSnapshot)).toBe(true)
   })
 })

--- a/src/views/SessionLaunchForm.tsx
+++ b/src/views/SessionLaunchForm.tsx
@@ -24,6 +24,10 @@ export function uniqueWorkspaces(data: DashboardPayload, live: LiveSnapshot | nu
   ].filter(Boolean))]
 }
 
+export function canLaunchSession(control: ControlSnapshot | null): boolean {
+  return Boolean(control?.connected)
+}
+
 export function listResumable(
   data: DashboardPayload,
   control: ControlSnapshot | null,
@@ -125,6 +129,24 @@ export function SessionLaunchForm({
     }
   }
 
+  if (!canLaunchSession(control)) {
+    return (
+      <section className="composer-panel panel-cut">
+        <header>
+          <div>
+            <span className="panel-index">{index}</span>
+            <h2>{heading}</h2>
+          </div>
+        </header>
+        <p className="composer-note">
+          {control?.reconnecting
+            ? 'Reconnecting control. CLI sessions still appear here.'
+            : 'Control is offline. CLI sessions still appear here. Starting a session from the dashboard needs control.'}
+        </p>
+      </section>
+    )
+  }
+
   return (
     <form className="composer-panel panel-cut" onSubmit={submit}>
       <header>
@@ -216,9 +238,7 @@ export function SessionLaunchForm({
         <CornerDownLeft size={17} />
       </button>
       <p className="composer-note">
-        {control?.connected
-          ? 'Tool executions still pass through Grok’s native permission system. Nothing is silently auto-approved.'
-          : 'Control is offline. The dashboard can still watch CLI sessions, but it cannot start one until control reconnects.'}
+        Tool executions still pass through Grok’s native permission system. Nothing is silently auto-approved.
       </p>
     </form>
   )


### PR DESCRIPTION
## Outcome

- Overview now shows the two-week activity matrix. Activity is off the primary rail and stays on the hash route and command palette.
- Look back is Overview and Usage — one history room, one cost room.
- First-run no longer shows a disabled Start session button while control is offline.

## Verification

- [x] `npm test` and `npm run check`
- [x] `npx playwright test e2e/launch.spec.ts` (20 passed)
- [x] Desktop: Activity gone from the sidebar, Last 14 days on Overview, Usage and Fleet still there
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added

## Test plan

- [ ] Overview shows turns/tools/lines/errors and the 14-day matrix
- [ ] Activity is absent from the sidebar and still opens at `#/activity`
- [ ] Empty Live with control offline explains the wait instead of a dead Start session button
- [ ] First-run with control connected still shows Start session


Made with [Cursor](https://cursor.com)