### PR TITLE
Explain unavailable usage and stop the WebKit fleet registration flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Usage explains why token and cost columns show dashes when every
+  observation is unavailable: Grok CLI records context occupancy for terminal
+  sessions but not cumulative usage, and Grok UI does not estimate spend.
+- Fleet browser tests register the first host with real key events and clear
+  the registry before the serial block, fixing a WebKit-only failure where a
+  `type="url"` field lost its value and a retry inherited stale hosts.
 - Live lets you allow or reject a pending tool from the roster peek,
   without opening Control.
 - Session console renders Grok replies as Markdown (headings, emphasis, code,

--- a/e2e/fleet.spec.ts
+++ b/e2e/fleet.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext, type Page } from '@playwright/test'
+import { expect, test, type APIRequestContext, type Locator, type Page } from '@playwright/test'
 import { promises as fs } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -34,6 +34,32 @@ async function registerHost(
   const body = await response.json()
   expect(response.status(), JSON.stringify(body)).toBe(201)
   return body
+}
+
+/**
+ * Remove every registered host so a CI retry of this serial block starts from
+ * the same empty registry as a fresh run instead of inheriting hosts from the
+ * failed attempt.
+ */
+async function clearFleet(request: APIRequestContext): Promise<void> {
+  const fleet = await (await request.get('/api/fleet')).json()
+  for (const host of fleet.hosts as Array<{ id: string }>) {
+    const response = await request.delete(`/api/fleet/hosts/${host.id}`)
+    expect([204, 404]).toContain(response.status())
+  }
+}
+
+/**
+ * Type a value with real key events and confirm React kept it. Playwright's
+ * `fill` on a `type="url"` input in WebKit can set the DOM value without the
+ * controlled input registering it, after which the next render clears the
+ * field and the form's required check silently blocks submission.
+ */
+async function typeInto(field: Locator, value: string): Promise<void> {
+  await field.click()
+  await field.fill('')
+  await field.pressSequentially(value)
+  await expect(field).toHaveValue(value)
 }
 
 async function fleetStatus(request: APIRequestContext, label: string): Promise<string> {
@@ -74,16 +100,18 @@ async function unreadableVisibleText(page: Page, minimumPx = 8) {
 test.describe.serial('read-only fleet monitoring', () => {
   test('registers multiple hosts and exposes bounded read-only telemetry with explicit states', async ({ page }) => {
     const setup = await fixture()
+    await clearFleet(page.request)
     await page.goto('/')
     await page.getByRole('button', { name: /Fleet/ }).click()
 
     await page.getByRole('button', { name: 'Register host' }).first().click()
     const editor = page.getByRole('dialog', { name: 'Register a host' })
-    await editor.getByLabel('Display name').fill('Healthy Workstation')
+    await typeInto(editor.getByLabel('Display name'), 'Healthy Workstation')
     await editor.getByLabel('Transport').selectOption('direct')
-    await editor.getByLabel('Loopback agent URL').fill(setup.fleetHosts.healthy.url)
-    await editor.getByLabel(/Agent token/).fill(setup.fleetHosts.healthy.token)
+    await typeInto(editor.getByLabel('Loopback agent URL'), setup.fleetHosts.healthy.url)
+    await typeInto(editor.getByLabel(/Agent token/), setup.fleetHosts.healthy.token)
     await editor.getByRole('button', { name: 'Register host' }).click()
+    await expect(editor).toBeHidden({ timeout: 10_000 })
 
     await registerHost(page.request, 'Degraded Workstation', setup.fleetHosts.degraded)
     await registerHost(page.request, 'Future Protocol Workstation', setup.fleetHosts.incompatible)

--- a/src/styles.css
+++ b/src/styles.css
@@ -8782,6 +8782,15 @@ kbd {
   color: var(--paper);
 }
 
+.usage-unavailable-note {
+  margin: 18px 0 0;
+}
+
+.usage-unavailable-note strong {
+  margin-right: 6px;
+  color: inherit;
+}
+
 .usage-scope-note {
   margin: 14px 0 0;
   padding: 12px 14px;

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -46,6 +46,10 @@ function metricValue(metric: UsageMetric): string {
   return metric.value >= 10_000 ? compact.format(metric.value) : metric.value.toLocaleString()
 }
 
+function allUnavailable(report: UsageReport): boolean {
+  return (report.coverage['grok-reported'] || 0) + (report.coverage.derived || 0) + (report.coverage.incomplete || 0) === 0
+}
+
 function sourceLabel(source: UsageSource): string {
   return source === 'grok-reported' ? 'Grok-reported' : source
 }
@@ -228,6 +232,15 @@ export function UsageView() {
               </div>
             </article>
           </section>
+
+          {report && report.entries.length > 0 && allUnavailable(report) && (
+            <p className="usage-scope-note usage-unavailable-note" role="note">
+              <strong>Why the dashes?</strong> Grok CLI records how full the context window is for terminal
+              sessions, but not cumulative token usage or cost, so Grok UI leaves those unavailable rather than
+              estimating spend. Token and cost figures appear for sessions started from Grok UI and for workflow
+              agents when Grok reports them.
+            </p>
+          )}
 
           <section className="usage-ledger section-gap">
             <header>


### PR DESCRIPTION
## Why

Two loose ends from the last review. Usage showed dashes for every column with no explanation, and the fleet e2e spec failed on WebKit in CI twice in one afternoon.

## What changed

- **Usage explainer.** When every observation is unavailable, a note under the summary explains that Grok CLI records context occupancy for terminal sessions but not cumulative token usage or cost, and that Grok UI does not estimate spend. I checked a real session directory: `signals.json` has context tokens only, and `events.jsonl` has no token fields, so there is nothing to derive.
- **Fleet e2e hardening.** The CI failure snapshot showed the Loopback agent URL field empty while the other fields were filled. Playwright's `fill` on a `type="url"` input in WebKit set the DOM value without the controlled React input registering it, so the next render cleared it and the `required` check silently blocked the submit. The first host is now registered with real key events plus a `toHaveValue` check, and the test waits for the dialog to close. The serial block also clears the registry first so a CI retry does not inherit hosts from the failed attempt (that was the "expected 1, received 2" failure).

## Verification

- `npm run check` clean
- WebKit `e2e/fleet.spec.ts` with `--repeat-each 2`: the previously flaky first test passes on both repeats
- `npm run test:e2e` (Chromium) 26 passed
- Browser: Usage note renders under the summary cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XWBXZXkWjND2DLyYuRBjz
