### PR TITLE
Put Grok plan review and dispatch options in the rooms people already use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Live groups sessions the way Grok’s dashboard does and lets you peek or
+  reply without opening a new room.
+- Session launch can start in plan mode, set Ask/Auto/Always-approve, use a
+  worktree, and pick from `grok models`.
+- Session console reviews ACP plans, shows todos and queued follow-ups, and
+  can compact, rewind, fork, export Markdown, or delete the Grok session.
+- Library inspects the current workspace through `grok inspect`. Runs can
+  author a workflow on the selected session.
 - Overview now holds the two-week activity matrix. Activity stays on the
   hash route and command palette instead of competing in the primary nav.
 - Hidden the dead Start session button while control is offline so first-run

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -228,6 +228,9 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByRole('heading', { name: 'Start a session' })).toBeVisible()
     await expect(page.getByLabel('WORKSPACE')).toBeVisible()
     await expect(page.getByLabel('INSTRUCTION')).toBeVisible()
+    await expect(page.getByLabel('PERMISSIONS')).toBeVisible()
+    await expect(page.getByLabel('PLAN FIRST')).toBeVisible()
+    await expect(page.getByLabel('WORKTREE')).toBeVisible()
     await expect(page.getByRole('button', { name: 'Start session' })).toBeVisible()
     await expect(page).toHaveURL(/#\/live$/)
     await expect(page.getByRole('navigation', { name: 'Primary navigation' })
@@ -371,6 +374,23 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByText('Preview is offline')).toBeVisible()
   })
 
+  test('reviews a Grok plan from the session console', async ({ page }) => {
+    await page.goto('/#/live')
+    const created = await page.request.post('/api/control/sessions', {
+      data: { cwd: workspace, prompt: 'Draft a plan fixture', planMode: true },
+    })
+    expect(created.ok()).toBe(true)
+    const session = await created.json()
+    await page.goto(`/#/live/${session.id}`)
+    await expect(page.getByText('Plan review')).toBeVisible({ timeout: 10_000 })
+    await page.getByRole('button', { name: 'Approve' }).click()
+    await expect.poll(async () => {
+      const snapshot = await (await page.request.get('/api/control')).json()
+      const row = snapshot.sessions.find((item: { id: string }) => item.id === session.id)
+      return row?.plan?.status
+    }, { timeout: 10_000 }).toBe('planning')
+  })
+
   test('launches and approves a managed ACP control session', async ({ page }, testInfo) => {
     const instruction = `Run the public release verification attempt ${testInfo.repeatEachIndex + 1}-${testInfo.retry + 1}`
     await page.goto('/#/control')
@@ -380,6 +400,7 @@ test.describe.serial('public launch path', () => {
     await page.getByRole('button', { name: 'Start session' }).click()
 
     await expect(page.getByText('New Grok lane launched.')).toBeVisible()
+    await expect(page.locator('.managed-stream').getByRole('heading', { name: instruction })).toBeVisible()
     const lane = page.locator('.lane-card').filter({ hasText: instruction })
     const approval = page.locator('.approval-card').filter({ hasText: 'Write the verified fixture' }).last()
     await expect(approval).toBeVisible()

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -331,7 +331,7 @@ test.describe.serial('public launch path', () => {
     await page.goto('/')
     await expect(page.getByText('Confidential Launch').first()).toBeVisible()
     await page.getByRole('button', { name: 'Open Session' }).click()
-    await expect(page.getByText(/192\.168\.1\.42/)).toBeVisible()
+    await expect(page.getByText(/192\.168\.1\.42/).first()).toBeVisible()
     await page.getByRole('button', { name: 'Close session console panel' }).click()
 
     await page.getByRole('button', { name: 'Privacy' }).click()

--- a/scripts/fake-grok-e2e.mjs
+++ b/scripts/fake-grok-e2e.mjs
@@ -21,6 +21,16 @@ if (args[0] === 'models') {
   process.exit(0)
 }
 
+if (args[0] === 'inspect') {
+  console.log('config: e2e\nskills: 1\nplugins: 0\nhooks: 0\nmcp: 0')
+  process.exit(0)
+}
+
+if (args[0] === 'sessions' && args[1] === 'delete') {
+  console.log(`deleted ${args[2] || 'unknown'}`)
+  process.exit(0)
+}
+
 if (args[0] !== 'agent') {
   console.error('Unsupported e2e command.')
   process.exit(1)
@@ -125,6 +135,7 @@ const agent = acp.agent({ name: 'grok-e2e' })
     sessions.add(sessionId)
     return { sessionId }
   })
+  .onRequest(acp.methods.agent.session.setMode, () => ({}))
   .onRequest(acp.methods.agent.session.load, ({ params }) => {
     sessions.add(params.sessionId)
     return {}
@@ -149,6 +160,32 @@ const agent = acp.agent({ name: 'grok-e2e' })
         content: { type: 'text', text: 'E2E agent received the command.' },
       },
     })
+    if (instruction.includes('Draft a plan fixture')) {
+      await client.notify(acp.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'plan',
+          entries: [
+            { content: 'Inspect the fixture workspace', priority: 'high', status: 'pending' },
+            { content: 'Write the verified change', priority: 'medium', status: 'pending' },
+          ],
+        },
+      })
+      return { stopReason: 'end_turn', usage: { inputTokens: 4, outputTokens: 3, totalTokens: 7 } }
+    }
+    if (instruction.includes('Approve the current plan')) {
+      await client.notify(acp.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'plan',
+          entries: [
+            { content: 'Inspect the fixture workspace', priority: 'high', status: 'in_progress' },
+            { content: 'Write the verified change', priority: 'medium', status: 'pending' },
+          ],
+        },
+      })
+      return { stopReason: 'end_turn', usage: { inputTokens: 2, outputTokens: 2, totalTokens: 4 } }
+    }
     if (instruction.includes('Start workflow fixture')) {
       await notifyWorkflow(client, params.sessionId, 'failed')
       return {

--- a/server/control-options.test.ts
+++ b/server/control-options.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { launchMeta, parsePermissionMode, planActionPrompt, slashPrompt } from './control-options.js'
+
+describe('launch options', () => {
+  it('maps permission and plan flags into ACP meta', () => {
+    expect(launchMeta({
+      cwd: '/repo',
+      prompt: 'go',
+      permissionMode: 'always-approve',
+      planMode: true,
+      worktree: true,
+      model: 'grok-e2e',
+    })).toMatchObject({
+      clientIdentifier: 'grok-ui',
+      modelId: 'grok-e2e',
+      yoloMode: true,
+      autoMode: false,
+      planMode: true,
+      worktree: true,
+    })
+    expect(parsePermissionMode('auto')).toBe('auto')
+    expect(parsePermissionMode('nope')).toBe('ask')
+  })
+
+  it('builds plan and slash prompts', () => {
+    expect(planActionPrompt('approve')).toContain('Approve')
+    expect(planActionPrompt('request-changes', 'keep tests')).toContain('keep tests')
+    expect(() => planActionPrompt('comment')).toThrow(/comment/)
+    expect(slashPrompt('create-workflow', 'review the branch')).toBe('/create-workflow review the branch')
+    expect(slashPrompt('compact')).toBe('/compact')
+  })
+})

--- a/server/control-options.ts
+++ b/server/control-options.ts
@@ -1,0 +1,88 @@
+export type PermissionMode = 'ask' | 'auto' | 'always-approve'
+export type PlanAction = 'approve' | 'request-changes' | 'comment' | 'quit'
+export type SessionSlash = 'compact' | 'rewind' | 'fork' | 'view-plan' | 'create-workflow'
+
+export interface LaunchOptions {
+  cwd: string
+  prompt: string
+  model?: string
+  reasoningEffort?: string
+  permissionMode?: PermissionMode
+  planMode?: boolean
+  worktree?: boolean
+}
+
+export interface SessionMeta {
+  clientIdentifier: 'grok-ui'
+  modelId?: string
+  reasoningEffort?: string
+  yoloMode: boolean
+  autoMode: boolean
+  planMode: boolean
+  worktree: boolean
+}
+
+const PERMISSION_MODES = new Set<PermissionMode>(['ask', 'auto', 'always-approve'])
+
+export function parsePermissionMode(value: unknown): PermissionMode {
+  return typeof value === 'string' && PERMISSION_MODES.has(value as PermissionMode)
+    ? value as PermissionMode
+    : 'ask'
+}
+
+export function launchMeta(input: LaunchOptions): SessionMeta {
+  const permissionMode = parsePermissionMode(input.permissionMode)
+  return {
+    clientIdentifier: 'grok-ui',
+    modelId: input.model || undefined,
+    reasoningEffort: input.reasoningEffort || undefined,
+    yoloMode: permissionMode === 'always-approve',
+    autoMode: permissionMode === 'auto',
+    planMode: input.planMode === true,
+    worktree: input.worktree === true,
+  }
+}
+
+export function planActionPrompt(action: PlanAction, note = ''): string {
+  const trimmed = note.trim()
+  if (action === 'approve') return 'Approve the current plan and start building.'
+  if (action === 'quit') return 'Quit plan mode without executing the plan.'
+  if (action === 'request-changes') {
+    if (!trimmed) throw new Error('Describe the changes the plan should make.')
+    return `Request changes to the current plan:\n${trimmed}`
+  }
+  if (!trimmed) throw new Error('Add a comment on the plan.')
+  return `Comment on the current plan:\n${trimmed}`
+}
+
+export function slashPrompt(command: SessionSlash, argument = ''): string {
+  const trimmed = argument.trim()
+  if (command === 'create-workflow') {
+    if (!trimmed) throw new Error('Describe the workflow to create.')
+    return `/create-workflow ${trimmed}`
+  }
+  if (command === 'compact') return trimmed ? `/compact ${trimmed}` : '/compact'
+  if (command === 'rewind') return '/rewind'
+  if (command === 'fork') return trimmed ? `/fork ${trimmed}` : '/fork'
+  return '/view-plan'
+}
+
+export function parsePlanAction(value: unknown): PlanAction {
+  if (value === 'approve' || value === 'request-changes' || value === 'comment' || value === 'quit') {
+    return value
+  }
+  throw new Error('Plan action must be approve, request-changes, comment, or quit.')
+}
+
+export function parseSlash(value: unknown): SessionSlash {
+  if (
+    value === 'compact'
+    || value === 'rewind'
+    || value === 'fork'
+    || value === 'view-plan'
+    || value === 'create-workflow'
+  ) {
+    return value
+  }
+  throw new Error('Unknown session command.')
+}

--- a/server/fleet-protocol.ts
+++ b/server/fleet-protocol.ts
@@ -539,6 +539,16 @@ function safeControlSession(value: unknown): Omit<ControlSession, 'workflows'> |
     feed: Array.isArray(item.feed)
       ? item.feed.slice(-MAX_AGENT_TRANSCRIPT_ITEMS).map(feedItem)
       : [],
+    permissionMode: 'ask',
+    planMode: false,
+    worktree: false,
+    parentSessionId: '',
+    currentModeId: '',
+    availableModes: [],
+    availableCommands: [],
+    plan: null,
+    todos: [],
+    queue: [],
   }
 }
 

