### PR TITLE
Shorten room heroes and number the rail in display order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Room heroes are about 40% shorter so the roster, tables, and diffs start
+  higher on a laptop screen.
+- The primary rail reads 01 through 07 in display order, every room hero
+  carries the same number, and the number keys 1 through 7 jump to those
+  rooms. Control, Activity, Library, Memory, and Themes follow as 08 to 12
+  with 8, 9, l, m, and t.
 - Usage explains why token and cost columns show dashes when every
   observation is unavailable: Grok CLI records context occupancy for terminal
   sessions but not cumulative usage, and Grok UI does not estimate spend.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,17 +97,17 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { id: 'live', index: '01', label: 'Live', eyebrow: 'Runtime', icon: Radio, shortcut: '1' },
-  { id: 'control', index: '02', label: 'Control', eyebrow: 'Operate', icon: Command, shortcut: '2' },
-  { id: 'runs', index: '03', label: 'Runs', eyebrow: 'Orchestrate', icon: Workflow, shortcut: '3' },
-  { id: 'changes', index: '04', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '4' },
+  { id: 'control', index: '08', label: 'Control', eyebrow: 'Operate', icon: Command, shortcut: '8' },
+  { id: 'runs', index: '02', label: 'Runs', eyebrow: 'Orchestrate', icon: Workflow, shortcut: '2' },
+  { id: 'changes', index: '03', label: 'Changes', eyebrow: 'Inspect', icon: GitCompareArrows, shortcut: '3' },
   { id: 'overview', index: '05', label: 'Overview', eyebrow: 'Command', icon: Gauge, shortcut: '5' },
-  { id: 'sessions', index: '06', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '6' },
-  { id: 'activity', index: '07', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '7' },
-  { id: 'usage', index: '08', label: 'Usage', eyebrow: 'Ledger', icon: WalletCards, shortcut: 'u' },
-  { id: 'fleet', index: '09', label: 'Fleet', eyebrow: 'Monitor', icon: Network, shortcut: 'f' },
-  { id: 'library', index: '10', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: '8' },
-  { id: 'memory', index: '11', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: '9' },
-  { id: 'themes', index: '12', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: '0' },
+  { id: 'sessions', index: '04', label: 'Sessions', eyebrow: 'Archive', icon: Layers3, shortcut: '4' },
+  { id: 'activity', index: '09', label: 'Activity', eyebrow: 'Signals', icon: Activity, shortcut: '9' },
+  { id: 'usage', index: '06', label: 'Usage', eyebrow: 'Ledger', icon: WalletCards, shortcut: '6' },
+  { id: 'fleet', index: '07', label: 'Fleet', eyebrow: 'Monitor', icon: Network, shortcut: '7' },
+  { id: 'library', index: '10', label: 'Library', eyebrow: 'Capability', icon: Blocks, shortcut: 'l' },
+  { id: 'memory', index: '11', label: 'Memory', eyebrow: 'Recall', icon: BrainCircuit, shortcut: 'm' },
+  { id: 'themes', index: '12', label: 'Themes', eyebrow: 'Appearance', icon: Palette, shortcut: 't' },
 ]
 
 const MOBILE_NAV_IDS: ViewId[] = ['live', 'runs', 'sessions', 'fleet']
