### PR TITLE
Keep the supervisor up under file-watch pressure and fix Live, Changes, and console glitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 - Live lets you allow or reject a pending tool from the roster peek,
   without opening Control.
+- File watching uses Node's native recursive `fs.watch` instead of one
+  descriptor per directory, so a large Grok home or repository no longer
+  exhausts file descriptors (`EMFILE`) and crashes the supervisor. A watcher
+  that still fails is closed and reported: the Live monitor falls back to its
+  liveness poll, and Changes shows Manual refresh for that workspace. Only
+  the three most recent workspaces stay watched and common build and cache
+  directories are ignored. `chokidar` is no longer a dependency.
+- An unreachable server shows a Link interrupted screen with Try again
+  instead of the remote access token gate.
+- Live roster titles and workspaces are readable again; the roster grid still
+  reserved a column for a removed index.
+- Live's Open agents count matches the roster, which includes managed
+  sessions, and the roster peek flattens Markdown into prose.
+- Session console shows an em dash instead of `NaNd` when a session has no
+  update time.
+- Changes explains when a workspace is not a Git repository or when a filter
+  matches nothing, and probes only the six most recent workspaces for a
+  repository.
 
 ## 0.12.1 — 2026-08-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@agentclientprotocol/sdk": "^1.3.0",
         "@fontsource-variable/syne": "^5.3.0",
         "@fontsource/ibm-plex-mono": "^5.3.0",
-        "chokidar": "^5.0.0",
         "express": "^5.2.1",
         "lucide-react": "^1.26.0",
         "react": "^19.2.8",
@@ -1989,21 +1988,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -3202,19 +3186,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.8"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/rolldown": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@agentclientprotocol/sdk": "^1.3.0",
     "@fontsource-variable/syne": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
-    "chokidar": "^5.0.0",
     "express": "^5.2.1",
     "lucide-react": "^1.26.0",
     "react": "^19.2.8",

--- a/server/live-monitor.ts
+++ b/server/live-monitor.ts
@@ -2,8 +2,8 @@ import { EventEmitter } from 'node:events'
 import { promises as fs } from 'node:fs'
 import type { Dirent } from 'node:fs'
 import path from 'node:path'
-import chokidar, { type FSWatcher } from 'chokidar'
 import type { GrokStore } from './grok-store.js'
