### PR TITLE
Fix pending-permission state and cut 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 0.12.1 — 2026-08-26
+
+- A pending permission stays in Needs you instead of flipping back to
+  Working when a late stream chunk arrives.
+
 ## 0.12.0 — 2026-08-25
 
 - Plan approval answers Grok’s `x.ai/exit_plan_mode` request instead of

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and move through your complete local history without leaving the browser.
 </a>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.12.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.12.0)
+· [**See what’s new in v0.12.1**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.12.1)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -592,7 +592,7 @@ test.describe.serial('public launch path', () => {
     await page.getByRole('button', { name: 'Start session' }).click()
 
     const lane = page.locator('.lane-card').filter({ hasText: 'Hold for permission cancellation' })
-    await expect(lane.locator('.lane-state')).toContainText('attention')
+    await expect(lane.locator('.lane-state')).toContainText('attention', { timeout: 10_000 })
     await lane.getByRole('button', { name: 'Stop', exact: true }).click()
 
     await expect(lane.locator('.lane-state')).toContainText('cancelled')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",

--- a/server/grok-controller.test.ts
+++ b/server/grok-controller.test.ts
@@ -167,7 +167,11 @@ describe('GrokController plan review', () => {
       cwd: workspace,
       prompt: 'Write a fixture after plan review',
     })
-    await waitFor(() => controller.snapshot().permissions.some((item) => item.sessionId === followOn.id), 5_000)
+    await waitFor(() => {
+      const row = controller.snapshot().sessions.find((item) => item.id === followOn.id)
+      return row?.state === 'attention'
+        && controller.snapshot().permissions.some((item) => item.sessionId === followOn.id)
+    }, 5_000)
     const permission = controller.snapshot().permissions.find((item) => item.sessionId === followOn.id)
     expect(permission).toBeTruthy()
     controller.resolvePermission(permission!.id, 'allow')

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -839,7 +839,7 @@ export class GrokController extends EventEmitter {
     if (
       (update.sessionUpdate === 'tool_call' || update.sessionUpdate === 'agent_message_chunk')
       && next.cancellationStatus === 'none'
-      && ['starting', 'working', 'attention', 'stopping'].includes(next.state)
+      && ['starting', 'working', 'stopping'].includes(next.state)
     ) {
       next.state = 'working'
     }


### PR DESCRIPTION
## Outcome

v0.12.0 tagged but the Release e2e failed: a pending permission lane flipped back to Working, so Stop-while-asking never reached Needs you. Late stream chunks no longer overwrite attention.

## Verification

- [x] Controller test now waits for `attention` before allow
- [x] e2e permission-cancel wait increased to 10s
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)