@@ -1522,7 +1522,7 @@ function SessionsView({
   return (
     <>
       <PageIntro
-        index="06"
+        index="04"
         eyebrow="Conversation archive"
         title={<>Every run.<br /><em>Nothing buried.</em></>}
         description="Search local session metadata without sending conversation content anywhere."
@@ -1582,7 +1582,7 @@ function ActivityView({ data }: { data: DashboardPayload }) {
   return (
     <>
       <PageIntro
-        index="07"
+        index="09"
         eyebrow="Operational telemetry"
         title={<>The shape of<br /><em>the work.</em></>}
         description="A two-week read on agent velocity, tool intensity, code movement, and friction."

--- a/src/styles.css
+++ b/src/styles.css
@@ -751,15 +751,16 @@ kbd {
 
 .page-intro {
   position: relative;
-  min-height: 205px;
+  min-height: 126px;
   display: grid;
-  grid-template-columns: 50px minmax(420px, 1fr) minmax(260px, 420px);
-  gap: 28px;
+  grid-template-columns: 44px minmax(380px, 1fr) minmax(260px, 420px);
+  gap: 22px;
   align-items: end;
-  padding-bottom: 38px;
+  padding-bottom: 22px;
 }
 
-.intro-index {
+.intro-index,
+.page-intro-index {
   align-self: start;
   padding-top: 7px;
   writing-mode: vertical-rl;
@@ -777,10 +778,10 @@ kbd {
 
 .page-intro h1 {
   max-width: 800px;
-  margin: 14px 0 0;
-  font-size: clamp(43px, 5vw, 78px);
-  line-height: .88;
-  letter-spacing: -.06em;
+  margin: 8px 0 0;
+  font-size: clamp(30px, 3.1vw, 46px);
+  line-height: .94;
+  letter-spacing: -.045em;
   font-weight: 650;
 }
 
@@ -4779,14 +4780,14 @@ kbd {
   }
 
   .page-intro {
-    min-height: 190px;
+    min-height: 132px;
     grid-template-columns: 20px 1fr;
     gap: 12px;
-    padding-bottom: 28px;
+    padding-bottom: 20px;
   }
 
   .page-intro h1 {
-    font-size: clamp(39px, 13vw, 58px);
+    font-size: clamp(30px, 9vw, 40px);
   }
 
   .page-intro > p {

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -97,7 +97,7 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
   return (
     <>
       <section className="page-intro changes-intro">
-        <div className="page-intro-index">04</div>
+        <div className="page-intro-index">03</div>
         <div className="page-intro-copy">
           <div className="kicker"><Braces size={14} /> Change surface</div>
           <h1>See the work.<br /><em>Before it lands.</em></h1>

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -101,7 +101,7 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
   return (
     <>
       <section className="page-intro command-intro">
-        <div className="page-intro-index">02</div>
+        <div className="page-intro-index">08</div>
         <div className="page-intro-copy">
           <div className="kicker"><Command size={14} /> Control</div>
           <h1>Don’t just watch.<br /><em>Run the room.</em></h1>

--- a/src/views/FleetView.tsx
+++ b/src/views/FleetView.tsx
@@ -162,7 +162,7 @@ export function FleetView({
   return (
     <>
       <header className="page-intro fleet-intro">
-        <div className="intro-index">09</div>
+        <div className="intro-index">07</div>
         <div>
           <div className="kicker"><Network size={14} /> Multi-machine monitoring</div>
           <h1>Every host.<br /><em>One quiet orbit.</em></h1>

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -147,7 +147,7 @@ export function UsageView() {
   return (
     <>
       <header className="page-intro">
-        <div className="intro-index">08</div>
+        <div className="intro-index">06</div>
         <div>
           <div className="kicker">Persistent usage ledger</div>
           <h1>Know what was used,<br /><em>and how we know.</em></h1>

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -171,7 +171,7 @@ export function WorkflowsView({
   return (
     <>
       <header className="page-intro">
-        <div className="intro-index">03</div>
+        <div className="intro-index">02</div>
         <div>
           <div className="kicker">Cross-session orchestration</div>
           <h1>Every run.<br /><em>One command field.</em></h1>


### PR DESCRIPTION
## Why

Every room spent ~205px on a hero before any content, so on a laptop the Live roster started below the fold. The rail read 01, 03, 04, 06, 05, 08, 09 because Control and Activity moved off it, and the keyboard shortcuts no longer matched the numbers people saw.

## What changed

- **Compact hero.** Min height 205 → 126px, title 43–78px → 30–46px, tighter padding, with a matching mobile override. The two-line title and right-hand description stay; the layout is unchanged.
- **Sequential rail.** Live 01, Runs 02, Changes 03, Sessions 04, Overview 05, Usage 06, Fleet 07. Off-rail rooms continue: Control 08, Activity 09, Library 10, Memory 11, Themes 12. Every hero index was updated to match.
- **Shortcuts match indices.** Keys 1–7 jump to the rail rooms in order; 8, 9, l, m, t reach the off-rail rooms. Previously 2 opened Control and 6 opened Sessions.
- The Changes and Control heroes now use the same vertical index badge as the other rooms.

## Verification

- `npm run check` clean
- `npx vitest run` 137 passed
- `npm run test:e2e` 26 passed (includes the mobile viewport and readable-text checks)
- Browser: Live, Changes, Fleet, Sessions, Overview heroes; pressed 5 and landed on Overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XWBXZXkWjND2DLyYuRBjz