+import { describeWatchError, watchTree, type TreeWatcher } from './tree-watcher.js'
 import type {
   LiveAgent,
   LiveAgentState,
@@ -292,7 +292,7 @@ function fallbackSession(record: ActiveSessionRecord): SessionRow {
 }
 
 export class LiveMonitor extends EventEmitter {
-  private watcher: FSWatcher | null = null
+  private watchers: TreeWatcher[] = []
   private refreshTimer: NodeJS.Timeout | null = null
   private dashboardTimer: NodeJS.Timeout | null = null
   private livenessTimer: NodeJS.Timeout | null = null
@@ -311,27 +311,43 @@ export class LiveMonitor extends EventEmitter {
 
   async start(): Promise<void> {
     await this.refresh()
-    this.watcher = chokidar.watch([
-      path.join(this.store.grokHome, 'active_sessions.json'),
-      path.join(this.store.grokHome, 'sessions'),
-      path.join(this.store.grokHome, 'memory'),
-      path.join(this.store.grokHome, 'skills'),
-      path.join(this.store.grokHome, 'agents'),
-    ], {
-      ignoreInitial: true,
-      ignored: [
-        /[/\\]terminal[/\\]/,
-        /[/\\]rewind_points/,
-        /[/\\]chat_history/,
-      ],
-    })
-    this.watcher.on('all', (_event, changedPath) => {
+    const onChange = (changedPath: string) => {
       this.scheduleRefresh()
       if (/(summary\.json|signals\.json|active_sessions\.json|MEMORY\.md|SKILL\.md)$/.test(changedPath)) {
         this.scheduleDashboard()
       }
-    })
-    await new Promise<void>((resolve) => this.watcher?.once('ready', () => resolve()))
+    }
+    const treeNames = ['sessions', 'memory', 'skills', 'agents']
+    const watchedTrees = new Set<string>()
+    const watchTreeIfPresent = async (name: string) => {
+      const root = path.join(this.store.grokHome, name)
+      if (watchedTrees.has(root)) return
+      try {
+        if (!(await fs.stat(root)).isDirectory()) return
+      } catch {
+        return
+      }
+      watchedTrees.add(root)
+      this.watchers.push(watchTree(root, {
+        ignored: [/\/terminal\//, /\/rewind_points/, /\/chat_history/],
+        onChange,
+        onError: (error) => this.degrade(root, error),
+      }))
+    }
+    // active_sessions.json lives at the top of the Grok home. Watch the home
+    // directory without recursion so unrelated trees stay untouched, and pick
+    // up state directories that Grok creates later.
+    this.watchers = [
+      watchTree(this.store.grokHome, {
+        recursive: false,
+        onChange: (changedPath) => {
+          if (changedPath === 'active_sessions.json') onChange(changedPath)
+          if (treeNames.includes(changedPath)) void watchTreeIfPresent(changedPath)
+        },
+        onError: (error) => this.degrade(this.store.grokHome, error),
+      }),
+    ]
+    await Promise.all(treeNames.map((name) => watchTreeIfPresent(name)))
     this.livenessTimer = setInterval(() => this.scheduleRefresh(), 2_000)
   }
 
@@ -340,8 +356,15 @@ export class LiveMonitor extends EventEmitter {
     if (this.dashboardTimer) clearTimeout(this.dashboardTimer)
     if (this.livenessTimer) clearInterval(this.livenessTimer)
     this.livenessTimer = null
-    await this.watcher?.close()
-    this.watcher = null
+    this.watchers.forEach((watcher) => watcher.close())
+    this.watchers = []
+  }
+
+  private degrade(root: string, error: unknown): void {
+    // Watching a large Grok home can fail (EMFILE, ENOSPC). An unhandled
+    // watcher error would crash the supervisor, so warn once and rely on the
+    // 2s liveness poll for that tree instead.
+    console.warn(`Live monitor file watching degraded to polling for ${root}: ${describeWatchError(error)}`)
   }
 
   snapshot(): LiveSnapshot {

--- a/server/tree-watcher.test.ts
+++ b/server/tree-watcher.test.ts
@@ -1,0 +1,90 @@
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { describeWatchError, watchTree } from './tree-watcher.js'
+
+const cleanup: string[] = []
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })))
+})
+
+function waitFor<T>(register: (resolve: (value: T) => void) => void, ms = 4_000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('watcher did not emit in time')), ms)
+    register((value) => {
+      clearTimeout(timer)
+      resolve(value)
+    })
+  })
+}
+
+describe('watchTree', () => {
+  it('reports nested changes with slash-separated relative paths and honors ignores', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-tree-watch-'))
+    cleanup.push(root)
+    await fs.mkdir(path.join(root, 'src', 'deep'), { recursive: true })
+    await fs.mkdir(path.join(root, 'node_modules', 'pkg'), { recursive: true })
+    const seen: string[] = []
+    let notify: ((value: string) => void) | null = null
+    const watcher = watchTree(root, {
+      ignored: [/\/node_modules\//],
+      onChange: (relative) => {
+        seen.push(relative)
+        notify?.(relative)
+      },
+    })
+    // Give the native watcher a moment to arm before writing.
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    const first = waitFor<string>((resolve) => { notify = resolve })
+    await fs.writeFile(path.join(root, 'src', 'deep', 'file.txt'), 'hello')
+    expect(await first).toBe('src/deep/file.txt')
+
+    await fs.writeFile(path.join(root, 'node_modules', 'pkg', 'index.js'), '// ignored')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(seen.some((item) => item.startsWith('node_modules/'))).toBe(false)
+    watcher.close()
+    watcher.close()
+  })
+
+  it('reports a missing root through onError instead of throwing', async () => {
+    const error = await waitFor<unknown>((resolve) => {
+      watchTree(path.join(os.tmpdir(), `grok-ui-missing-${Date.now()}`), {
+        onChange: () => undefined,
+        onError: resolve,
+      })
+    })
+    expect(describeWatchError(error)).toBe('ENOENT')
+  })
+
+  it('describes descriptor exhaustion with a hint', () => {
+    expect(describeWatchError(Object.assign(new Error('x'), { code: 'EMFILE' }))).toContain('too many open files')
+    expect(describeWatchError(new Error('plain'))).toBe('plain')
+  })
+})
+
+describe('watchTree without recursion', () => {
+  it('only reports direct children', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'grok-ui-flat-watch-'))
+    cleanup.push(root)
+    await fs.mkdir(path.join(root, 'nested'))
+    const seen: string[] = []
+    let notify: ((value: string) => void) | null = null
+    const watcher = watchTree(root, {
+      recursive: false,
+      onChange: (relative) => {
+        seen.push(relative)
+        notify?.(relative)
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    await fs.writeFile(path.join(root, 'nested', 'inner.txt'), 'x')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const top = waitFor<string>((resolve) => { notify = resolve })
+    await fs.writeFile(path.join(root, 'active_sessions.json'), '[]')
+    expect(await top).toBe('active_sessions.json')
+    expect(seen.some((item) => item.includes('inner.txt'))).toBe(false)
+    watcher.close()
+  })
+})

