### PR TITLE
Make the session console read like a conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 - Live lets you allow or reject a pending tool from the roster peek,
   without opening Control.
+- Session console renders Grok replies as Markdown (headings, emphasis, code,
+  lists, tables, links) through a renderer that never emits raw HTML.
+- Session console shows one row per tool call, with the descriptive title and
+  final status, instead of a pending row followed by an update row. Live and
+  recorded events share the same labels: User message, Reasoning, Grok
+  response.
+- Long pasted messages start collapsed with a Show all control; the newest
+  event always shows in full. The timeline opens at the latest event and the
+  Latest button only appears once you scroll up.
+- Session console header shows model, agent, and start date instead of filler
+  copy, and the instruments show the model where status was duplicated. While
+  a session loads, the title and workspace say so instead of inventing values.
 - File watching uses Node's native recursive `fs.watch` instead of one
   descriptor per directory, so a large Grok home or repository no longer
   exhausts file descriptors (`EMFILE`) and crashes the supervisor. A watcher

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -309,7 +309,7 @@ test.describe.serial('public launch path', () => {
     const dialog = page.getByRole('dialog', { name: /Session console:/ })
     await expect(dialog).toBeVisible()
     await expect(page.getByText(/^Session · /)).toBeVisible()
-    await expect(page.getByText('Chat with this agent, review its activity, and inspect changes.')).toBeVisible()
+    await expect(dialog.getByLabel('Session context')).toBeVisible()
     await expect(page.getByRole('navigation', { name: 'Session console sections' })).toBeVisible()
     const prompt = page.getByPlaceholder('Send a follow-up to this session…')
     const closeButton = page.getByRole('button', { name: 'Close session console panel' })

--- a/server/grok-controller.ts
+++ b/server/grok-controller.ts
@@ -117,29 +117,21 @@ function feedItem(update: SessionNotification['update']): LiveFeedItem | null {
     return {
       id: `${timestamp}:${type}:${Math.random()}`,
       type: type === 'user_message_chunk' ? 'user' : type === 'agent_message_chunk' ? 'assistant' : 'thought',
-      title: type.replaceAll('_', ' '),
+      // Match the labels the on-disk transcript reader uses so live and recorded rows read the same.
+      title: type === 'user_message_chunk' ? 'User message' : type === 'agent_message_chunk' ? 'Grok response' : 'Reasoning',
       text: blockText(update.content),
       status: '',
       timestamp,
     }
   }
-  if (type === 'tool_call') {
+  if (type === 'tool_call' || type === 'tool_call_update') {
+    // One stable id per tool call so later updates replace the row instead of adding one.
     return {
-      id: `${timestamp}:${update.toolCallId}`,
+      id: `tool:${update.toolCallId}`,
       type: 'tool',
-      title: update.title,
+      title: update.title || (type === 'tool_call' ? 'Tool call' : 'Tool update'),
       text: '',
-      status: update.status || 'pending',
-      timestamp,
-    }
-  }
-  if (type === 'tool_call_update') {
-    return {
-      id: `${timestamp}:${update.toolCallId}:${Math.random()}`,
-      type: 'tool',
-      title: update.title || 'Tool update',
-      text: '',
-      status: update.status || '',
+      status: update.status || (type === 'tool_call' ? 'pending' : ''),
       timestamp,
     }
   }
@@ -864,7 +856,16 @@ export class GrokController extends EventEmitter {
         return
       }
       const previous = next.feed.at(-1)
-      if (
+      const existingTool = item.type === 'tool' ? next.feed.find((existing) => existing.id === item.id) : undefined
+      if (existingTool) {
+        const merged = item
+        next.feed = next.feed.map((existing) => existing.id !== merged.id ? existing : {
+          ...existing,
+          title: merged.title && merged.title !== 'Tool update' ? merged.title : existing.title,
+          status: merged.status || existing.status,
+          timestamp: merged.timestamp,
+        })
+      } else if (
         previous
         && previous.type === item.type
         && ['user', 'assistant', 'thought'].includes(item.type)

--- a/server/session-reader.ts
+++ b/server/session-reader.ts
@@ -61,7 +61,9 @@ function boundedText(value: string): string {
   return `${value.slice(0, MAX_ITEM_TEXT)}\n\n[content truncated by Grok UI]`
 }
 
-function updateItem(line: string, index: number, fallback: string): LiveFeedItem | null {
+type DiskFeedItem = LiveFeedItem & { toolCallId?: string }
+
+function updateItem(line: string, index: number, fallback: string): DiskFeedItem | null {
   let record: Json
   try {
     record = object(JSON.parse(line))
@@ -92,13 +94,15 @@ function updateItem(line: string, index: number, fallback: string): LiveFeedItem
     }
   }
   if (kind === 'tool_call' || kind === 'tool_call_update') {
+    const toolCallId = string(update.toolCallId)
     return {
       ...base,
-      id: `disk:${string(update.toolCallId) || index}:${at}:${kind}`,
+      id: `disk:${toolCallId || index}:${at}:${kind}`,
       type: 'tool',
       title: string(update.title) || (kind === 'tool_call' ? 'Tool call' : 'Tool update'),
       text: '',
       status: string(update.status) || (kind === 'tool_call' ? 'pending' : ''),
+      toolCallId: toolCallId || undefined,
     }
   }
   if (kind === 'plan' || kind === 'plan_update') {
@@ -134,8 +138,9 @@ function historyItem(line: string, index: number, fallback: string): LiveFeedIte
   return null
 }
 
-function coalesce(items: LiveFeedItem[]): LiveFeedItem[] {
+function coalesce(items: DiskFeedItem[]): LiveFeedItem[] {
   const output: LiveFeedItem[] = []
+  const toolRows = new Map<string, LiveFeedItem>()
   for (const item of items) {
     const previous = output.at(-1)
     if (
@@ -148,7 +153,21 @@ function coalesce(items: LiveFeedItem[]): LiveFeedItem[] {
       previous.timestamp = item.timestamp
       continue
     }
-    output.push({ ...item })
+    const { toolCallId, ...row } = item
+    if (item.type === 'tool' && toolCallId) {
+      // Grok emits one tool_call followed by several tool_call_update records
+      // for the same call. Show a single row that carries the most descriptive
+      // title Grok has provided so far and the latest status.
+      const existing = toolRows.get(toolCallId)
+      if (existing) {
+        if (row.title && row.title !== 'Tool update') existing.title = row.title
+        if (row.status) existing.status = row.status
+        existing.timestamp = row.timestamp
+        continue
+      }
+      toolRows.set(toolCallId, row)
+    }
+    output.push(row)
   }
   return output.slice(-MAX_ITEMS)
 }
@@ -199,9 +218,17 @@ export class SessionReader {
   }
 }
 
+/** Labels written by earlier Grok UI versions, kept readable for sessions persisted before the rename. */
+const LEGACY_TITLES: Record<string, string> = {
+  'user message chunk': 'User message',
+  'agent message chunk': 'Grok response',
+  'agent thought chunk': 'Reasoning',
+}
+
 export function mergeSessionFeed(...feeds: LiveFeedItem[][]): LiveFeedItem[] {
   const seen = new Set<string>()
   return feeds.flat()
+    .map((item) => LEGACY_TITLES[item.title] ? { ...item, title: LEGACY_TITLES[item.title] } : item)
     .filter((item) => {
       const key = item.text
         ? `${item.type}\u0000${item.text.trim()}`

--- a/server/session-workbench.test.ts
+++ b/server/session-workbench.test.ts
@@ -168,8 +168,30 @@ describe('Session transcript reader', () => {
           update: {
             sessionUpdate: 'tool_call',
             toolCallId: 'tool-1',
+            title: 'read_file',
+            rawInput: { secret: 'do-not-expose' },
+          },
+        },
+      },
+      {
+        timestamp: 1_784_887_204,
+        params: {
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tool-1',
             title: 'Read project',
             rawInput: { secret: 'do-not-expose' },
+          },
+        },
+      },
+      {
+        timestamp: 1_784_887_205,
+        params: {
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'tool-1',
+            status: 'completed',
+            rawOutput: { secret: 'do-not-expose' },
           },
         },
       },
@@ -203,7 +225,9 @@ describe('Session transcript reader', () => {
     })
 
     expect(transcript.map((item) => item.type)).toEqual(['user', 'thought', 'assistant', 'tool'])
-    expect(transcript[3]).toMatchObject({ title: 'Read project', status: 'pending' })
+    // One tool call and its updates collapse into a single row with the descriptive title and final status.
+    expect(transcript[3]).toMatchObject({ title: 'Read project', status: 'completed' })
+    expect(JSON.stringify(transcript)).not.toContain('toolCallId')
     expect(JSON.stringify(transcript)).not.toContain('do-not-expose')
   })
 

--- a/src/markdown.test.tsx
+++ b/src/markdown.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { Markdown } from './markdown'
+
+const html = (text: string) => renderToStaticMarkup(<Markdown text={text} />)
+
+describe('Markdown', () => {
+  it('renders headings, emphasis, inline code, and paragraphs', () => {
+    const out = html('## Summary\n\n**Branch:** `main` is *clean* and ~~dirty~~.\nSecond line.')
+    expect(out).toContain('<h2>Summary</h2>')
+    expect(out).toContain('<strong>Branch:</strong> <code>main</code> is <em>clean</em> and <s>dirty</s>.')
+    expect(out).toContain('<br/>Second line.')
+  })
+
+  it('renders fenced code without interpreting its contents', () => {
+    const out = html('```bash\ngit pull --rebase # **not bold**\n```')
+    expect(out).toContain('<pre data-language="bash"><code>git pull --rebase # **not bold**</code></pre>')
+  })
+
+  it('renders lists, task items, block quotes, tables, and rules', () => {
+    const out = html([
+      '- first',
+      '- [x] done task',
+      '1. one',
+      '2. two',
+      '',
+      '> quoted **text**',
+      '',
+      '| Commit | Message |',
+      '|---|---|',
+      '| `0c3e7ef` | control: confirm |',
+      '',
+      '---',
+    ].join('\n'))
+    expect(out).toContain('<ul><li>first</li><li class="task is-done">')
+    expect(out).toContain('<ol><li>one</li><li>two</li></ol>')
+    expect(out).toContain('<blockquote><p>quoted <strong>text</strong></p></blockquote>')
+    expect(out).toContain('<th>Commit</th><th>Message</th>')
+    expect(out).toContain('<td><code>0c3e7ef</code></td><td>control: confirm</td>')
+    expect(out).toContain('<hr/>')
+  })
+
+  it('escapes HTML and only links to http(s) targets', () => {
+    const out = html('<script>alert(1)</script> [ok](https://example.com) [bad](javascript:alert(1)) <https://x.test>')
+    expect(out).not.toContain('<script>')
+    expect(out).toContain('&lt;script&gt;')
+    expect(out).toContain('<a href="https://example.com" target="_blank" rel="noopener noreferrer">ok</a>')
+    expect(out).toContain('[bad](javascript:alert(1))')
+    expect(out).toContain('<a href="https://x.test" target="_blank" rel="noopener noreferrer">https://x.test</a>')
+  })
+
+  it('leaves underscores inside identifiers alone', () => {
+    expect(html('use read_file then list_dir')).toContain('<p>use read_file then list_dir</p>')
+  })
+})

--- a/src/markdown.tsx
+++ b/src/markdown.tsx
@@ -1,0 +1,209 @@
+import { Fragment, type ReactNode } from 'react'
+
+/**
+ * Render a bounded subset of Markdown produced by Grok into React elements.
+ *
+ * The renderer never emits raw HTML. Every construct becomes a React element
+ * built from parsed text, so content from a session record cannot inject
+ * markup. Supported: headings, paragraphs, fenced and inline code, bold,
+ * italic, strikethrough, links (http/https only, opened in a new tab),
+ * bullet and numbered lists, block quotes, tables, and horizontal rules.
+ */
+export function Markdown({ text, className }: { text: string; className?: string }) {
+  return <div className={className ? `markdown ${className}` : 'markdown'}>{renderMarkdown(text)}</div>
+}
+
+export function renderMarkdown(text: string): ReactNode[] {
+  const lines = text.replace(/\r\n?/g, '\n').split('\n')
+  const output: ReactNode[] = []
+  let index = 0
+  let key = 0
+  const next = () => `md-${key++}`
+
+  while (index < lines.length) {
+    const line = lines[index]
+    if (!line.trim()) {
+      index += 1
+      continue
+    }
+
+    const fence = /^\s*(```|~~~)\s*([\w+-]*)\s*$/.exec(line)
+    if (fence) {
+      const marker = fence[1]
+      const language = fence[2]
+      const body: string[] = []
+      index += 1
+      while (index < lines.length && !new RegExp(`^\\s*${marker}\\s*$`).test(lines[index])) {
+        body.push(lines[index])
+        index += 1
+      }
+      index += 1
+      output.push(
+        <pre key={next()} data-language={language || undefined}>
+          <code>{body.join('\n')}</code>
+        </pre>,
+      )
+      continue
+    }
+
+    const heading = /^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line)
+    if (heading) {
+      const level = Math.min(heading[1].length, 6)
+      const Tag = `h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+      output.push(<Tag key={next()}>{renderInline(heading[2])}</Tag>)
+      index += 1
+      continue
+    }
+
+    if (/^\s{0,3}([-*_])(\s*\1){2,}\s*$/.test(line)) {
+      output.push(<hr key={next()} />)
+      index += 1
+      continue
+    }
+
+    if (/^\s{0,3}>/.test(line)) {
+      const quoted: string[] = []
+      while (index < lines.length && /^\s{0,3}>/.test(lines[index])) {
+        quoted.push(lines[index].replace(/^\s{0,3}>\s?/, ''))
+        index += 1
+      }
+      output.push(<blockquote key={next()}>{renderMarkdown(quoted.join('\n'))}</blockquote>)
+      continue
+    }
+
+    if (isTableStart(lines, index)) {
+      const rows: string[] = []
+      while (index < lines.length && lines[index].includes('|') && lines[index].trim()) {
+        rows.push(lines[index])
+        index += 1
+      }
+      output.push(renderTable(rows, next()))
+      continue
+    }
+
+    const bullet = /^(\s*)([-*+])\s+(.*)$/.exec(line)
+    const numbered = /^(\s*)(\d{1,3})[.)]\s+(.*)$/.exec(line)
+    if (bullet || numbered) {
+      const ordered = Boolean(numbered)
+      const pattern = ordered ? /^(\s*)\d{1,3}[.)]\s+(.*)$/ : /^(\s*)[-*+]\s+(.*)$/
+      const items: string[] = []
+      while (index < lines.length) {
+        const match = pattern.exec(lines[index])
+        if (match) {
+          items.push(match[2])
+          index += 1
+          continue
+        }
+        // Continuation lines stay attached to the current item.
+        if (items.length && lines[index].trim() && /^\s+/.test(lines[index]) && !/^\s*([-*+]|\d{1,3}[.)])\s+/.test(lines[index])) {
+          items[items.length - 1] += ` ${lines[index].trim()}`
+          index += 1
+          continue
+        }
+        break
+      }
+      const ListTag = ordered ? 'ol' : 'ul'
+      output.push(
+        <ListTag key={next()}>
+          {items.map((item, itemIndex) => {
+            const task = /^\[( |x|X)\]\s+(.*)$/.exec(item)
+            return (
+              <li key={itemIndex} className={task ? (task[1] === ' ' ? 'task' : 'task is-done') : undefined}>
+                {task ? <><input type="checkbox" checked={task[1] !== ' '} readOnly tabIndex={-1} aria-hidden="true" /> {renderInline(task[2])}</> : renderInline(item)}
+              </li>
+            )
+          })}
+        </ListTag>,
+      )
+      continue
+    }
+
+    const paragraph: string[] = []
+    while (index < lines.length && lines[index].trim() && !isBlockStart(lines, index)) {
+      paragraph.push(lines[index])
+      index += 1
+    }
+    if (!paragraph.length) {
+      paragraph.push(line)
+      index += 1
+    }
+    output.push(
+      <p key={next()}>
+        {paragraph.map((part, partIndex) => (
+          <Fragment key={partIndex}>
+            {partIndex > 0 && <br />}
+            {renderInline(part)}
+          </Fragment>
+        ))}
+      </p>,
+    )
+  }
+  return output
+}
+
+function isBlockStart(lines: string[], index: number): boolean {
+  const line = lines[index]
+  return /^\s*(```|~~~)/.test(line)
+    || /^\s{0,3}#{1,6}\s/.test(line)
+    || /^\s{0,3}>/.test(line)
+    || /^\s*([-*+]|\d{1,3}[.)])\s+/.test(line)
+    || /^\s{0,3}([-*_])(\s*\1){2,}\s*$/.test(line)
+    || isTableStart(lines, index)
+}
+
+function isTableStart(lines: string[], index: number): boolean {
+  const header = lines[index]
+  const separator = lines[index + 1]
+  return Boolean(
+    header && separator
+    && header.includes('|')
+    && /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(separator),
+  )
+}
+
+function splitCells(row: string): string[] {
+  return row.trim().replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => cell.trim())
+}
+
+function renderTable(rows: string[], key: string): ReactNode {
+  const header = splitCells(rows[0])
+  const body = rows.slice(2).map(splitCells)
+  return (
+    <div className="markdown-table" key={key}>
+      <table>
+        <thead>
+          <tr>{header.map((cell, cellIndex) => <th key={cellIndex}>{renderInline(cell)}</th>)}</tr>
+        </thead>
+        <tbody>
+          {body.map((cells, rowIndex) => (
+            <tr key={rowIndex}>
+              {header.map((_cell, cellIndex) => <td key={cellIndex}>{renderInline(cells[cellIndex] || '')}</td>)}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const INLINE = /(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)|\*\*([^*]+?)\*\*|__([^_]+?)__|~~([^~]+?)~~|(?<![\w*])\*([^*\n]+?)\*(?![\w*])|(?<![\w_])_([^_\n]+?)_(?![\w_])|\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)|<(https?:\/\/[^>\s]+)>/g
+
+export function renderInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  let cursor = 0
+  let key = 0
+  for (const match of text.matchAll(INLINE)) {
+    const start = match.index ?? 0
+    if (start > cursor) nodes.push(text.slice(cursor, start))
+    const [, , code, bold, boldAlt, strike, italic, italicAlt, linkText, linkHref, bareHref] = match
+    if (code !== undefined) nodes.push(<code key={key++}>{code.trim() === code ? code : code.slice(1, -1)}</code>)
+    else if (bold !== undefined || boldAlt !== undefined) nodes.push(<strong key={key++}>{renderInline(bold ?? boldAlt)}</strong>)
+    else if (strike !== undefined) nodes.push(<s key={key++}>{renderInline(strike)}</s>)
+    else if (italic !== undefined || italicAlt !== undefined) nodes.push(<em key={key++}>{renderInline(italic ?? italicAlt)}</em>)
+    else if (linkText !== undefined) nodes.push(<a key={key++} href={linkHref} target="_blank" rel="noopener noreferrer">{renderInline(linkText)}</a>)
+    else if (bareHref !== undefined) nodes.push(<a key={key++} href={bareHref} target="_blank" rel="noopener noreferrer">{bareHref}</a>)
+    cursor = start + match[0].length
+  }
+  if (cursor < text.length) nodes.push(text.slice(cursor))
+  return nodes
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6152,6 +6152,7 @@ kbd {
 }
 
 .workbench-event-content > header strong {
+  min-width: 0;
   overflow: hidden;
   color: #a9ada2;
   font-size: var(--type-meta);
@@ -6180,7 +6181,15 @@ kbd {
   margin-left: 0;
 }
 
-.workbench-event-content > p {
+.workbench-event-content > header strong code {
+  padding: 0 4px;
+  color: #c9ccc2;
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,.04);
+  font-size: .95em;
+}
+
+.workbench-event-content p.workbench-event-body {
   margin: 12px 0 0;
   max-width: 980px;
   color: #d3d4cd;
@@ -6191,14 +6200,192 @@ kbd {
   overflow-wrap: anywhere;
 }
 
-.workbench-event.event-user .workbench-event-content > p {
+.workbench-event.event-user .workbench-event-content p.workbench-event-body {
   padding: 12px 14px;
   border-left: 2px solid var(--paper);
   background: rgba(238,238,232,.035);
 }
 
-.workbench-event.event-tool .workbench-event-content > p {
+.workbench-event.event-tool .workbench-event-content p.workbench-event-body {
   color: var(--muted);
+}
+
+/* Event bodies: collapsible long text and rendered Markdown for Grok replies. */
+.workbench-event-text {
+  position: relative;
+}
+
+.workbench-event-text.is-collapsed .workbench-event-body {
+  max-height: 260px;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(180deg, #000 62%, transparent 100%);
+  mask-image: linear-gradient(180deg, #000 62%, transparent 100%);
+}
+
+.event-collapse {
+  margin-top: 8px;
+  padding: 4px 9px 4px 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  border: 1px solid var(--line-strong);
+  background: rgba(255,255,255,.03);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: var(--type-label);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.event-collapse:hover {
+  color: var(--paper);
+  border-color: var(--paper);
+}
+
+.event-collapse .is-flipped {
+  transform: rotate(180deg);
+}
+
+.workbench-event-content .markdown {
+  margin: 12px 0 0;
+  max-width: 980px;
+  color: #d3d4cd;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: var(--type-control);
+  line-height: 1.72;
+  overflow-wrap: anywhere;
+}
+
+.markdown > :first-child { margin-top: 0; }
+.markdown > :last-child { margin-bottom: 0; }
+
+.markdown p,
+.markdown ul,
+.markdown ol,
+.markdown blockquote,
+.markdown pre,
+.markdown .markdown-table {
+  margin: 0 0 12px;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  margin: 18px 0 8px;
+  color: var(--paper);
+  font-family: 'Syne Variable', sans-serif;
+  font-weight: 600;
+  letter-spacing: -.01em;
+  line-height: 1.25;
+}
+
+.markdown h1 { font-size: 20px; }
+.markdown h2 { font-size: 17px; }
+.markdown h3 { font-size: 15px; }
+.markdown h4,
+.markdown h5,
+.markdown h6 { font-size: var(--type-control); text-transform: uppercase; letter-spacing: .06em; }
+
+.markdown strong { color: var(--paper); font-weight: 700; }
+.markdown em { font-style: italic; }
+.markdown s { color: var(--muted); }
+
+.markdown code {
+  padding: 1px 5px;
+  color: var(--paper);
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,.05);
+  font-size: .94em;
+}
+
+.markdown pre {
+  padding: 12px 14px;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-left: 2px solid var(--lime);
+  background: rgba(0,0,0,.35);
+}
+
+.markdown pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: var(--type-meta);
+  line-height: 1.6;
+  white-space: pre;
+}
+
+.markdown ul,
+.markdown ol {
+  padding-left: 22px;
+}
+
+.markdown li { margin: 3px 0; }
+.markdown li.task { list-style: none; margin-left: -18px; }
+.markdown li.task input { margin: 0 6px 0 0; vertical-align: -1px; accent-color: var(--lime); pointer-events: none; }
+.markdown li.task.is-done { color: var(--muted); }
+
+.markdown blockquote {
+  padding: 6px 14px;
+  color: var(--muted);
+  border-left: 2px solid var(--line-strong);
+  background: rgba(255,255,255,.02);
+}
+
+.markdown hr {
+  margin: 14px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.markdown a {
+  color: var(--lime);
+  text-decoration: underline;
+  text-decoration-color: rgba(217,255,67,.4);
+  text-underline-offset: 3px;
+}
+
+.markdown a:hover { text-decoration-color: var(--lime); }
+
+.markdown .markdown-table {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+}
+
+.markdown table {
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-meta);
+}
+
+.markdown th,
+.markdown td {
+  padding: 7px 11px;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid var(--line);
+}
+
+.markdown th {
+  color: var(--muted);
+  background: rgba(255,255,255,.03);
+  font-weight: 600;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  font-size: var(--type-label);
+}
+
+.markdown tr:last-child td { border-bottom: 0; }
+
+.workbench-instruments strong.is-text {
+  overflow: hidden;
+  font-size: var(--type-control);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .workbench-permission {
@@ -6264,20 +6451,21 @@ kbd {
 
 .jump-latest {
   position: sticky;
-  left: 50%;
-  bottom: 8px;
+  bottom: 10px;
+  margin: 0 8px 0 auto;
   min-height: 31px;
   padding: 0 11px;
-  display: inline-flex;
+  display: flex;
+  width: max-content;
   align-items: center;
   gap: 6px;
   color: var(--ink);
   border: 0;
   background: var(--lime);
+  box-shadow: 0 6px 18px rgba(0,0,0,.45);
   font-size: var(--type-meta);
   font-weight: 700;
   cursor: pointer;
-  transform: translateX(-50%);
 }
 
 .workbench-composer {

--- a/src/views/SessionWorkbench.tsx
+++ b/src/views/SessionWorkbench.tsx
@@ -50,6 +50,7 @@ import type {
   WorkspaceDiff,
   WorkspaceSnapshot,
 } from '../types'
+import { Markdown, renderInline } from '../markdown'
 import { usePrivacy } from '../privacy'
 import { SessionPlanPanel } from './SessionPlanPanel'
 
@@ -84,6 +85,28 @@ function elapsed(value: string): string {
   if (difference < 3_600_000) return `${Math.floor(difference / 60_000)}m`
   if (difference < 86_400_000) return `${Math.floor(difference / 3_600_000)}h`
   return `${Math.floor(difference / 86_400_000)}d`
+}
+
+function startedLabel(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  const sameYear = date.getFullYear() === new Date().getFullYear()
+  return date.toLocaleDateString('en-US', sameYear ? { month: 'short', day: 'numeric' } : { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+/**
+ * Messages longer than this start collapsed so a pasted wall of text does not
+ * bury the conversation. Grok's own replies get more room because they are
+ * what the reader came for.
+ */
+const COLLAPSE = {
+  user: { chars: 900, lines: 12 },
+  assistant: { chars: 3_500, lines: 45 },
+} as const
+
+function isLong(text: string, type: LiveFeedItem['type']): boolean {
+  const limit = type === 'assistant' || type === 'plan' ? COLLAPSE.assistant : COLLAPSE.user
+  return text.length > limit.chars || text.split('\n').length > limit.lines
 }
 
 function statusLabel(data: SessionWorkbenchData | null): string {
@@ -219,10 +242,17 @@ export function SessionWorkbench({
     return () => window.clearInterval(timer)
   }, [refreshPreview, tab])
 
+  const latestEventId = data?.transcript.at(-1)?.id
   useEffect(() => {
-    if (!feedRef.current) return
-    feedRef.current.scrollTop = feedRef.current.scrollHeight
-  }, [data?.transcript.at(-1)?.id])
+    if (!latestEventId) return
+    // Wait one frame so collapsed bodies and rendered Markdown have their final height.
+    const frame = window.requestAnimationFrame(() => {
+      // Instant, not smooth: a smooth scroll is cancelled by the re-render that
+      // shows the Latest button part-way through the animation.
+      feedRef.current?.scrollTo({ top: feedRef.current.scrollHeight, behavior: 'instant' })
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [latestEventId, tab])
 
   const openDiff = async (file: string) => {
     const cwd = data?.session.cwd || fallback?.cwd
@@ -381,7 +411,11 @@ export function SessionWorkbench({
               <div className="workbench-title">
                 <div>
                   <span>Session · {privacy.identifier(sessionId)}</span>
-                  <h1>{privacy.sessionTitle(session?.title || `Session ${sessionId.slice(0, 8)}`, sessionId)}</h1>
+                  <h1>
+                    {session?.title
+                      ? privacy.sessionTitle(session.title, sessionId)
+                      : loading ? 'Loading session…' : privacy.sessionTitle(`Session ${sessionId.slice(0, 8)}`, sessionId)}
+                  </h1>
                 </div>
                 <button onClick={() => setRenaming(true)} aria-label="Rename session"><Pencil size={15} /></button>
               </div>
@@ -389,9 +423,15 @@ export function SessionWorkbench({
             <div className="workbench-context">
               <p>
                 <FolderGit2 size={14} />
-                <span>{session?.cwd ? privacy.path(session.cwd) : 'Resolving workspace…'}</span>
+                <span>{session?.cwd ? privacy.path(session.cwd) : loading ? 'Resolving workspace…' : 'No workspace recorded'}</span>
               </p>
-              <span>Chat with this agent, review its activity, and inspect changes.</span>
+              <span aria-label="Session context">
+                {[
+                  session?.model,
+                  session?.agent ? privacy.capability(session.agent, 'Agent') : '',
+                  session?.createdAt ? `Started ${startedLabel(session.createdAt)}` : '',
+                ].filter(Boolean).join(' · ') || (loading ? 'Reading session record…' : 'Chat with this agent, review its activity, and inspect changes.')}
+              </span>
             </div>
           </div>
           <div className="workbench-head-actions">
@@ -418,7 +458,7 @@ export function SessionWorkbench({
         </header>
 
         <div className="workbench-instruments">
-          <div><span>STATUS</span><strong>{statusLabel(data)}</strong></div>
+          <div><span>MODEL</span><strong className="is-text">{session?.model || '—'}</strong></div>
           <div><span>TURNS</span><strong>{compact(session?.turns || turnCount)}</strong></div>
           <div><span>TOOLS</span><strong>{compact(session?.toolCalls || toolCount)}</strong></div>
           <div><span>CONTEXT</span><strong>{Math.round((data?.live?.contextUsage || session?.contextUsage || 0) * 100)}%</strong></div>
@@ -667,8 +707,16 @@ export function SessionTimeline({
   onDecide: (permissionId: string, optionId?: string) => Promise<void>
 }) {
   const privacy = usePrivacy()
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [atBottom, setAtBottom] = useState(true)
+  const toggle = (id: string) => setExpanded((current) => ({ ...current, [id]: !current[id] }))
+  const onScroll = () => {
+    const element = feedRef.current
+    if (!element) return
+    setAtBottom(element.scrollHeight - element.scrollTop - element.clientHeight < 48)
+  }
   return (
-    <div className="workbench-timeline" ref={feedRef}>
+    <div className="workbench-timeline" ref={feedRef} onScroll={onScroll}>
       {permissions.map((permission) => (
         <article className="workbench-permission" key={permission.id}>
           <div><ShieldAlert size={18} /><span><small>PERMISSION REQUIRED</small><strong>{privacy.content(permission.title)}</strong></span></div>
@@ -695,11 +743,19 @@ export function SessionTimeline({
           <div className="workbench-event-content">
             <header>
               <span>{item.type === 'assistant' ? 'GROK' : item.type.toUpperCase()}</span>
-              <strong>{privacy.content(item.title)}</strong>
+              <strong title={privacy.content(item.title)}>{renderInline(privacy.content(item.title))}</strong>
               {item.status && <em>{item.status}</em>}
               <time>{time(item.timestamp)}</time>
             </header>
-            {item.text && <p>{privacy.content(item.text)}</p>}
+            {item.text && (
+              <EventBody
+                item={item}
+                text={privacy.content(item.text)}
+                expanded={Boolean(expanded[item.id])}
+                pinned={index === items.length - 1}
+                onToggle={() => toggle(item.id)}
+              />
+            )}
           </div>
         </article>
       )) : (
@@ -709,7 +765,44 @@ export function SessionTimeline({
           <p>Send a follow-up below. New messages, reasoning, and tool calls will stream here.</p>
         </div>
       )}
-      {items.length > 8 && <button className="jump-latest" onClick={() => feedRef.current?.scrollTo({ top: feedRef.current.scrollHeight, behavior: 'smooth' })}><ArrowDown size={14} /> Latest</button>}
+      {items.length > 8 && !atBottom && (
+        <button className="jump-latest" onClick={() => feedRef.current?.scrollTo({ top: feedRef.current.scrollHeight, behavior: 'smooth' })}>
+          <ArrowDown size={14} /> Latest
+        </button>
+      )}
+    </div>
+  )
+}
+
+function EventBody({
+  item,
+  text,
+  expanded,
+  pinned = false,
+  onToggle,
+}: {
+  item: LiveFeedItem
+  text: string
+  expanded: boolean
+  /** The newest event always shows in full; it is what the reader came to see. */
+  pinned?: boolean
+  onToggle: () => void
+}) {
+  const long = isLong(text, item.type) && !pinned
+  const collapsed = long && !expanded
+  const lineCount = text.split('\n').length
+  const body = item.type === 'assistant' || item.type === 'plan'
+    ? <Markdown className="workbench-event-body" text={text} />
+    : <p className="workbench-event-body">{text}</p>
+  return (
+    <div className={`workbench-event-text ${collapsed ? 'is-collapsed' : ''}`}>
+      {body}
+      {long && (
+        <button type="button" className="event-collapse" onClick={onToggle} aria-expanded={!collapsed}>
+          {collapsed ? <ChevronRight size={13} /> : <ArrowDown size={13} className="is-flipped" />}
+          {collapsed ? `Show all ${lineCount} lines` : 'Collapse'}
+        </button>
+      )}
     </div>
   )
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['server/**/*.test.ts', 'src/**/*.test.ts'],
+    include: ['server/**/*.test.ts', 'src/**/*.test.{ts,tsx}'],
   },
 })


### PR DESCRIPTION
## Why

The session console is where people spend their time, and it had several trust breaks: Grok replies showed raw `**Markdown**`, every tool call appeared as two rows (a pending row and an update row with a different title), a pasted system prompt filled the whole viewport, the Latest button floated over the text, and the header carried filler copy plus "Session 019f9c1c / Resolving workspace…" whenever data had not loaded.

## What changed

- **Markdown rendering** in `src/markdown.tsx`: headings, emphasis, inline and fenced code, lists and task items, block quotes, tables, rules, and http(s) links. It builds React elements from parsed text and never emits raw HTML; tests cover escaping and `javascript:` rejection.
- **One row per tool call.** The transcript reader merges `tool_call` and `tool_call_update` by `toolCallId`, keeping the descriptive title and final status. The live controller feed does the same with a stable per-call id. Live rows now use the recorded labels (User message, Reasoning, Grok response); legacy persisted labels are normalized on merge.
- **Collapsible long messages.** User and reasoning text over 12 lines or 900 chars starts collapsed with Show all; Grok replies get a higher threshold, and the newest event is always shown in full.
- **Timeline behaviour.** Opens at the latest event with an instant scroll (a smooth scroll was being cancelled by a mid-animation re-render). Latest appears only after scrolling up and sits bottom-right instead of over the text.
- **Header and instruments.** Model · agent · start date replace the filler sentence; the duplicate STATUS instrument becomes MODEL; loading states say "Loading session…" and "Resolving workspace…" only while loading.
- vitest now includes `.test.tsx` files.

## Verification

- `npm run check` clean
- `npx vitest run` 137 passed (5 new Markdown tests, extended transcript reader test)
- `npm run test:e2e` 26 passed
- Browser: verified on a 103-event recorded session, a managed session with tables and code, and a session with shell tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XWBXZXkWjND2DLyYuRBjz
