### PR TITLE
Answer Grok’s real plan approval and cut 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
+## 0.12.0 — 2026-08-25
+
+- Plan approval answers Grok’s `x.ai/exit_plan_mode` request instead of
+  sending a fake “approve the plan” chat turn.
+- Session console keeps plan, todos, and the queue up front. Compact,
+  rewind, fork, export, and delete sit under More session actions.
 - Live groups sessions the way Grok’s dashboard does and lets you peek or
   reply without opening a new room.
 - Session launch can start in plan mode, set Ask/Auto/Always-approve, use a
   worktree, and pick from `grok models`.
-- Session console reviews ACP plans, shows todos and queued follow-ups, and
-  can compact, rewind, fork, export Markdown, or delete the Grok session.
+- Session console reviews ACP plans and shows todos and queued follow-ups.
 - Library inspects the current workspace through `grok inspect`. Runs can
   author a workflow on the selected session.
 - Overview now holds the two-week activity matrix. Activity stays on the

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and move through your complete local history without leaving the browser.
 </a>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.11.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.11.0)
+· [**See what’s new in v0.12.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.12.0)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -382,7 +382,7 @@ test.describe.serial('public launch path', () => {
     expect(created.ok()).toBe(true)
     const session = await created.json()
     await page.goto(`/#/live/${session.id}`)
-    await expect(page.getByText('Plan review')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('Plan approval')).toBeVisible({ timeout: 10_000 })
     await page.getByRole('button', { name: 'Approve' }).click()
     await expect.poll(async () => {
       const snapshot = await (await page.request.get('/api/control')).json()
@@ -819,6 +819,10 @@ test.describe.serial('public launch path', () => {
     ]) {
       await page.goto(`/#/${section}`)
       expect(await unreadableVisibleText(page), `${section} contains text below 8px`).toEqual([])
+      if (section === 'library') {
+        await page.getByRole('button', { name: 'Inspect this workspace' }).click()
+        await expect(page.getByText('config: e2e')).toBeVisible()
+      }
     }
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/scripts/fake-grok-e2e.mjs
+++ b/scripts/fake-grok-e2e.mjs
@@ -171,6 +171,25 @@ const agent = acp.agent({ name: 'grok-e2e' })
           ],
         },
       })