--- a/server/tree-watcher.ts
+++ b/server/tree-watcher.ts
@@ -1,0 +1,68 @@
+import { watch, type FSWatcher } from 'node:fs'
+import path from 'node:path'
+
+export interface TreeWatcherOptions {
+  /** Patterns tested against the path relative to the watched root, wrapped in `/` separators. */
+  ignored?: RegExp[]
+  /** Watch nested directories too. Defaults to true. */
+  recursive?: boolean
+  onChange: (relativePath: string) => void
+  /** Called at most once when the watcher fails; the watcher is closed before the call. */
+  onError?: (error: unknown) => void
+}
+
+export interface TreeWatcher {
+  close(): void
+}
+
+/**
+ * Watch a directory tree with Node's native recursive `fs.watch`.
+ *
+ * On macOS this is one FSEvents stream and on Windows one ReadDirectoryChangesW
+ * handle regardless of tree size, so a large repository or Grok home does not
+ * consume one file descriptor per directory the way a per-directory watcher
+ * does. Linux uses inotify watches, which are bounded by
+ * `fs.inotify.max_user_watches` rather than the descriptor limit.
+ */
+export function watchTree(root: string, options: TreeWatcherOptions): TreeWatcher {
+  const ignored = options.ignored || []
+  let watcher: FSWatcher | null = null
+  let failed = false
+  const fail = (error: unknown) => {
+    if (failed) return
+    failed = true
+    close()
+    options.onError?.(error)
+  }
+  const close = () => {
+    if (!watcher) return
+    const current = watcher
+    watcher = null
+    try {
+      current.close()
+    } catch {
+      // Closing twice or after an error is harmless.
+    }
+  }
+  try {
+    watcher = watch(root, { recursive: options.recursive !== false, persistent: true }, (_event, filename) => {
+      const relative = filename ? path.normalize(String(filename)).split(path.sep).join('/') : ''
+      if (relative && ignored.some((pattern) => pattern.test(`/${relative}/`))) return
+      options.onChange(relative)
+    })
+    watcher.on('error', fail)
+  } catch (error) {
+    queueMicrotask(() => fail(error))
+  }
+  return { close }
+}
+
+export function describeWatchError(error: unknown): string {
+  if (error && typeof error === 'object' && 'code' in error && typeof (error as { code: unknown }).code === 'string') {
+    const code = (error as { code: string }).code
+    if (code === 'EMFILE' || code === 'ENFILE') return `${code} (too many open files; raise ulimit -n or reduce watched files)`
+    if (code === 'ENOSPC') return `${code} (inotify watch limit reached; raise fs.inotify.max_user_watches)`
+    return code
+  }
+  return error instanceof Error ? error.message : String(error)
+}