--- a/server/grok-catalog.test.ts
+++ b/server/grok-catalog.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { parseModelList } from './grok-catalog.js'
+
+describe('model catalog', () => {
+  it('parses grok models output into unique ids', () => {
+    expect(parseModelList('Available models\n* grok-4.6\ngrok-e2e extra label\ngrok-4.6\n')).toEqual([
+      { id: 'grok-4.6', label: 'grok-4.6' },
+      { id: 'grok-e2e', label: 'grok-e2e extra label' },
+    ])
+  })
+})

--- a/server/grok-catalog.ts
+++ b/server/grok-catalog.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const TIMEOUT_MS = 3_500
+const MAX_OUTPUT = 64_000
+
+export interface ModelOption {
+  id: string
+  label: string
+}
+
+export interface InspectSnapshot {
+  cwd: string
+  generatedAt: string
+  text: string
+}
+
+function grokBin(): string {
+  return process.env.GROK_BIN || 'grok'
+}
+
+function clip(value: string): string {
+  return value.replace(/\u001B\[[0-9;]*m/g, '').slice(0, MAX_OUTPUT).trim()
+}
+
+export function parseModelList(output: string): ModelOption[] {
+  const seen = new Set<string>()
+  const models: ModelOption[] = []
+  for (const raw of clip(output).split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#') || line.toLowerCase().includes('available model')) continue
+    const id = line.replace(/^[*\-•]\s+/, '').split(/\s+/)[0]
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    models.push({ id, label: line.replace(/^[*\-•]\s+/, '').slice(0, 120) })
+    if (models.length >= 64) break
+  }
+  return models
+}
+
+export async function listGrokModels(): Promise<ModelOption[]> {
+  const { stdout, stderr } = await execFileAsync(grokBin(), ['models'], {
+    timeout: TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT,
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+  return parseModelList(`${stdout}\n${stderr}`)
+}
+
+export async function inspectWorkspace(cwd: string): Promise<InspectSnapshot> {
+  const { stdout, stderr } = await execFileAsync(grokBin(), ['inspect'], {
+    cwd,
+    timeout: TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT,
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+  return {
+    cwd,
+    generatedAt: new Date().toISOString(),
+    text: clip(`${stdout}\n${stderr}`) || 'Grok inspect returned no configuration.',
+  }
+}
+
+export async function deleteGrokSession(sessionId: string, cwd: string): Promise<void> {
+  await execFileAsync(grokBin(), ['sessions', 'delete', sessionId], {
+    cwd,
+    timeout: TIMEOUT_MS,
+    maxBuffer: MAX_OUTPUT,
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+}

--- a/server/grok-controller.test.ts
+++ b/server/grok-controller.test.ts
@@ -141,3 +141,25 @@ describe('GrokController workflows', () => {
     expect(controller.snapshot().sessions[0]?.lastPrompt).toBe('/workflow resume release-check')
   })
 })
+
+describe('GrokController plan review', () => {
+  it('projects a plan and approves it through the existing session prompt', async () => {
+    process.env.GROK_BIN = fakeGrok
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-plan-'))
+    cleanup.push(workspace)
+    const controller = new GrokController()
+    controllers.push(controller)
+
+    const created = await controller.createSession({
+      cwd: workspace,
+      prompt: 'Draft a plan fixture',
+      planMode: true,
+    })
+    await waitFor(() => controller.snapshot().sessions[0]?.plan?.status === 'review', 5_000)
+    expect(controller.snapshot().sessions[0]?.todos).toHaveLength(2)
+
+    await controller.reviewPlan(created.id, 'approve')
+    await waitFor(() => controller.snapshot().sessions[0]?.plan?.status === 'planning', 5_000)
+    expect(controller.snapshot().sessions[0]?.lastPrompt).toContain('Approve the current plan')
+  })
+})

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -13,18 +13,24 @@ import type {
   ControlSession,
   ControlSnapshot,
   LiveFeedItem,
+  PermissionMode,
   WorkflowControlAction,
 } from './types.js'
 import { SessionStateStore } from './session-state.js'
 import { APP_VERSION } from './app-version.js'
 import { parseWorkflowNotification, workflowControlCommand } from './workflow-state.js'
+import {
+  launchMeta,
+  parsePermissionMode,
+  planActionPrompt,
+  slashPrompt,
+  type LaunchOptions,
+  type PlanAction,
+  type SessionSlash,
+} from './control-options.js'
+import { applyPlanUpdate, emptyPlan, todosFromPlan } from './plan-projection.js'
 
-interface NewControlSession {
-  cwd: string
-  prompt: string
-  model?: string
-  reasoningEffort?: string
-}
+interface NewControlSession extends LaunchOptions {}
 
 interface PromptControlSession {
   sessionId: string
@@ -75,6 +81,16 @@ function sessionSeed(id: string, cwd: string, prompt: string, model = ''): Contr
     costTelemetryAvailable: false,
     feed: [],
     workflows: [],
+    permissionMode: 'ask',
+    planMode: false,
+    worktree: false,
+    parentSessionId: '',
+    currentModeId: '',
+    availableModes: [],
+    availableCommands: [],
+    plan: null,
+    todos: [],
+    queue: [],
   }
 }
 
@@ -119,12 +135,13 @@ function feedItem(update: SessionNotification['update']): LiveFeedItem | null {
     }
   }
   if (type === 'plan' || type === 'plan_update') {
+    const projected = applyPlanUpdate(null, update)
     return {
       id: `${timestamp}:${type}:${Math.random()}`,
       type: 'plan',
-      title: 'Plan updated',
-      text: JSON.stringify(update),
-      status: '',
+      title: projected.title || 'Plan updated',
+      text: projected.markdown || projected.entries.map((entry) => `- ${entry.content}`).join('\n'),
+      status: projected.status,
       timestamp,
     }
   }
@@ -243,18 +260,18 @@ export class GrokController extends EventEmitter {
     const cwd = await this.validateCwd(input.cwd)
     await this.start()
     const context = this.context()
+    const meta = launchMeta(input)
     const response = await context.request(acp.methods.agent.session.new, {
       cwd,
       mcpServers: [],
-      _meta: {
-        clientIdentifier: 'grok-ui',
-        modelId: input.model || undefined,
-        reasoningEffort: input.reasoningEffort || undefined,
-        yoloMode: false,
-        autoMode: false,
-      },
-    })
-    const session = sessionSeed(response.sessionId, cwd, input.prompt, input.model)
+      _meta: meta,
+    }) as { sessionId: string }
+    const session = {
+      ...sessionSeed(response.sessionId, cwd, input.prompt, input.model),
+      permissionMode: parsePermissionMode(input.permissionMode),
+      planMode: meta.planMode,
+      worktree: meta.worktree,
+    }
     this.sessions.set(session.id, session)
     this.loadedSessions.add(session.id)
     this.emitSnapshot()
@@ -297,8 +314,77 @@ export class GrokController extends EventEmitter {
     }
     this.sessions.set(session.id, session)
     this.emitSnapshot()
+    if (['working', 'starting', 'attention', 'stopping'].includes(existing.state)) {
+      const queued = [...session.queue, {
+        id: `queue-${Date.now()}`,
+        text: input.prompt,
+        createdAt: now(),
+      }].slice(-20)
+      this.sessions.set(session.id, { ...session, queue: queued, updatedAt: now() })
+      this.emitSnapshot()
+      return this.sessions.get(session.id)!
+    }
     void this.runPrompt(session.id, input.prompt)
     return session
+  }
+
+  async reviewPlan(sessionId: string, action: PlanAction, note = ''): Promise<ControlSession> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error('Managed session was not found.')
+    if (!session.plan || session.plan.status === 'none') throw new Error('This session has no plan to review.')
+    const prompt = planActionPrompt(action, note)
+    const status = action === 'approve'
+      ? 'approved'
+      : action === 'quit'
+        ? 'quit'
+        : action === 'request-changes'
+          ? 'changes-requested'
+          : session.plan.status
+    this.sessions.set(sessionId, {
+      ...session,
+      plan: { ...session.plan, status, updatedAt: now() },
+      planMode: action !== 'quit',
+      updatedAt: now(),
+    })
+    return this.promptSession({ sessionId, cwd: session.cwd, prompt })
+  }
+
+  async runSlash(sessionId: string, command: SessionSlash, argument = ''): Promise<ControlSession> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error('Managed session was not found.')
+    return this.promptSession({
+      sessionId,
+      cwd: session.cwd,
+      prompt: slashPrompt(command, argument),
+    })
+  }
+
+  async setSessionMode(sessionId: string, modeId: string): Promise<ControlSession> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error('Managed session was not found.')
+    if (!modeId.trim()) throw new Error('Mode is required.')
+    await this.start()
+    await this.context().request(acp.methods.agent.session.setMode, {
+      sessionId,
+      modeId,
+    })
+    const permissionMode: PermissionMode = modeId.includes('always') || modeId.includes('yolo')
+      ? 'always-approve'
+      : modeId.includes('auto')
+        ? 'auto'
+        : modeId.includes('plan')
+          ? session.permissionMode
+          : 'ask'
+    const next = {
+      ...session,
+      currentModeId: modeId,
+      permissionMode: modeId.includes('plan') ? session.permissionMode : permissionMode,
+      planMode: modeId.includes('plan') || session.planMode,
+      updatedAt: now(),
+    }
+    this.sessions.set(sessionId, next)
+    this.emitSnapshot()
+    return next
   }
 
   async cancelSession(sessionId: string): Promise<void> {
@@ -603,6 +689,7 @@ export class GrokController extends EventEmitter {
     this.clearCancellationTimer(sessionId)
     const timestamp = now()
     const cancelled = response.stopReason === 'cancelled'
+    const [nextPrompt, ...remaining] = session.queue
     this.sessions.set(sessionId, {
       ...session,
       state: cancelled ? 'cancelled' : 'idle',
@@ -615,8 +702,10 @@ export class GrokController extends EventEmitter {
       outputTokens: response.usage?.outputTokens || session.outputTokens,
       totalTokens: response.usage?.totalTokens || session.totalTokens,
       tokenTelemetryAvailable: Boolean(response.usage) || session.tokenTelemetryAvailable,
+      queue: remaining,
     })
     this.emitSnapshot()
+    if (!cancelled && nextPrompt) void this.runPrompt(sessionId, nextPrompt.text)
   }
 
   private requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
@@ -657,6 +746,23 @@ export class GrokController extends EventEmitter {
     let next = { ...session, updatedAt: now() }
     if (update.sessionUpdate === 'session_info_update' && update.title) {
       next.title = update.title
+    }
+    if (update.sessionUpdate === 'plan' || update.sessionUpdate === 'plan_update' || update.sessionUpdate === 'plan_removed') {
+      next.plan = applyPlanUpdate(session.plan || emptyPlan(), update)
+      next.todos = todosFromPlan(next.plan)
+      if (next.plan.status === 'review') next.state = 'attention'
+    }
+    if (update.sessionUpdate === 'current_mode_update' && 'currentModeId' in update) {
+      next.currentModeId = String(update.currentModeId || '')
+      next.planMode = next.currentModeId.includes('plan')
+    }
+    if (update.sessionUpdate === 'available_commands_update' && 'availableCommands' in update) {
+      const commands = Array.isArray(update.availableCommands) ? update.availableCommands : []
+      next.availableCommands = commands.flatMap((command) => {
+        if (!command || typeof command !== 'object') return []
+        const item = command as { name?: string; description?: string }
+        return item.name ? [{ name: item.name, description: item.description || '' }] : []
+      })
     }
     if (update.sessionUpdate === 'usage_update') {
       next.costAmount = update.cost?.amount || next.costAmount

--- a/server/host-agent.ts
+++ b/server/host-agent.ts
@@ -381,6 +381,16 @@ export class LocalHostAgentProvider implements HostAgentProvider {
       costCurrency: managed.costCurrency,
       costTelemetryAvailable: managed.costTelemetryAvailable,
       feed: managed.feed.slice(-MAX_AGENT_TRANSCRIPT_ITEMS),
+      permissionMode: managed.permissionMode,
+      planMode: managed.planMode,
+      worktree: managed.worktree,
+      parentSessionId: managed.parentSessionId,
+      currentModeId: managed.currentModeId,
+      availableModes: managed.availableModes,
+      availableCommands: [],
+      plan: managed.plan,
+      todos: managed.todos,
+      queue: [],
     } : null
     return boundedSessionDetail({
       protocolVersion: FLEET_PROTOCOL_VERSION,

--- a/server/index.ts
+++ b/server/index.ts
@@ -31,6 +31,9 @@ import { FleetRegistryStore, publicHostConfig } from './fleet-registry.js'
 import { FleetMonitor } from './fleet-monitor.js'
 import { controlSessionRow, liveAgentRow } from './session-projection.js'
 import { PreviewSupervisor } from './preview-supervisor.js'
+import { parsePermissionMode, parsePlanAction, parseSlash } from './control-options.js'
+import { deleteGrokSession, inspectWorkspace, listGrokModels } from './grok-catalog.js'
+import { transcriptMarkdown } from './session-transcript.js'
 
 const app = express()
 const sessionState = new SessionStateStore()
@@ -519,6 +522,9 @@ app.post('/api/control/sessions', async (request, response) => {
       prompt: typeof request.body?.prompt === 'string' ? request.body.prompt : '',
       model: typeof request.body?.model === 'string' ? request.body.model : '',
       reasoningEffort: typeof request.body?.reasoningEffort === 'string' ? request.body.reasoningEffort : '',
+      permissionMode: parsePermissionMode(request.body?.permissionMode),
+      planMode: request.body?.planMode === true,
+      worktree: request.body?.worktree === true,
     })
     response.status(202).json(session)
   } catch (error) {
@@ -558,6 +564,62 @@ app.post('/api/control/sessions/:sessionId/workflows/:workflowId', async (reques
     response.status(202).json({ accepted: true })
   } catch (error) {
     response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to control workflow.' })
+  }
+})
+
+app.get('/api/control/models', async (_request, response) => {
+  try {
+    response.json({ models: await listGrokModels() })
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to list models.' })
+  }
+})
+
+app.post('/api/control/sessions/:id/plan', async (request, response) => {
+  try {
+    const session = await controller.reviewPlan(
+      request.params.id,
+      parsePlanAction(request.body?.action),
+      typeof request.body?.note === 'string' ? request.body.note : '',
+    )
+    response.status(202).json(session)
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to review plan.' })
+  }
+})
+
+app.post('/api/control/sessions/:id/command', async (request, response) => {
+  try {
+    const session = await controller.runSlash(
+      request.params.id,
+      parseSlash(request.body?.command),
+      typeof request.body?.argument === 'string' ? request.body.argument : '',
+    )
+    response.status(202).json(session)
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to run session command.' })
+  }
+})
+
+app.post('/api/control/sessions/:id/mode', async (request, response) => {
+  try {
+    const modeId = typeof request.body?.modeId === 'string' ? request.body.modeId : ''
+    response.json(await controller.setSessionMode(request.params.id, modeId))
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to set session mode.' })
+  }
+})
+
+app.get('/api/inspect', async (request, response) => {
+  const cwd = typeof request.query.cwd === 'string' ? request.query.cwd : ''
+  if (!cwd || !(await workspaceAllowed(cwd))) {
+    response.status(403).json({ error: 'Workspace is not associated with a Grok session.' })
+    return
+  }
+  try {
+    response.json(await inspectWorkspace(path.resolve(cwd)))
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to inspect workspace.' })
   }
 })
 
@@ -650,6 +712,43 @@ app.get('/api/sessions/:id/workbench', async (request, response, next) => {
     })
   } catch (error) {
     next(error)
+  }
+})
+
+app.get('/api/sessions/:id/export', async (request, response, next) => {
+  try {
+    const session = await resolveSession(request.params.id)
+    if (!session) {
+      response.status(404).json({ error: 'Session not found' })
+      return
+    }
+    const live = liveMonitor.snapshot().agents.find((item) => item.id === session.id)
+    const control = controller.snapshot().sessions.find((item) => item.id === session.id)
+    const markdown = transcriptMarkdown(
+      session,
+      mergeSessionFeed(await sessionReader.transcript(session), live?.feed || [], control?.feed || []),
+    )
+    response.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+    response.setHeader('Content-Disposition', `attachment; filename="${session.id}.md"`)
+    response.send(markdown)
+  } catch (error) {
+    next(error)
+  }
+})
+
+app.delete('/api/sessions/:id', async (request, response) => {
+  const session = await resolveSession(request.params.id)
+  if (!session) {
+    response.status(404).json({ error: 'Session not found' })
+    return
+  }
+  try {
+    await deleteGrokSession(session.id, session.cwd)
+    await sessionState.annotate(session.id, { archived: true })
+    store.invalidate()
+    response.json({ deleted: true })
+  } catch (error) {
+    response.status(400).json({ error: error instanceof Error ? error.message : 'Unable to delete session.' })
   }
 })
 

--- a/server/plan-projection.test.ts
+++ b/server/plan-projection.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { applyPlanUpdate, todosFromPlan } from './plan-projection.js'
+
+describe('plan projection', () => {
+  it('turns ACP plan entries into a reviewable plan and todos', () => {
+    const plan = applyPlanUpdate(null, {
+      sessionUpdate: 'plan',
+      entries: [
+        { content: 'Inspect workspace', priority: 'high', status: 'pending' },
+        { content: 'Write the change', priority: 'medium', status: 'pending' },
+      ],
+    })
+    expect(plan.status).toBe('review')
+    expect(plan.entries).toHaveLength(2)
+    expect(todosFromPlan(plan).map((item) => item.status)).toEqual(['pending', 'pending'])
+  })
+
+  it('marks in-progress plans as planning and completed plans as approved', () => {
+    const planning = applyPlanUpdate(null, {
+      sessionUpdate: 'plan',
+      entries: [{ content: 'Doing', priority: 'high', status: 'in_progress' }],
+    })
+    expect(planning.status).toBe('planning')
+    const done = applyPlanUpdate(planning, {
+      sessionUpdate: 'plan',
+      entries: [{ content: 'Doing', priority: 'high', status: 'completed' }],
+    })
+    expect(done.status).toBe('approved')
+  })
+})

--- a/server/plan-projection.ts
+++ b/server/plan-projection.ts
@@ -1,0 +1,103 @@
+import type { SessionPlan, SessionPlanEntry, SessionTodo } from './types.js'
+
+export function emptyPlan(): SessionPlan {
+  return {
+    status: 'none',
+    title: '',
+    markdown: '',
+    entries: [],
+    updatedAt: '',
+  }
+}
+
+export function applyPlanUpdate(previous: SessionPlan | null, update: unknown): SessionPlan {
+  const current = previous || emptyPlan()
+  if (!update || typeof update !== 'object') return current
+  const payload = update as Record<string, unknown>
+  const kind = typeof payload.sessionUpdate === 'string' ? payload.sessionUpdate : ''
+  if (kind === 'plan_removed') return { ...emptyPlan(), updatedAt: new Date().toISOString() }
+
+  const entries = extractEntries(payload)
+  const markdown = extractMarkdown(payload)
+  const title = extractTitle(payload, entries)
+  const next: SessionPlan = {
+    status: reviewStatus(entries, markdown, kind),
+    title,
+    markdown,
+    entries,
+    updatedAt: new Date().toISOString(),
+  }
+  return next.entries.length || next.markdown ? next : { ...current, updatedAt: next.updatedAt }
+}
+
+export function todosFromPlan(plan: SessionPlan | null): SessionTodo[] {
+  if (!plan) return []
+  return plan.entries.map((entry, index) => ({
+    id: entry.id || `todo-${index + 1}`,
+    content: entry.content,
+    status: todoStatus(entry.status),
+  }))
+}
+
+function extractEntries(payload: Record<string, unknown>): SessionPlanEntry[] {
+  const candidates = [
+    payload.entries,
+    isRecord(payload.plan) ? payload.plan.entries : null,
+    isRecord(payload.plan) && isRecord(payload.plan.plan) ? payload.plan.plan.entries : null,
+  ]
+  for (const list of candidates) {
+    if (!Array.isArray(list)) continue
+    return list.flatMap((item, index) => {
+      if (!item || typeof item !== 'object') return []
+      const entry = item as Record<string, unknown>
+      const content = typeof entry.content === 'string' ? entry.content.trim() : ''
+      if (!content) return []
+      return [{
+        id: typeof entry.id === 'string' && entry.id ? entry.id : `step-${index + 1}`,
+        content: content.slice(0, 2_000),
+        status: typeof entry.status === 'string' ? entry.status : 'pending',
+        priority: typeof entry.priority === 'string' ? entry.priority : 'medium',
+      }]
+    })
+  }
+  return []
+}
+
+function extractMarkdown(payload: Record<string, unknown>): string {
+  const plan = isRecord(payload.plan) ? payload.plan : payload
+  if (plan.type === 'markdown' && typeof plan.content === 'string') return plan.content.slice(0, 20_000)
+  if (typeof payload.content === 'string' && payload.sessionUpdate === 'plan_update') {
+    return payload.content.slice(0, 20_000)
+  }
+  return ''
+}
+
+function extractTitle(payload: Record<string, unknown>, entries: SessionPlanEntry[]): string {
+  if (typeof payload.title === 'string' && payload.title.trim()) return payload.title.trim().slice(0, 160)
+  const plan = isRecord(payload.plan) ? payload.plan : null
+  if (plan && typeof plan.title === 'string' && plan.title.trim()) return plan.title.trim().slice(0, 160)
+  return entries[0]?.content.slice(0, 96) || 'Plan'
+}
+
+function reviewStatus(
+  entries: SessionPlanEntry[],
+  markdown: string,
+  kind: string,
+): SessionPlan['status'] {
+  if (!entries.length && !markdown) return 'none'
+  if (entries.some((entry) => entry.status === 'in_progress')) return 'planning'
+  if (entries.length && entries.every((entry) => entry.status === 'completed')) return 'approved'
+  if (kind === 'plan' || entries.every((entry) => entry.status === 'pending')) return 'review'
+  return 'planning'
+}
+
+function todoStatus(status: string): SessionTodo['status'] {
+  if (status === 'in_progress') return 'in_progress'
+  if (status === 'completed') return 'completed'
+  if (status === 'cancelled') return 'cancelled'
+  return 'pending'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/server/session-state.ts
+++ b/server/session-state.ts
@@ -205,6 +205,18 @@ function normalizeControlSession(value: unknown): ControlSession | null {
         .filter((workflow) => workflow && typeof workflow === 'object')
         .map((workflow) => interruptRestoredWorkflow(workflow as WorkflowRun))
       : [],
+    permissionMode: item.permissionMode === 'auto' || item.permissionMode === 'always-approve'
+      ? item.permissionMode
+      : 'ask',
+    planMode: item.planMode === true,
+    worktree: item.worktree === true,
+    parentSessionId: typeof item.parentSessionId === 'string' ? item.parentSessionId : '',
+    currentModeId: typeof item.currentModeId === 'string' ? item.currentModeId : '',
+    availableModes: Array.isArray(item.availableModes) ? item.availableModes : [],
+    availableCommands: Array.isArray(item.availableCommands) ? item.availableCommands : [],
+    plan: item.plan && typeof item.plan === 'object' ? item.plan : null,
+    todos: Array.isArray(item.todos) ? item.todos : [],
+    queue: [],
   }
 }
 

--- a/server/session-transcript.test.ts
+++ b/server/session-transcript.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { transcriptMarkdown } from './session-transcript.js'
+import type { SessionRow } from './types.js'
+
+describe('transcript export', () => {
+  it('writes a markdown transcript without inventing content', () => {
+    const markdown = transcriptMarkdown(
+      { id: 'sess-1', title: 'Launch', cwd: '/repo', model: 'grok-e2e', updatedAt: '2026-08-25T00:00:00.000Z' } as SessionRow,
+      [{ id: '1', type: 'user', title: 'user', text: 'Fix the test', status: '', timestamp: '2026-08-25T00:00:00.000Z' }],
+    )
+    expect(markdown).toContain('# Launch')
+    expect(markdown).toContain('Fix the test')
+    expect(markdown).toContain('sess-1')
+  })
+})

--- a/server/session-transcript.ts
+++ b/server/session-transcript.ts
@@ -1,0 +1,25 @@
+import type { LiveFeedItem, SessionRow } from './types.js'
+
+export function transcriptMarkdown(session: SessionRow, items: LiveFeedItem[]): string {
+  const lines = [
+    `# ${session.title || session.id}`,
+    '',
+    `- Session: \`${session.id}\``,
+    `- Workspace: \`${session.cwd}\``,
+    `- Model: ${session.model || 'default'}`,
+    `- Updated: ${session.updatedAt || 'unknown'}`,
+    '',
+  ]
+  for (const item of items) {
+    const heading = item.type === 'assistant' ? 'Grok' : item.type
+    lines.push(`## ${heading}${item.title && item.title !== heading ? ` — ${item.title}` : ''}`)
+    if (item.status) lines.push(`Status: ${item.status}`)
+    if (item.timestamp) lines.push(`Time: ${item.timestamp}`)
+    if (item.text) {
+      lines.push('')
+      lines.push(item.text)
+    }
+    lines.push('')
+  }
+  return `${lines.join('\n').trim()}\n`
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -146,6 +146,58 @@ export interface LiveSnapshot {
 
 export type ControlSessionState = 'starting' | 'idle' | 'working' | 'attention' | 'stopping' | 'cancelled' | 'failed'
 export type ControlCancellationStatus = 'none' | 'requested' | 'confirmed' | 'timed_out' | 'failed'
+export type PermissionMode = 'ask' | 'auto' | 'always-approve'
+export type PlanReviewStatus = 'none' | 'planning' | 'review' | 'approved' | 'changes-requested' | 'quit'
+export type PlanAction = 'approve' | 'request-changes' | 'comment' | 'quit'
+export type SessionSlash = 'compact' | 'rewind' | 'fork' | 'view-plan' | 'create-workflow'
+
+export interface SessionPlanEntry {
+  id: string
+  content: string
+  status: string
+  priority: string
+}
+
+export interface SessionPlan {
+  status: PlanReviewStatus
+  title: string
+  markdown: string
+  entries: SessionPlanEntry[]
+  updatedAt: string
+}
+
+export interface SessionTodo {
+  id: string
+  content: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+}
+
+export interface QueuedPrompt {
+  id: string
+  text: string
+  createdAt: string
+}
+
+export interface SessionModeOption {
+  id: string
+  name: string
+}
+
+export interface AvailableSessionCommand {
+  name: string
+  description: string
+}
+
+export interface ModelOption {
+  id: string
+  label: string
+}
+
+export interface InspectSnapshot {
+  cwd: string
+  generatedAt: string
+  text: string
+}
 export type WorkflowRunStatus =
   | 'running'
   | 'paused'
@@ -230,6 +282,16 @@ export interface ControlSession {
   costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
   workflows: WorkflowRun[]
+  permissionMode: PermissionMode
+  planMode: boolean
+  worktree: boolean
+  parentSessionId: string
+  currentModeId: string
+  availableModes: SessionModeOption[]
+  availableCommands: AvailableSessionCommand[]
+  plan: SessionPlan | null
+  todos: SessionTodo[]
+  queue: QueuedPrompt[]
 }
 
 export interface ControlPermissionOption {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,6 @@ import type {
   DashboardPayload,
   FleetSnapshot,
   FleetHostView,
-  LiveAgent,
   LiveSnapshot,
   RankedDatum,
   RuntimeSnapshot,
@@ -65,6 +64,9 @@ import type {
 import { ChangesView } from './views/ChangesView'
 import { ControlView } from './views/ControlView'
 import { SessionLaunchForm } from './views/SessionLaunchForm'
+import { LiveRoster } from './views/LiveRoster'
+import { LibraryInspect } from './views/LibraryInspect'
+import { buildRoster } from './live-roster'
 import { SessionWorkbench } from './views/SessionWorkbench'
 import { RemoteSessionWorkbench } from './views/RemoteSessionWorkbench'
 import { WorkflowsView } from './views/WorkflowsView'
@@ -928,24 +930,8 @@ function LiveView({
   onRefresh: () => void
   onRefreshControl: () => Promise<void>
 }) {
-  const privacy = usePrivacy()
-  const [selectedId, setSelectedId] = useState(live?.agents[0]?.id || '')
-  const agents = live?.agents || []
-
-  useEffect(() => {
-    if (!agents.length) {
-      setSelectedId('')
-      return
-    }
-    if (!agents.some((agent) => agent.id === selectedId)) setSelectedId(agents[0].id)
-  }, [agents, selectedId])
-
-  const selected = agents.find((agent) => agent.id === selectedId) || agents[0]
-
-  const openAgent = (agent: LiveAgent) => {
-    const session = data.sessions.find((row) => row.id === agent.id)
-    onOpenSession(session || agent.id)
-  }
+  const roster = useMemo(() => buildRoster(live, control), [control, live])
+  const selected = roster[0]
 
   return (
     <>
@@ -1010,53 +996,12 @@ function LiveView({
           />
         </section>
       ) : (
-        <section className="live-console-grid section-gap">
-          <aside className="agent-roster">
-            <header>
-              <span>ACTIVE / {String(agents.length).padStart(2, '0')}</span>
-              <span className="live-word"><i /> LIVE</span>
-            </header>
-            <div className="agent-roster-list">
-              {agents.map((agent, index) => (
-                <button
-                  key={agent.id}
-                  className={selected.id === agent.id ? 'is-active' : ''}
-                  onClick={() => {
-                    setSelectedId(agent.id)
-                    openAgent(agent)
-                  }}
-                >
-                  <span className="agent-number">A{String(index + 1).padStart(2, '0')}</span>
-                  <AgentStateGlyph state={agent.state} />
-                  <span className="agent-roster-copy">
-                    <strong>{privacy.sessionTitle(agent.title, agent.id)}</strong>
-                    <small>{privacy.workspace(agent.cwd)} · {privacy.enabled ? 'PID ••••' : `PID ${agent.pid}`}</small>
-                  </span>
-                  <ChevronRight size={15} />
-                </button>
-              ))}
-            </div>
-          </aside>
-
-          <section className="runtime-console">
-            <header className="runtime-head">
-              <div className="runtime-identity">
-                <AgentStateGlyph state={selected.state} />
-                <div>
-                  <span>{privacy.workspace(selected.cwd)} / {selected.model}</span>
-                  <h2>{privacy.sessionTitle(selected.title, selected.id)}</h2>
-                </div>
-              </div>
-              <div className="runtime-actions">
-                <AgentStatePill agent={selected} />
-                <button className="text-button" onClick={() => openAgent(selected)}>
-                  Open Session <ArrowRight size={14} />
-                </button>
-              </div>
-            </header>
-            <p className="live-open-hint">Chat, approve, and inspect changes in the session.</p>
-          </section>
-        </section>
+        <LiveRoster
+          live={live}
+          control={control}
+          sessions={data.sessions}
+          onOpenSession={onOpenSession}
+        />
       )}
       <RuntimeIntelligencePanels runtime={runtime} />
     </>
@@ -1208,25 +1153,6 @@ function LiveSummaryMetric({
       <small>{detail}</small>
     </div>
   )
-}
-
-function AgentStateGlyph({ state }: { state: LiveAgent['state'] }) {
-  return (
-    <span className={`agent-state-glyph agent-state-${state}`} aria-label={state}>
-      <i />
-    </span>
-  )
-}
-
-function AgentStatePill({ agent }: { agent: LiveAgent }) {
-  const label = agent.state === 'attention'
-    ? 'Needs input'
-    : agent.state === 'working'
-      ? 'Working'
-      : agent.state === 'waiting'
-        ? 'Waiting on model'
-        : 'Idle / attached'
-  return <span className={`agent-state-pill state-pill-${agent.state}`}><i />{label}</span>
 }
 
 function Overview({
@@ -1768,6 +1694,7 @@ function LibraryView({
           <p>{selected.kind} from {selected.source} source. The file body is not loaded into the dashboard.</p>
         </section>
       )}
+      <LibraryInspect cwd={data.sessions[0]?.cwd || ''} />
     </>
   )
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,6 +26,10 @@ import type {
   WorkflowControlAction,
   WorkspaceDiff,
   WorkspaceSnapshot,
+  InspectSnapshot,
+  ModelOption,
+  PlanAction,
+  SessionSlash,
 } from './types'
 
 const JSON_RESPONSE_CAP = 5 * 1024 * 1024
@@ -382,12 +386,80 @@ export async function createControlSession(input: {
   prompt: string
   model?: string
   reasoningEffort?: string
+  permissionMode?: string
+  planMode?: boolean
+  worktree?: boolean
 }): Promise<ControlSession> {
   return json(await fetch('/api/control/sessions', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(input),
   }), 'Unable to create Grok session')
+}
+
+export async function listControlModels(): Promise<ModelOption[]> {
+  const payload = await json<{ models: ModelOption[] }>(
+    await fetch('/api/control/models'),
+    'Unable to list models',
+  )
+  return payload.models || []
+}
+
+export async function reviewControlPlan(
+  sessionId: string,
+  action: PlanAction,
+  note = '',
+): Promise<ControlSession> {
+  return json(await fetch(`/api/control/sessions/${encodeURIComponent(sessionId)}/plan`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action, note }),
+  }), 'Unable to review plan')
+}
+
+export async function runControlCommand(
+  sessionId: string,
+  command: SessionSlash,
+  argument = '',
+): Promise<ControlSession> {
+  return json(await fetch(`/api/control/sessions/${encodeURIComponent(sessionId)}/command`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ command, argument }),
+  }), 'Unable to run session command')
+}
+
+export async function setControlMode(sessionId: string, modeId: string): Promise<ControlSession> {
+  return json(await fetch(`/api/control/sessions/${encodeURIComponent(sessionId)}/mode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ modeId }),
+  }), 'Unable to set session mode')
+}
+
+export async function inspectWorkspace(cwd: string): Promise<InspectSnapshot> {
+  return json(
+    await fetch(`/api/inspect?cwd=${encodeURIComponent(cwd)}`),
+    'Unable to inspect workspace',
+  )
+}
+
+export async function exportSessionMarkdown(sessionId: string): Promise<void> {
+  const response = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/export`)
+  if (!response.ok) throw new Error('Unable to export session.')
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${sessionId}.md`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+export async function deleteRecordedSession(sessionId: string): Promise<void> {
+  await json(await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+    method: 'DELETE',
+  }), 'Unable to delete session')
 }
 
 export async function promptControlSession(

--- a/src/control-snapshot.test.ts
+++ b/src/control-snapshot.test.ts
@@ -33,6 +33,16 @@ function session(updatedAt: string, feedItems: number): ControlSession {
       timestamp: updatedAt,
     })),
     workflows: [],
+    permissionMode: 'ask',
+    planMode: false,
+    worktree: false,
+    parentSessionId: '',
+    currentModeId: '',
+    availableModes: [],
+    availableCommands: [],
+    plan: null,
+    todos: [],
+    queue: [],
   }
 }
 

--- a/src/live-roster.test.ts
+++ b/src/live-roster.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildRoster, groupedRoster } from './live-roster'
+import type { ControlSnapshot, LiveSnapshot } from './types'
+
+describe('live roster', () => {
+  it('groups needs-input first and rolls children under a parent', () => {
+    const rows = buildRoster(
+      {
+        agents: [
+          { id: 'parent', title: 'Parent', cwd: '/repo', state: 'working', feed: [] },
+          { id: 'child', title: 'Child', cwd: '/repo', state: 'waiting', feed: [] },
+        ],
+      } as unknown as LiveSnapshot,
+      {
+        sessions: [{
+          id: 'parent',
+          title: 'Parent',
+          cwd: '/repo',
+          state: 'working',
+          parentSessionId: '',
+          feed: [{ id: '1', type: 'assistant', title: 'hi', text: 'working', status: '', timestamp: '' }],
+          workflows: [],
+        }, {
+          id: 'child',
+          title: 'Child',
+          cwd: '/repo',
+          state: 'attention',
+          parentSessionId: 'parent',
+          feed: [],
+          workflows: [],
+        }],
+        permissions: [],
+      } as unknown as ControlSnapshot,
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].children).toHaveLength(1)
+    expect(groupedRoster(rows)[0].id).toBe('working')
+  })
+})

--- a/src/live-roster.ts
+++ b/src/live-roster.ts
@@ -1,0 +1,106 @@
+import type {
+  ControlSession,
+  ControlSnapshot,
+  LiveAgent,
+  LiveFeedItem,
+  LiveSnapshot,
+} from './types'
+
+export type RosterState = 'attention' | 'working' | 'waiting' | 'idle' | 'failed'
+
+export interface RosterRow {
+  id: string
+  title: string
+  cwd: string
+  state: RosterState
+  source: 'live' | 'managed'
+  parentId: string
+  pid: number
+  peek: LiveFeedItem[]
+  children: RosterRow[]
+}
+
+export const ROSTER_GROUPS: Array<{ id: RosterState; label: string }> = [
+  { id: 'attention', label: 'Needs input' },
+  { id: 'working', label: 'Working' },
+  { id: 'waiting', label: 'Waiting' },
+  { id: 'idle', label: 'Idle' },
+  { id: 'failed', label: 'Failed' },
+]
+
+export function buildRoster(
+  live: LiveSnapshot | null,
+  control: ControlSnapshot | null,
+): RosterRow[] {
+  const rows = new Map<string, RosterRow>()
+  for (const agent of live?.agents || []) {
+    rows.set(agent.id, fromLive(agent))
+  }
+  for (const session of control?.sessions || []) {
+    const existing = rows.get(session.id)
+    if (existing) {
+      existing.source = 'managed'
+      existing.parentId = existing.parentId || session.parentSessionId
+      if (session.feed.length) existing.peek = session.feed.slice(-4)
+      if (session.state === 'attention' || session.state === 'failed') existing.state = session.state
+      continue
+    }
+    rows.set(session.id, fromManaged(session))
+  }
+  const roots: RosterRow[] = []
+  for (const row of rows.values()) {
+    const parent = row.parentId ? rows.get(row.parentId) : undefined
+    if (parent && parent.id !== row.id) parent.children.push(row)
+    else roots.push(row)
+  }
+  return roots.sort(byAttention)
+}
+
+export function groupedRoster(rows: RosterRow[]): Array<{ id: RosterState; label: string; rows: RosterRow[] }> {
+  return ROSTER_GROUPS
+    .map((group) => ({
+      ...group,
+      rows: rows.filter((row) => row.state === group.id),
+    }))
+    .filter((group) => group.rows.length > 0)
+}
+
+function fromLive(agent: LiveAgent): RosterRow {
+  return {
+    id: agent.id,
+    title: agent.title,
+    cwd: agent.cwd,
+    state: agent.state === 'attention' ? 'attention' : agent.state === 'working' ? 'working' : agent.state === 'waiting' ? 'waiting' : 'idle',
+    source: 'live',
+    parentId: '',
+    pid: agent.pid,
+    peek: agent.feed.slice(-4),
+    children: [],
+  }
+}
+
+function fromManaged(session: ControlSession): RosterRow {
+  const state: RosterState = session.state === 'attention'
+    ? 'attention'
+    : session.state === 'working' || session.state === 'starting' || session.state === 'stopping'
+      ? 'working'
+      : session.state === 'failed'
+        ? 'failed'
+        : 'idle'
+  return {
+    id: session.id,
+    title: session.title,
+    cwd: session.cwd,
+    state,
+    source: 'managed',
+    parentId: session.parentSessionId,
+    pid: 0,
+    peek: session.feed.slice(-4),
+    children: [],
+  }
+}
+
+function byAttention(left: RosterRow, right: RosterRow): number {
+  const rank = (state: RosterState) => ROSTER_GROUPS.findIndex((group) => group.id === state)
+  return rank(left.state) - rank(right.state) || left.title.localeCompare(right.title)
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -956,6 +956,92 @@ kbd {
   white-space: nowrap;
 }
 
+.roster-group {
+  display: grid;
+  gap: 2px;
+}
+
+.roster-group > small {
+  padding: 10px 14px 4px;
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.roster-state {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.roster-state.is-attention { background: var(--coral); }
+.roster-state.is-working { background: var(--lime); }
+.roster-state.is-waiting { background: var(--paper); }
+.roster-state.is-failed { background: var(--coral); }
+
+.roster-peek {
+  display: grid;
+  gap: 10px;
+  padding: 16px 18px;
+  min-height: 180px;
+}
+
+.roster-peek small {
+  display: block;
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+
+.roster-reply {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 0 18px 18px;
+}
+
+.roster-reply textarea,
+.plan-review textarea,
+.workflow-author input {
+  width: 100%;
+  padding: 10px 12px;
+  color: inherit;
+  border: 1px solid var(--line);
+  background: transparent;
+}
+
+.session-plan-panel,
+.library-inspect,
+.plan-review,
+.session-todos,
+.session-queue,
+.session-commands,
+.workflow-author {
+  display: grid;
+  gap: 10px;
+}
+
+.session-plan-panel {
+  padding: 14px 16px 0;
+}
+
+.plan-actions,
+.session-commands {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.plan-actions button,
+.session-commands button,
+.workflow-author button {
+  min-height: 32px;
+  padding: 0 10px;
+}
+
 .agent-roster-copy small {
   overflow: hidden;
   color: var(--muted-dim);

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,58 @@ export interface LiveSnapshot {
 
 export type ControlSessionState = 'starting' | 'idle' | 'working' | 'attention' | 'stopping' | 'cancelled' | 'failed'
 export type ControlCancellationStatus = 'none' | 'requested' | 'confirmed' | 'timed_out' | 'failed'
+export type PermissionMode = 'ask' | 'auto' | 'always-approve'
+export type PlanReviewStatus = 'none' | 'planning' | 'review' | 'approved' | 'changes-requested' | 'quit'
+export type PlanAction = 'approve' | 'request-changes' | 'comment' | 'quit'
+export type SessionSlash = 'compact' | 'rewind' | 'fork' | 'view-plan' | 'create-workflow'
+
+export interface SessionPlanEntry {
+  id: string
+  content: string
+  status: string
+  priority: string
+}
+
+export interface SessionPlan {
+  status: PlanReviewStatus
+  title: string
+  markdown: string
+  entries: SessionPlanEntry[]
+  updatedAt: string
+}
+
+export interface SessionTodo {
+  id: string
+  content: string
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled'
+}
+
+export interface QueuedPrompt {
+  id: string
+  text: string
+  createdAt: string
+}
+
+export interface SessionModeOption {
+  id: string
+  name: string
+}
+
+export interface AvailableSessionCommand {
+  name: string
+  description: string
+}
+
+export interface ModelOption {
+  id: string
+  label: string
+}
+
+export interface InspectSnapshot {
+  cwd: string
+  generatedAt: string
+  text: string
+}
 export type WorkflowRunStatus =
   | 'running'
   | 'paused'
@@ -231,6 +283,16 @@ export interface ControlSession {
   costTelemetryAvailable: boolean
   feed: LiveFeedItem[]
   workflows: WorkflowRun[]
+  permissionMode: PermissionMode
+  planMode: boolean
+  worktree: boolean
+  parentSessionId: string
+  currentModeId: string
+  availableModes: SessionModeOption[]
+  availableCommands: AvailableSessionCommand[]
+  plan: SessionPlan | null
+  todos: SessionTodo[]
+  queue: QueuedPrompt[]
 }
 
 export interface ControlPermissionOption {

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -148,6 +148,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
           requestedResumeId={resumeRequest.id}
           resumeToken={resumeRequest.token}
           onRefresh={onRefresh}
+          onLaunched={(session) => setSelectedLane(session.id)}
         />
 
         <aside className="approval-panel">

--- a/src/views/LibraryInspect.tsx
+++ b/src/views/LibraryInspect.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { inspectWorkspace } from '../api'
+import { usePrivacy } from '../privacy'
+
+export function LibraryInspect({ cwd }: { cwd: string }) {
+  const privacy = usePrivacy()
+  const [text, setText] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  if (!cwd) return null
+
+  const run = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const snapshot = await inspectWorkspace(cwd)
+      setText(snapshot.text)
+    } catch (inspectError) {
+      setError(inspectError instanceof Error ? inspectError.message : 'Unable to inspect.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="library-inspect section-gap">
+      <button type="button" className="text-button" onClick={() => void run()} disabled={loading}>
+        {loading ? 'Inspecting…' : 'Inspect this workspace'}
+      </button>
+      {error && <p className="launch-form-status is-error" role="alert">{privacy.content(error)}</p>}
+      {text && <pre>{privacy.content(text)}</pre>}
+    </section>
+  )
+}

--- a/src/views/LiveRoster.tsx
+++ b/src/views/LiveRoster.tsx
@@ -1,0 +1,133 @@
+import { ArrowRight, ChevronRight, CornerDownLeft } from 'lucide-react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { promptControlSession } from '../api'
+import { buildRoster, groupedRoster } from '../live-roster'
+import { usePrivacy } from '../privacy'
+import type { ControlSnapshot, LiveSnapshot, SessionRow } from '../types'
+
+export function LiveRoster({
+  live,
+  control,
+  sessions,
+  onOpenSession,
+}: {
+  live: LiveSnapshot | null
+  control: ControlSnapshot | null
+  sessions: SessionRow[]
+  onOpenSession: (session: SessionRow | string) => void
+}) {
+  const privacy = usePrivacy()
+  const roots = useMemo(() => buildRoster(live, control), [control, live])
+  const groups = useMemo(() => groupedRoster(roots), [roots])
+  const flat = useMemo(() => groups.flatMap((group) => group.rows), [groups])
+  const [selectedId, setSelectedId] = useState(flat[0]?.id || '')
+  const selected = flat.find((row) => row.id === selectedId) || flat[0]
+  const [reply, setReply] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!flat.length) {
+      setSelectedId('')
+      return
+    }
+    if (!flat.some((row) => row.id === selectedId)) setSelectedId(flat[0].id)
+  }, [flat, selectedId])
+
+  const open = (id: string) => {
+    const session = sessions.find((item) => item.id === id)
+    onOpenSession(session || id)
+  }
+
+  const send = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!selected || !reply.trim()) return
+    setSending(true)
+    setError('')
+    try {
+      await promptControlSession(selected.id, { cwd: selected.cwd, prompt: reply })
+      setReply('')
+    } catch (sendError) {
+      setError(sendError instanceof Error ? sendError.message : 'Unable to send reply.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <section className="live-console-grid section-gap">
+      <aside className="agent-roster">
+        <header>
+          <span>ACTIVE / {String(flat.length).padStart(2, '0')}</span>
+          <span className="live-word"><i /> LIVE</span>
+        </header>
+        <div className="agent-roster-list">
+          {groups.map((group) => (
+            <div className="roster-group" key={group.id}>
+              <small>{group.label}</small>
+              {group.rows.map((row) => (
+                <button
+                  key={row.id}
+                  className={selected?.id === row.id ? 'is-active' : ''}
+                  onClick={() => setSelectedId(row.id)}
+                >
+                  <span className={`roster-state is-${row.state}`} />
+                  <span className="agent-roster-copy">
+                    <strong>{privacy.sessionTitle(row.title, row.id)}</strong>
+                    <small>
+                      {privacy.workspace(row.cwd)}
+                      {row.pid ? ` · ${privacy.enabled ? 'PID ••••' : `PID ${row.pid}`}` : ''}
+                      {row.children.length ? ` · ${row.children.length} subagents` : ''}
+                    </small>
+                  </span>
+                  <ChevronRight size={15} />
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      </aside>
+      <section className="runtime-console">
+        {selected ? (
+          <>
+            <header className="runtime-head">
+              <div className="runtime-identity">
+                <span className={`roster-state is-${selected.state}`} />
+                <div>
+                  <span>{privacy.workspace(selected.cwd)}</span>
+                  <h2>{privacy.sessionTitle(selected.title, selected.id)}</h2>
+                </div>
+              </div>
+              <div className="runtime-actions">
+                <button className="text-button" type="button" onClick={() => open(selected.id)}>
+                  Open Session <ArrowRight size={14} />
+                </button>
+              </div>
+            </header>
+            <div className="roster-peek">
+              {selected.peek.length ? selected.peek.map((item) => (
+                <p key={item.id}>
+                  <small>{item.type}</small>
+                  {privacy.content(item.text || item.title)}
+                </p>
+              )) : <p>No recent activity to peek yet.</p>}
+            </div>
+            {error && <p className="launch-form-status is-error" role="alert">{privacy.content(error)}</p>}
+            <form className="roster-reply" onSubmit={(event) => void send(event)}>
+              <textarea
+                value={reply}
+                onChange={(event) => setReply(event.target.value)}
+                placeholder={selected.state === 'working' ? 'Queue a follow-up…' : 'Reply from the roster…'}
+                rows={3}
+              />
+              <button disabled={sending || !reply.trim() || !control?.connected}>
+                <span>{sending ? 'Sending…' : selected.state === 'working' ? 'Queue' : 'Reply'}</span>
+                <CornerDownLeft size={16} />
+              </button>
+            </form>
+          </>
+        ) : null}
+      </section>
+    </section>
+  )
+}

--- a/src/views/SessionLaunchForm.tsx
+++ b/src/views/SessionLaunchForm.tsx
@@ -1,12 +1,14 @@
 import { CornerDownLeft, Radio, Sparkles } from 'lucide-react'
 import { useEffect, useMemo, useState, type FormEvent } from 'react'
-import { createControlSession, promptControlSession } from '../api'
+import { createControlSession, listControlModels, promptControlSession } from '../api'
 import { usePrivacy } from '../privacy'
 import type {
   ControlSession,
   ControlSnapshot,
   DashboardPayload,
   LiveSnapshot,
+  ModelOption,
+  PermissionMode,
 } from '../types'
 
 export type LaunchMode = 'new' | 'resume'
@@ -82,10 +84,18 @@ export function SessionLaunchForm({
   const [sessionId, setSessionId] = useState('')
   const [prompt, setPrompt] = useState('')
   const [model, setModel] = useState('')
+  const [models, setModels] = useState<ModelOption[]>([])
   const [reasoningEffort, setReasoningEffort] = useState('medium')
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>('ask')
+  const [planMode, setPlanMode] = useState(false)
+  const [worktree, setWorktree] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    void listControlModels().then(setModels).catch(() => setModels([]))
+  }, [])
 
   useEffect(() => {
     if (!requestedResumeId) return
@@ -116,7 +126,15 @@ export function SessionLaunchForm({
         await promptControlSession(selected.id, { cwd: selected.cwd, prompt })
         setMessage(`Prompt sent to ${privacy.sessionTitle(selected.title, selected.id)}.`)
       } else {
-        const created = await createControlSession({ cwd, prompt, model, reasoningEffort })
+        const created = await createControlSession({
+          cwd,
+          prompt,
+          model,
+          reasoningEffort,
+          permissionMode,
+          planMode,
+          worktree,
+        })
         setMessage('New Grok lane launched.')
         onLaunched?.(created)
       }
@@ -202,13 +220,38 @@ export function SessionLaunchForm({
           <div className="control-field-row">
             <label className="control-field">
               <span>MODEL <em>optional</em></span>
-              <input value={model} onChange={(event) => setModel(event.target.value)} placeholder="Use Grok default" />
+              {models.length ? (
+                <select value={model} onChange={(event) => setModel(event.target.value)}>
+                  <option value="">Use Grok default</option>
+                  {models.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+                </select>
+              ) : (
+                <input value={model} onChange={(event) => setModel(event.target.value)} placeholder="Use Grok default" />
+              )}
             </label>
             <label className="control-field">
               <span>REASONING</span>
               <select value={reasoningEffort} onChange={(event) => setReasoningEffort(event.target.value)}>
                 {['low', 'medium', 'high', 'xhigh', 'max'].map((effort) => <option key={effort}>{effort}</option>)}
               </select>
+            </label>
+          </div>
+          <div className="control-field-row">
+            <label className="control-field">
+              <span>PERMISSIONS</span>
+              <select value={permissionMode} onChange={(event) => setPermissionMode(event.target.value as PermissionMode)}>
+                <option value="ask">Ask</option>
+                <option value="auto">Auto</option>
+                <option value="always-approve">Always-approve</option>
+              </select>
+            </label>
+            <label className="control-field launch-toggle">
+              <span>PLAN FIRST</span>
+              <input type="checkbox" checked={planMode} onChange={(event) => setPlanMode(event.target.checked)} />
+            </label>
+            <label className="control-field launch-toggle">
+              <span>WORKTREE</span>
+              <input type="checkbox" checked={worktree} onChange={(event) => setWorktree(event.target.checked)} />
             </label>
           </div>
         </>

--- a/src/views/SessionPlanPanel.tsx
+++ b/src/views/SessionPlanPanel.tsx
@@ -1,0 +1,119 @@
+import { Check, ListTodo, ShieldAlert } from 'lucide-react'
+import { useState } from 'react'
+import {
+  deleteRecordedSession,
+  exportSessionMarkdown,
+  reviewControlPlan,
+  runControlCommand,
+  setControlMode,
+} from '../api'
+import { usePrivacy } from '../privacy'
+import type { ControlSession, PlanAction, SessionSlash } from '../types'
+
+export function SessionPlanPanel({
+  session,
+  onUpdated,
+  onDeleted,
+}: {
+  session: ControlSession
+  onUpdated: () => Promise<void>
+  onDeleted?: () => void
+}) {
+  const privacy = usePrivacy()
+  const [note, setNote] = useState('')
+  const [workflow, setWorkflow] = useState('')
+  const [error, setError] = useState('')
+  const plan = session.plan
+
+  const act = async (action: PlanAction) => {
+    setError('')
+    try {
+      await reviewControlPlan(session.id, action, note)
+      setNote('')
+      await onUpdated()
+    } catch (reviewError) {
+      setError(reviewError instanceof Error ? reviewError.message : 'Unable to review plan.')
+    }
+  }
+
+  const command = async (name: SessionSlash, argument = '') => {
+    setError('')
+    try {
+      await runControlCommand(session.id, name, argument)
+      await onUpdated()
+    } catch (commandError) {
+      setError(commandError instanceof Error ? commandError.message : 'Unable to run command.')
+    }
+  }
+
+  return (
+    <section className="session-plan-panel">
+      {error && <p className="launch-form-status is-error" role="alert">{privacy.content(error)}</p>}
+      {plan && plan.status !== 'none' && (
+        <article className="plan-review">
+          <header>
+            <ShieldAlert size={16} />
+            <div>
+              <small>Plan {plan.status}</small>
+              <strong>{privacy.content(plan.title)}</strong>
+            </div>
+          </header>
+          {plan.markdown && <pre>{privacy.content(plan.markdown)}</pre>}
+          {plan.entries.map((entry) => (
+            <p key={entry.id}><em>{entry.status}</em> {privacy.content(entry.content)}</p>
+          ))}
+          {plan.status === 'review' && (
+            <>
+              <textarea value={note} onChange={(event) => setNote(event.target.value)} placeholder="Request changes or comment…" rows={3} />
+              <div className="plan-actions">
+                <button type="button" onClick={() => void act('approve')}><Check size={14} /> Approve</button>
+                <button type="button" onClick={() => void act('request-changes')}>Request changes</button>
+                <button type="button" onClick={() => void act('comment')}>Comment</button>
+                <button type="button" className="is-reject" onClick={() => void act('quit')}>Quit plan</button>
+              </div>
+            </>
+          )}
+        </article>
+      )}
+      {session.todos.length > 0 && (
+        <article className="session-todos">
+          <header><ListTodo size={15} /> Todos</header>
+          {session.todos.map((todo) => (
+            <p key={todo.id}><em>{todo.status}</em> {privacy.content(todo.content)}</p>
+          ))}
+        </article>
+      )}
+      {session.queue.length > 0 && (
+        <article className="session-queue">
+          <header>Queued prompts</header>
+          {session.queue.map((item) => <p key={item.id}>{privacy.content(item.text)}</p>)}
+        </article>
+      )}
+      <div className="session-commands">
+        {session.availableModes.length > 0 && (
+          <label>
+            Mode
+            <select
+              value={session.currentModeId}
+              onChange={(event) => void setControlMode(session.id, event.target.value).then(onUpdated)}
+            >
+              {session.availableModes.map((mode) => <option key={mode.id} value={mode.id}>{mode.name}</option>)}
+            </select>
+          </label>
+        )}
+        <button type="button" onClick={() => void command('compact')}>Compact</button>
+        <button type="button" onClick={() => void command('rewind')}>Rewind</button>
+        <button type="button" onClick={() => void command('fork')}>Fork</button>
+        <button type="button" onClick={() => void exportSessionMarkdown(session.id)}>Export</button>
+        <button type="button" className="is-reject" onClick={() => void deleteRecordedSession(session.id).then(onDeleted)}>Delete</button>
+      </div>
+      <form className="workflow-author" onSubmit={(event) => {
+        event.preventDefault()
+        void command('create-workflow', workflow).then(() => setWorkflow(''))
+      }}>
+        <input value={workflow} onChange={(event) => setWorkflow(event.target.value)} placeholder="Create a workflow…" />
+        <button type="submit">Author</button>
+      </form>
+    </section>
+  )
+}

--- a/src/views/SessionWorkbench.tsx
+++ b/src/views/SessionWorkbench.tsx
@@ -51,6 +51,7 @@ import type {
   WorkspaceSnapshot,
 } from '../types'
 import { usePrivacy } from '../privacy'
+import { SessionPlanPanel } from './SessionPlanPanel'
 
 type WorkbenchTab = 'timeline' | 'preview' | 'changes' | 'specs'
 type PreviewViewport = 'desktop' | 'tablet' | 'mobile'
@@ -453,12 +454,21 @@ export function SessionWorkbench({
           {loading && !data ? (
             <div className="workbench-loading"><LoaderCircle size={25} className="is-spinning" /><span>Assembling session record…</span></div>
           ) : tab === 'timeline' ? (
-            <SessionTimeline
-              items={transcript}
-              permissions={data?.permissions || []}
-              feedRef={feedRef}
-              onDecide={decide}
-            />
+            <>
+              {data?.control && (
+                <SessionPlanPanel
+                  session={data.control}
+                  onUpdated={() => refresh(true)}
+                  onDeleted={onClose}
+                />
+              )}
+              <SessionTimeline
+                items={transcript}
+                permissions={data?.permissions || []}
+                feedRef={feedRef}
+                onDecide={decide}
+              />
+            </>
           ) : tab === 'preview' ? (
             <Preview
               preview={preview}

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -15,7 +15,7 @@ import {
   Workflow,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import { controlWorkflow } from '../api'
+import { controlWorkflow, runControlCommand } from '../api'
 import { usePrivacy } from '../privacy'
 import type {
   ControlSnapshot,
@@ -110,6 +110,7 @@ export function WorkflowsView({
   const [error, setError] = useState('')
   const [agentQuery, setAgentQuery] = useState('')
   const [agentPage, setAgentPage] = useState(0)
+  const [workflowDraft, setWorkflowDraft] = useState('')
 
   const filtered = useMemo(
     () => runs.filter((run) => matchesFilter(run, filter)),
@@ -203,6 +204,31 @@ export function WorkflowsView({
           </small>
         </div>
       </section>
+
+      {control?.sessions[0] && (
+        <form
+          className="workflow-author section-gap"
+          onSubmit={(event) => {
+            event.preventDefault()
+            const host = selected?.sessionId || control.sessions[0].id
+            void runControlCommand(host, 'create-workflow', workflowDraft)
+              .then(() => {
+                setWorkflowDraft('')
+                return onRefresh()
+              })
+              .catch((authorError: unknown) => {
+                setError(authorError instanceof Error ? authorError.message : 'Unable to author workflow.')
+              })
+          }}
+        >
+          <input
+            value={workflowDraft}
+            onChange={(event) => setWorkflowDraft(event.target.value)}
+            placeholder="Describe a workflow to author in the current session…"
+          />
+          <button type="submit" disabled={!workflowDraft.trim()}>Author workflow</button>
+        </form>
+      )}
 
       {!runs.length ? (
         <section className="workflow-empty section-gap">


### PR DESCRIPTION
## Outcome

Grok Build controls now live in existing rooms instead of new destinations. Live groups and peeks sessions, launch can set plan/permissions/worktree/`grok models`, and the session console reviews plans, todos, and queued follow-ups. Library inspects the workspace; Runs can author a workflow on the selected session.

Control now keeps the managed stream on the lane you just launched so leftover sessions do not hide approval results.

## Verification

- [x] `npm run verify` not re-run at PR time; `vitest` 124/124 and Playwright 25/25 passed after the Control stream fix
- [x] Relevant automated tests added or updated
- [x] Desktop behavior checked (Playwright launch + fleet, plus browser walk of Live/Control plan path)
- [x] Mobile behavior checked when UI changed (existing mobile Playwright coverage)
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added
- [x] Fleet changes preserve authenticated, bounded, read-only remote access
- [x] Fleet changes cover compatibility, failure, freshness, and reconnect states


Made with [Cursor](https://cursor.com)