+      const verdict = await client.request('x.ai/exit_plan_mode', {
+        sessionId: params.sessionId,
+        planContent: '- Inspect the fixture workspace\n- Write the verified change',
+      })
+      const approved = verdict?.type === 'approved'
+      await client.notify(acp.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: 'plan',
+          entries: [
+            {
+              content: 'Inspect the fixture workspace',
+              priority: 'high',
+              status: approved ? 'in_progress' : 'pending',
+            },
+            { content: 'Write the verified change', priority: 'medium', status: 'pending' },
+          ],
+        },
+      })
       return { stopReason: 'end_turn', usage: { inputTokens: 4, outputTokens: 3, totalTokens: 7 } }
     }
     if (instruction.includes('Approve the current plan')) {

--- a/server/control-options.test.ts
+++ b/server/control-options.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { launchMeta, parsePermissionMode, planActionPrompt, slashPrompt } from './control-options.js'
+import {
+  launchMeta,
+  parseExitPlanRequest,
+  parsePermissionMode,
+  planActionPrompt,
+  planExitVerdict,
+  slashPrompt,
+} from './control-options.js'
 
 describe('launch options', () => {
   it('maps permission and plan flags into ACP meta', () => {
@@ -28,5 +35,12 @@ describe('launch options', () => {
     expect(() => planActionPrompt('comment')).toThrow(/comment/)
     expect(slashPrompt('create-workflow', 'review the branch')).toBe('/create-workflow review the branch')
     expect(slashPrompt('compact')).toBe('/compact')
+    expect(planExitVerdict('approve')).toBe('approved')
+    expect(planExitVerdict('quit')).toBe('abandoned')
+    expect(planExitVerdict('request-changes')).toBe('rejected')
+    expect(parseExitPlanRequest({
+      sessionId: 'sess-1',
+      planContent: 'Ship the fixture',
+    })).toEqual({ sessionId: 'sess-1', plan: 'Ship the fixture' })
   })
 })

--- a/server/control-options.ts
+++ b/server/control-options.ts
@@ -43,6 +43,25 @@ export function launchMeta(input: LaunchOptions): SessionMeta {
   }
 }
 
+export type PlanExitVerdict = 'approved' | 'abandoned' | 'rejected'
+
+export function planExitVerdict(action: PlanAction): PlanExitVerdict {
+  if (action === 'approve') return 'approved'
+  if (action === 'quit') return 'abandoned'
+  return 'rejected'
+}
+
+export function parseExitPlanRequest(params: unknown): { sessionId: string; plan: string } {
+  const payload = params && typeof params === 'object' ? params as Record<string, unknown> : {}
+  const sessionId = typeof payload.sessionId === 'string' ? payload.sessionId : ''
+  const nested = payload.input && typeof payload.input === 'object'
+    ? payload.input as Record<string, unknown>
+    : {}
+  const plan = [payload.planContent, payload.plan, nested.plan]
+    .find((value) => typeof value === 'string' && value.trim())
+  return { sessionId, plan: typeof plan === 'string' ? plan.slice(0, 20_000) : '' }
+}
+
 export function planActionPrompt(action: PlanAction, note = ''): string {
   const trimmed = note.trim()
   if (action === 'approve') return 'Approve the current plan and start building.'

--- a/server/fleet-protocol.ts
+++ b/server/fleet-protocol.ts
@@ -549,6 +549,7 @@ function safeControlSession(value: unknown): Omit<ControlSession, 'workflows'> |
     plan: null,
     todos: [],
     queue: [],
+    awaitingPlanApproval: false,
   }
 }
 

--- a/server/grok-controller.test.ts
+++ b/server/grok-controller.test.ts
@@ -143,7 +143,7 @@ describe('GrokController workflows', () => {
 })
 
 describe('GrokController plan review', () => {
-  it('projects a plan and approves it through the existing session prompt', async () => {
+  it('projects a plan and approves it through Grok’s exit_plan_mode request', async () => {
     process.env.GROK_BIN = fakeGrok
     const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-plan-'))
     cleanup.push(workspace)
@@ -155,11 +155,25 @@ describe('GrokController plan review', () => {
       prompt: 'Draft a plan fixture',
       planMode: true,
     })
-    await waitFor(() => controller.snapshot().sessions[0]?.plan?.status === 'review', 5_000)
+    await waitFor(() => controller.snapshot().sessions[0]?.awaitingPlanApproval === true, 5_000)
     expect(controller.snapshot().sessions[0]?.todos).toHaveLength(2)
 
     await controller.reviewPlan(created.id, 'approve')
     await waitFor(() => controller.snapshot().sessions[0]?.plan?.status === 'planning', 5_000)
-    expect(controller.snapshot().sessions[0]?.lastPrompt).toContain('Approve the current plan')
+    expect(controller.snapshot().sessions[0]?.lastPrompt).toBe('Draft a plan fixture')
+    expect(controller.snapshot().sessions[0]?.awaitingPlanApproval).toBe(false)
+
+    const followOn = await controller.createSession({
+      cwd: workspace,
+      prompt: 'Write a fixture after plan review',
+    })
+    await waitFor(() => controller.snapshot().permissions.some((item) => item.sessionId === followOn.id), 5_000)
+    const permission = controller.snapshot().permissions.find((item) => item.sessionId === followOn.id)
+    expect(permission).toBeTruthy()
+    controller.resolvePermission(permission!.id, 'allow')
+    await waitFor(() => {
+      const row = controller.snapshot().sessions.find((item) => item.id === followOn.id)
+      return row?.state === 'idle' && row.totalTokens === 20
+    }, 5_000)
   })
 })

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -21,11 +21,14 @@ import { APP_VERSION } from './app-version.js'
 import { parseWorkflowNotification, workflowControlCommand } from './workflow-state.js'
 import {
   launchMeta,
+  parseExitPlanRequest,
   parsePermissionMode,
   planActionPrompt,
+  planExitVerdict,
   slashPrompt,
   type LaunchOptions,
   type PlanAction,
+  type PlanExitVerdict,
   type SessionSlash,
 } from './control-options.js'
 import { applyPlanUpdate, emptyPlan, todosFromPlan } from './plan-projection.js'
@@ -41,6 +44,11 @@ interface PromptControlSession {
 interface PendingPermission {
   public: ControlPermission
   resolve: (response: RequestPermissionResponse) => void
+}
+
+interface PendingPlanExit {
+  sessionId: string
+  resolve: (response: { type: PlanExitVerdict }) => void
 }
 
 function now(): string {
@@ -91,6 +99,7 @@ function sessionSeed(id: string, cwd: string, prompt: string, model = ''): Contr
     plan: null,
     todos: [],
     queue: [],
+    awaitingPlanApproval: false,
   }
 }
 
@@ -161,6 +170,7 @@ export class GrokController extends EventEmitter {
   private loadedSessions = new Set<string>()
   private replayingSessions = new Set<string>()
   private permissions = new Map<string, PendingPermission>()
+  private planExits = new Map<string, PendingPlanExit>()
   private cancellationTimers = new Map<string, NodeJS.Timeout>()
   private stderrTail: string[] = []
   private persistTimer: NodeJS.Timeout | null = null
@@ -231,6 +241,7 @@ export class GrokController extends EventEmitter {
       permission.resolve({ outcome: { outcome: 'cancelled' } })
     })
     this.permissions.clear()
+    this.rejectPlanExits()
     this.connection?.close()
     this.connection = null
     this.connected = false
@@ -332,7 +343,6 @@ export class GrokController extends EventEmitter {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error('Managed session was not found.')
     if (!session.plan || session.plan.status === 'none') throw new Error('This session has no plan to review.')
-    const prompt = planActionPrompt(action, note)
     const status = action === 'approve'
       ? 'approved'
       : action === 'quit'
@@ -340,13 +350,32 @@ export class GrokController extends EventEmitter {
         : action === 'request-changes'
           ? 'changes-requested'
           : session.plan.status
+    const parked = this.planExits.get(sessionId)
     this.sessions.set(sessionId, {
       ...session,
       plan: { ...session.plan, status, updatedAt: now() },
       planMode: action !== 'quit',
+      awaitingPlanApproval: false,
       updatedAt: now(),
     })
-    return this.promptSession({ sessionId, cwd: session.cwd, prompt })
+    if (parked) {
+      parked.resolve({ type: planExitVerdict(action) })
+      this.planExits.delete(sessionId)
+      this.emitSnapshot()
+      if (action === 'request-changes' || action === 'comment') {
+        return this.promptSession({
+          sessionId,
+          cwd: session.cwd,
+          prompt: planActionPrompt(action, note),
+        })
+      }
+      return this.sessions.get(sessionId)!
+    }
+    return this.promptSession({
+      sessionId,
+      cwd: session.cwd,
+      prompt: planActionPrompt(action, note),
+    })
   }
 
   async runSlash(sessionId: string, command: SessionSlash, argument = ''): Promise<ControlSession> {
@@ -511,6 +540,10 @@ export class GrokController extends EventEmitter {
       const app = acp.client({ name: 'grok-ui' })
         .onRequest(acp.methods.client.session.requestPermission, ({ params }) =>
           this.requestPermission(params))
+        .onRequest('x.ai/exit_plan_mode', (params: unknown) => params, ({ params }) =>
+          this.requestPlanExit(params))
+        .onRequest('_x.ai/exit_plan_mode', (params: unknown) => params, ({ params }) =>
+          this.requestPlanExit(params))
         .onNotification(acp.methods.client.session.update, ({ params }) => {
           this.sessionUpdate(params)
         })
@@ -595,6 +628,7 @@ export class GrokController extends EventEmitter {
       permission.resolve({ outcome: { outcome: 'cancelled' } })
     })
     this.permissions.clear()
+    this.rejectPlanExits()
     this.sessions = new Map([...this.sessions].map(([id, session]) => {
       if (!['starting', 'working', 'attention', 'stopping'].includes(session.state)) {
         return [id, session]
@@ -708,6 +742,39 @@ export class GrokController extends EventEmitter {
     if (!cancelled && nextPrompt) void this.runPrompt(sessionId, nextPrompt.text)
   }
 
+  private requestPlanExit(params: unknown): Promise<{ type: PlanExitVerdict }> {
+    const { sessionId, plan } = parseExitPlanRequest(params)
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      return Promise.resolve({ type: 'abandoned' })
+    }
+    const current = session.plan && session.plan.status !== 'none' ? session.plan : emptyPlan()
+    const planState = {
+      ...current,
+      status: 'review' as const,
+      markdown: plan || current.markdown,
+      title: current.title || 'Plan approval',
+      updatedAt: now(),
+    }
+    this.sessions.set(sessionId, {
+      ...session,
+      state: 'attention',
+      awaitingPlanApproval: true,
+      plan: planState,
+      todos: todosFromPlan(planState),
+      updatedAt: now(),
+    })
+    return new Promise((resolve) => {
+      this.planExits.set(sessionId, { sessionId, resolve })
+      this.emitSnapshot()
+    })
+  }
+
+  private rejectPlanExits(): void {
+    this.planExits.forEach((pending) => pending.resolve({ type: 'abandoned' }))
+    this.planExits.clear()
+  }
+
   private requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse> {
     const current = this.sessions.get(params.sessionId)
     if (current && ['requested', 'confirmed', 'timed_out'].includes(current.cancellationStatus)) {
@@ -772,11 +839,16 @@ export class GrokController extends EventEmitter {
     if (
       (update.sessionUpdate === 'tool_call' || update.sessionUpdate === 'agent_message_chunk')
       && next.cancellationStatus === 'none'
+      && ['starting', 'working', 'attention', 'stopping'].includes(next.state)
     ) {
       next.state = 'working'
     }
     let item = feedItem(update)
-    if (item?.type === 'tool' && item.status === 'failed' && next.cancellationStatus === 'requested') {
+    if (
+      item?.type === 'tool'
+      && item.status === 'failed'
+      && ['requested', 'confirmed'].includes(next.cancellationStatus)
+    ) {
       item = { ...item, status: 'cancelled' }
     }
     if (item) {

--- a/server/host-agent.ts
+++ b/server/host-agent.ts
@@ -391,6 +391,7 @@ export class LocalHostAgentProvider implements HostAgentProvider {
       plan: managed.plan,
       todos: managed.todos,
       queue: [],
+      awaitingPlanApproval: false,
     } : null
     return boundedSessionDetail({
       protocolVersion: FLEET_PROTOCOL_VERSION,

--- a/server/session-state.ts
+++ b/server/session-state.ts
@@ -217,6 +217,7 @@ function normalizeControlSession(value: unknown): ControlSession | null {
     plan: item.plan && typeof item.plan === 'object' ? item.plan : null,
     todos: Array.isArray(item.todos) ? item.todos : [],
     queue: [],
+    awaitingPlanApproval: false,
   }
 }
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -292,6 +292,7 @@ export interface ControlSession {
   plan: SessionPlan | null
   todos: SessionTodo[]
   queue: QueuedPrompt[]
+  awaitingPlanApproval: boolean
 }
 
 export interface ControlPermissionOption {

--- a/src/control-snapshot.test.ts
+++ b/src/control-snapshot.test.ts
@@ -43,6 +43,7 @@ function session(updatedAt: string, feedItems: number): ControlSession {
     plan: null,
     todos: [],
     queue: [],
+    awaitingPlanApproval: false,
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1028,6 +1028,15 @@ kbd {
   padding: 14px 16px 0;
 }
 
+.session-more {
+  color: var(--muted);
+}
+
+.session-more summary {
+  cursor: pointer;
+  font-size: var(--type-label);
+}
+
 .plan-actions,
 .session-commands {
   display: flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,6 +293,7 @@ export interface ControlSession {
   plan: SessionPlan | null
   todos: SessionTodo[]
   queue: QueuedPrompt[]
+  awaitingPlanApproval: boolean
 }
 
 export interface ControlPermissionOption {

--- a/src/views/SessionPlanPanel.tsx
+++ b/src/views/SessionPlanPanel.tsx
@@ -21,9 +21,9 @@ export function SessionPlanPanel({
 }) {
   const privacy = usePrivacy()
   const [note, setNote] = useState('')
-  const [workflow, setWorkflow] = useState('')
   const [error, setError] = useState('')
   const plan = session.plan
+  const reviewing = plan && (plan.status === 'review' || session.awaitingPlanApproval)
 
   const act = async (action: PlanAction) => {
     setError('')
@@ -54,7 +54,7 @@ export function SessionPlanPanel({
           <header>
             <ShieldAlert size={16} />
             <div>
-              <small>Plan {plan.status}</small>
+              <small>{reviewing ? 'Plan approval' : `Plan ${plan.status}`}</small>
               <strong>{privacy.content(plan.title)}</strong>
             </div>
           </header>
@@ -62,11 +62,18 @@ export function SessionPlanPanel({
           {plan.entries.map((entry) => (
             <p key={entry.id}><em>{entry.status}</em> {privacy.content(entry.content)}</p>
           ))}
-          {plan.status === 'review' && (
+          {reviewing && (
             <>
-              <textarea value={note} onChange={(event) => setNote(event.target.value)} placeholder="Request changes or comment…" rows={3} />
+              <textarea
+                value={note}
+                onChange={(event) => setNote(event.target.value)}
+                placeholder="Notes for request changes or a comment…"
+                rows={3}
+              />
               <div className="plan-actions">
-                <button type="button" onClick={() => void act('approve')}><Check size={14} /> Approve</button>
+                <button type="button" onClick={() => void act('approve')}>
+                  <Check size={14} /> Approve
+                </button>
                 <button type="button" onClick={() => void act('request-changes')}>Request changes</button>
                 <button type="button" onClick={() => void act('comment')}>Comment</button>
                 <button type="button" className="is-reject" onClick={() => void act('quit')}>Quit plan</button>
@@ -89,31 +96,35 @@ export function SessionPlanPanel({
           {session.queue.map((item) => <p key={item.id}>{privacy.content(item.text)}</p>)}
         </article>
       )}
-      <div className="session-commands">
-        {session.availableModes.length > 0 && (
-          <label>
-            Mode
-            <select
-              value={session.currentModeId}
-              onChange={(event) => void setControlMode(session.id, event.target.value).then(onUpdated)}
-            >
-              {session.availableModes.map((mode) => <option key={mode.id} value={mode.id}>{mode.name}</option>)}
-            </select>
-          </label>
-        )}
-        <button type="button" onClick={() => void command('compact')}>Compact</button>
-        <button type="button" onClick={() => void command('rewind')}>Rewind</button>
-        <button type="button" onClick={() => void command('fork')}>Fork</button>
-        <button type="button" onClick={() => void exportSessionMarkdown(session.id)}>Export</button>
-        <button type="button" className="is-reject" onClick={() => void deleteRecordedSession(session.id).then(onDeleted)}>Delete</button>
-      </div>
-      <form className="workflow-author" onSubmit={(event) => {
-        event.preventDefault()
-        void command('create-workflow', workflow).then(() => setWorkflow(''))
-      }}>
-        <input value={workflow} onChange={(event) => setWorkflow(event.target.value)} placeholder="Create a workflow…" />
-        <button type="submit">Author</button>
-      </form>
+      <details className="session-more">
+        <summary>More session actions</summary>
+        <div className="session-commands">
+          {session.availableModes.length > 0 && (
+            <label>
+              Mode
+              <select
+                value={session.currentModeId}
+                onChange={(event) => void setControlMode(session.id, event.target.value).then(onUpdated)}
+              >
+                {session.availableModes.map((mode) => (
+                  <option key={mode.id} value={mode.id}>{mode.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button type="button" onClick={() => void command('compact')}>Compact</button>
+          <button type="button" onClick={() => void command('rewind')}>Rewind</button>
+          <button type="button" onClick={() => void command('fork')}>Fork</button>
+          <button type="button" onClick={() => void exportSessionMarkdown(session.id)}>Export</button>
+          <button
+            type="button"
+            className="is-reject"
+            onClick={() => void deleteRecordedSession(session.id).then(onDeleted)}
+          >
+            Delete
+          </button>
+        </div>
+      </details>
     </section>
   )
 }


### PR DESCRIPTION
## Outcome

Plan approval answers Grok’s `x.ai/exit_plan_mode` request instead of sending a fake chat turn. The session console keeps plan, todos, and the queue up front; compact, rewind, fork, export, and delete sit under More session actions.

Cuts **v0.12.0** from the Unreleased changelog.

## Verification

- [x] `vitest` 124/124 and `npm run check`
- [x] Playwright 25/25 (Live, Control, Sessions, Library inspect, Runs, Fleet, Privacy, cancel)
- [x] Relevant automated tests added or updated
- [x] Desktop behavior checked
- [x] Mobile behavior checked when UI changed
- [x] No credentials, prompts, private source, personal names, local paths, or IP addresses added
- [x] Fleet changes preserve authenticated, bounded, read-only remote access
- [x] Fleet changes cover compatibility, failure, freshness, and reconnect states


Made with [Cursor](https://cursor.com)