--- a/server/tree-watcher.ts
+++ b/server/tree-watcher.ts
@@ -1,4 +1,4 @@
-import { watch, type FSWatcher } from 'node:fs'
+import { statSync, watch, type FSWatcher } from 'node:fs'
 import path from 'node:path'
 
 export interface TreeWatcherOptions {
@@ -45,6 +45,11 @@ export function watchTree(root: string, options: TreeWatcherOptions): TreeWatche
     }
   }
   try {
+    // Node reports a missing root differently per platform (a synchronous
+    // throw, a later error event, or silence on Linux), so check up front.
+    if (!statSync(root).isDirectory()) {
+      throw Object.assign(new Error(`${root} is not a directory`), { code: 'ENOTDIR' })
+    }
     watcher = watch(root, { recursive: options.recursive !== false, persistent: true }, (_event, filename) => {
       const relative = filename ? path.normalize(String(filename)).split(path.sep).join('/') : ''
       if (relative && ignored.some((pattern) => pattern.test(`/${relative}/`))) return

--- a/server/types.ts
+++ b/server/types.ts
@@ -348,6 +348,8 @@ export interface WorkspaceSnapshot {
   additions: number
   deletions: number
   error: string
+  /** False when live file watching is unavailable and only manual refresh updates the view. */
+  watching?: boolean
 }
 
 export interface WorkspaceChangeEvent {

--- a/server/workspace-inspector.ts
+++ b/server/workspace-inspector.ts
@@ -3,13 +3,13 @@ import { EventEmitter } from 'node:events'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import chokidar, { type FSWatcher } from 'chokidar'
 import type {
   WorkspaceChangeEvent,
   WorkspaceDiff,
   WorkspaceFileChange,
   WorkspaceSnapshot,
 } from './types.js'
+import { describeWatchError, watchTree, type TreeWatcher } from './tree-watcher.js'
 
 const execFileAsync = promisify(execFile)
 const MAX_DIFF_BYTES = 240 * 1024
@@ -40,14 +40,29 @@ function parseNumstat(value: string, staged: boolean): Map<string, WorkspaceFile
   return files
 }
 
-export class WorkspaceInspector extends EventEmitter {
-  private watchers = new Map<string, FSWatcher[]>()
-  private watcherReady = new Map<string, Promise<void>>()
-  private changeTimers = new Map<string, NodeJS.Timeout>()
+const MAX_WATCHED_ROOTS = 3
 
-  private async watch(root: string): Promise<void> {
-    const existing = this.watcherReady.get(root)
-    if (existing) return existing
+const WATCH_IGNORED = [
+  // Git internals churn constantly; the few files that matter are allowed below.
+  /^\/\.git\/(?!(HEAD|ORIG_HEAD|MERGE_HEAD|FETCH_HEAD|index|packed-refs)\/|refs\/)/,
+  /\/node_modules\//,
+  /\/(dist|dist-server|build|out|coverage|target|vendor|\.next|\.nuxt|\.turbo|\.cache|\.venv|venv|__pycache__|\.pytest_cache|\.gradle|DerivedData|Pods)\//,
+]
+
+
+export class WorkspaceInspector extends EventEmitter {
+  private watchers = new Map<string, TreeWatcher>()
+  private changeTimers = new Map<string, NodeJS.Timeout>()
+  private degraded = new Set<string>()
+
+  private watch(root: string): void {
+    if (this.degraded.has(root) || this.watchers.has(root)) return
+    // Bound resource use: keep only the most recently inspected roots.
+    while (this.watchers.size >= MAX_WATCHED_ROOTS) {
+      const oldest = this.watchers.keys().next().value
+      if (!oldest) break
+      this.unwatch(oldest)
+    }
     const onChange = () => {
       const existing = this.changeTimers.get(root)
       if (existing) clearTimeout(existing)
@@ -60,36 +75,38 @@ export class WorkspaceInspector extends EventEmitter {
         this.emit('change', event)
       }, 180))
     }
-    const files = chokidar.watch(root, {
-      ignoreInitial: true,
-      ignored: [
-        /[/\\]\.git[/\\]/,
-        /[/\\]node_modules[/\\]/,
-      ],
+    const watcher = watchTree(root, {
+      ignored: WATCH_IGNORED,
+      onChange,
+      onError: (error) => {
+        // A failing watcher (EMFILE, ENOSPC, an unmounted volume) must not
+        // take the supervisor down. Stop watching that root; the manual
+        // refresh and the Git status snapshot keep working.
+        this.degraded.add(root)
+        this.unwatch(root)
+        console.warn(`Workspace watch stopped for ${root}: ${describeWatchError(error)}`)
+        // Let open Changes views refresh and switch to their manual-refresh state.
+        onChange()
+      },
     })
-    const gitState = chokidar.watch([
-      path.join(root, '.git', 'HEAD'),
-      path.join(root, '.git', 'index'),
-      path.join(root, '.git', 'refs'),
-    ], {
-      ignoreInitial: true,
-    })
-    files.on('all', onChange)
-    gitState.on('all', onChange)
-    this.watchers.set(root, [files, gitState])
-    const ready = Promise.all([files, gitState].map((watcher) =>
-      new Promise<void>((resolve) => watcher.once('ready', () => resolve())),
-    )).then(() => undefined)
-    this.watcherReady.set(root, ready)
-    await ready
+    this.watchers.set(root, watcher)
+  }
+
+  watching(root: string): boolean {
+    return this.watchers.has(root) && !this.degraded.has(root)
+  }
+
+  private unwatch(root: string): void {
+    const watcher = this.watchers.get(root)
+    this.watchers.delete(root)
+    watcher?.close()
   }
 
   async close(): Promise<void> {
     this.changeTimers.forEach((timer) => clearTimeout(timer))
     this.changeTimers.clear()
-    await Promise.all([...this.watchers.values()].flat().map((watcher) => watcher.close()))
+    this.watchers.forEach((watcher) => watcher.close())
     this.watchers.clear()
-    this.watcherReady.clear()
   }
 
   async snapshot(inputCwd: string): Promise<WorkspaceSnapshot> {
@@ -107,7 +124,7 @@ export class WorkspaceInspector extends EventEmitter {
         ? await git(root, ['rev-list', '--left-right', '--count', `HEAD...${upstream}`]).catch(() => '0\t0')
         : '0\t0'
       const [ahead, behind] = divergence.split(/\s+/).map((value) => Number(value) || 0)
-      await this.watch(root)
+      this.watch(root)
       const unstaged = parseNumstat(unstagedRaw, false)
       const staged = parseNumstat(stagedRaw, true)
       const files = new Map<string, WorkspaceFileChange>()
@@ -152,6 +169,7 @@ export class WorkspaceInspector extends EventEmitter {
         additions: list.reduce((sum, file) => sum + file.additions, 0),
         deletions: list.reduce((sum, file) => sum + file.deletions, 0),
         error: '',
+        watching: this.watching(root),
       }
     } catch {
       return {
@@ -167,6 +185,7 @@ export class WorkspaceInspector extends EventEmitter {
         additions: 0,
         deletions: 0,
         error: 'This workspace is not a Git repository.',
+        watching: false,
       }
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,6 +198,7 @@ function liveSessionStatus(session: SessionRow, live: LiveSnapshot | null): Sess
 function App() {
   const initialRoute = parseHash(window.location.hash)
   const [authenticated, setAuthenticated] = useState<boolean | null>(null)
+  const [authCheckError, setAuthCheckError] = useState('')
   const [view, setView] = useState<ViewId>(initialRoute.view)
   const [data, setData] = useState<DashboardPayload | null>(null)
   const [live, setLive] = useState<LiveSnapshot | null>(null)
@@ -293,11 +294,22 @@ function App() {
     }
   }, [])
 
-  useEffect(() => {
+  const checkAuth = useCallback(() => {
+    setAuthCheckError('')
+    setAuthenticated(null)
     void getAuthStatus()
       .then((status) => setAuthenticated(status.authenticated))
-      .catch(() => setAuthenticated(false))
+      .catch((checkError) => {
+        // A failed status request means the local API is unreachable, not
+        // that a token is required. Show a retry instead of the sign-in gate.
+        console.warn('Grok UI server unreachable:', checkError)
+        setAuthCheckError(checkError instanceof Error ? checkError.message : 'Authentication check failed')
+      })
   }, [])
+
+  useEffect(() => {
+    checkAuth()
+  }, [checkAuth])
 
   useEffect(() => {
     if (!authenticated) return
@@ -475,6 +487,18 @@ function App() {
       : { id: session.id, fallback: session, opener })
   }, [data?.sessions, takeInteractionTarget])
 
+  if (authCheckError) {
+    return (
+      <main className="access-screen">
+        <AmbientGrid />
+        <ErrorState
+          message="The Grok UI server did not respond. Start it with grok-ui or npm start, then try again."
+
+          onRetry={checkAuth}
+        />
+      </main>
+    )
+  }
   if (authenticated === null) return <BootScreen label="SECURING LOCAL LINK" />
   if (!authenticated) return <AuthScreen onAuthenticated={() => setAuthenticated(true)} />
 
@@ -944,8 +968,8 @@ function LiveView({
       <section className="live-summary-strip">
         <LiveSummaryMetric
           label="Open agents"
-          value={String(live?.activeCount || 0)}
-          detail="registered Grok processes"
+          value={String(roster.length)}
+          detail={live?.activeCount ? `${live.activeCount} Grok process${live.activeCount === 1 ? '' : 'es'}` : 'live and managed sessions'}
           tone="lime"
         />
         <LiveSummaryMetric

--- a/src/live-roster.test.ts
+++ b/src/live-roster.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildRoster, groupedRoster, permissionsForSession, shouldShowFirstRun } from './live-roster'
+import { buildRoster, groupedRoster, peekText, permissionsForSession, shouldShowFirstRun } from './live-roster'
 import type { ControlSnapshot, LiveSnapshot } from './types'
 
 describe('live roster', () => {
@@ -74,5 +74,20 @@ describe('live roster', () => {
       hasRoster: false,
       archivedSessions: 0,
     })).toBe(true)
+  })
+})
+
+describe('peekText', () => {
+  it('flattens Markdown into prose for the roster peek', () => {
+    const input = '## Summary\n\n**Branch:** `main` - working tree *clean*.\n\n| Commit | Message |\n|---|---|\n| `0c3e7ef` | control: confirm |\n\n- run `git pull --rebase`\n- then push'
+    expect(peekText(input)).toBe(
+      'Summary Branch: main - working tree clean. Commit · Message 0c3e7ef · control: confirm run git pull --rebase then push',
+    )
+  })
+
+  it('keeps plain text and bounds the length', () => {
+    expect(peekText('Hello there')).toBe('Hello there')
+    expect(peekText('x'.repeat(500), 40)).toHaveLength(40)
+    expect(peekText('x'.repeat(500), 40).endsWith('…')).toBe(true)
   })
 })

--- a/src/live-roster.ts
+++ b/src/live-roster.ts
@@ -83,6 +83,30 @@ export function groupedRoster(rows: RosterRow[]): Array<{ id: RosterState; label
     .filter((group) => group.rows.length > 0)
 }
 
+/**
+ * Flatten Markdown from an assistant message into plain prose for the small
+ * roster peek, which has no room to render it.
+ */
+export function peekText(input: string, limit = 360): string {
+  let text = input
+    .replace(/```[a-z]*\n?([\s\S]*?)```/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/(^|\s)[*_]([^*_\n]+)[*_](?=\s|$|[.,;:!?])/g, '$1$2')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/^\s*[-*+]\s+/gm, '')
+    .replace(/^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/gm, '')
+    .replace(/^[ \t]*\|[ \t]*|[ \t]*\|[ \t]*$/gm, '')
+    .replace(/\s*\|\s*/g, ' · ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\s*\n+\s*/g, ' ')
+    .trim()
+  if (text.length > limit) text = `${text.slice(0, limit - 1).trimEnd()}…`
+  return text
+}
+
 function fromLive(agent: LiveAgent): RosterRow {
   return {
     id: agent.id,

--- a/src/styles.css
+++ b/src/styles.css
@@ -913,9 +913,9 @@ kbd {
   min-height: 78px;
   padding: 11px 12px;
   display: grid;
-  grid-template-columns: 25px 18px 1fr 16px;
+  grid-template-columns: 18px minmax(0, 1fr) 16px;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   color: var(--muted);
   border: 0;
   border-bottom: 1px solid var(--line);

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,6 +349,8 @@ export interface WorkspaceSnapshot {
   additions: number
   deletions: number
   error: string
+  /** False when live file watching is unavailable and only manual refresh updates the view. */
+  watching?: boolean
 }
 
 export interface WorkspaceChangeEvent {

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -18,6 +18,8 @@ import type {
 } from '../types'
 import { usePrivacy } from '../privacy'
 
+const REPOSITORY_PROBE_LIMIT = 6
+
 interface ChangesViewProps {
   data: DashboardPayload
   live: LiveSnapshot | null
@@ -46,7 +48,9 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
     try {
       let payload = await getWorkspaceSnapshot(workspace)
       if (!payload.repository && workspace === workspaces[0]) {
-        for (const candidate of workspaces.slice(1)) {
+        // Probe only a handful of recent workspaces for a repository; each
+        // probe starts a Git status read on the server.
+        for (const candidate of workspaces.slice(1, 1 + REPOSITORY_PROBE_LIMIT)) {
           const candidatePayload = await getWorkspaceSnapshot(candidate)
           if (candidatePayload.repository) {
             setCwd(candidate)
@@ -88,6 +92,7 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
   }
 
   const files = snapshot?.files.filter((file) => file.path.toLowerCase().includes(query.toLowerCase())) || []
+  const watching = snapshot ? snapshot.watching !== false && snapshot.repository : true
 
   return (
     <>
@@ -109,9 +114,12 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
             ))}
           </select>
         </label>
-        <span className={`workspace-live-state ${connected ? 'is-connected' : ''}`}>
-          <span className={`status-dot ${connected ? 'is-live' : ''}`} />
-          {connected ? 'LIVE WATCH' : 'RECONNECTING'}
+        <span
+          className={`workspace-live-state ${connected && watching ? 'is-connected' : ''}`}
+          title={!connected ? 'The event stream is reconnecting.' : watching ? 'Changes update automatically as files change.' : 'Live file watching is unavailable for this workspace. Use Refresh to update.'}
+        >
+          <span className={`status-dot ${connected && watching ? 'is-live' : ''}`} />
+          {!connected ? 'RECONNECTING' : watching ? 'LIVE WATCH' : 'MANUAL REFRESH'}
         </span>
         <button className="icon-button" onClick={() => void loadWorkspace()} aria-label="Refresh changes">
           <RefreshCw size={17} className={loading ? 'is-spinning' : ''} />
@@ -149,10 +157,12 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
             {!files.length && (
               <p className="files-empty">
                 {snapshot?.repository
-                  ? 'Working tree clean.'
-                  : snapshot?.error
-                    ? privacy.content(snapshot.error)
-                    : 'No workspace selected.'}
+                  ? (query ? 'No changed files match this filter.' : 'Working tree clean.')
+                  : snapshot
+                    ? privacy.content(snapshot.error || 'This workspace is not a Git repository.')
+                    : workspaces.length
+                      ? 'Reading workspace…'
+                      : 'No workspace yet. Start a Grok session in a repository to inspect its changes here.'}
               </p>
             )}
           </div>

--- a/src/views/LiveRoster.tsx
+++ b/src/views/LiveRoster.tsx
@@ -1,7 +1,7 @@
 import { ArrowRight, Check, ChevronRight, CornerDownLeft, ShieldAlert, X } from 'lucide-react'
 import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import { promptControlSession, resolveControlPermission } from '../api'
-import { buildRoster, groupedRoster, permissionsForSession } from '../live-roster'
+import { buildRoster, groupedRoster, peekText, permissionsForSession } from '../live-roster'
 import { usePrivacy } from '../privacy'
 import type { ControlSnapshot, LiveSnapshot, SessionRow } from '../types'
 
@@ -148,7 +148,7 @@ export function LiveRoster({
               {selected.peek.length ? selected.peek.map((item) => (
                 <p key={item.id}>
                   <small>{item.type}</small>
-                  {privacy.content(item.text || item.title)}
+                  {privacy.content(peekText(item.text || item.title))}
                 </p>
               )) : pending.length === 0 ? <p>No recent activity to peek yet.</p> : null}
             </div>

--- a/src/views/SessionWorkbench.tsx
+++ b/src/views/SessionWorkbench.tsx
@@ -77,7 +77,9 @@ function time(value: string): string {
 }
 
 function elapsed(value: string): string {
-  const difference = Math.max(0, Date.now() - new Date(value).getTime())
+  const stamp = new Date(value).getTime()
+  if (!value || Number.isNaN(stamp)) return '—'
+  const difference = Math.max(0, Date.now() - stamp)
   if (difference < 60_000) return 'now'
   if (difference < 3_600_000) return `${Math.floor(difference / 60_000)}m`
   if (difference < 86_400_000) return `${Math.floor(difference / 3_600_000)}h`


### PR DESCRIPTION
## Why

While reviewing the UI, the supervisor crashed twice with `EMFILE`. Chokidar opened one descriptor per directory: the Live monitor held ~2,000 on `~/.grok/sessions` and one large repo on Changes added ~7,500 more. Neither watcher handled the error event, so the process died, and the client then showed the remote access token gate because the auth check failed.

## What changed

- **Native file watching.** New `server/tree-watcher.ts` wraps Node's recursive `fs.watch`. Both the Live monitor and the workspace inspector use it with the same ignore rules, an error path that degrades instead of crashing, and a cap of three watched workspaces. Descriptor count with two repos plus the Grok home dropped from 11,846 to 26. `chokidar` is removed.
- **Unreachable server screen.** A failed auth check shows Link interrupted with Try again instead of the token gate.
- **Live roster titles readable.** The roster grid still reserved a column for a removed index, squeezing titles to "gi…".
- **Live metrics agree with the roster.** Open agents counts live and managed sessions; the peek flattens Markdown into prose.
- **Session console** shows an em dash instead of `NaNd` when a session has no timestamp.
- **Changes** explains non-repository workspaces and empty filters, probes only six recent workspaces, shows Manual refresh if a watch is lost, and no longer blocks the snapshot on watcher scanning.

## Verification

- `npm run check` clean
- `npx vitest run` 132 passed (4 new tree-watcher tests)
- `npm run test:e2e` 26 passed
- `git diff --check` clean
- Browser: Live, Changes live update on file touch, session console, and the retry path confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XWBXZXkWjND2DLyYuRBjz
