### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 — 2026-09-12
 
+- File watching uses Node's native recursive `fs.watch` instead of one
+  descriptor per directory, so a large Grok home or repository no longer
+  exhausts file descriptors (`EMFILE`) and crashes the supervisor. A watcher
+  that still fails is closed and reported: the Live monitor falls back to its
+  liveness poll, and Changes shows Manual refresh for that workspace. Only
+  the three most recent workspaces stay watched and common build and cache
+  directories are ignored. `chokidar` is no longer a dependency.
+- An unreachable server shows a Link interrupted screen with Try again
+  instead of the remote access token gate.
 - Room heroes are about 40% shorter so the roster, tables, and diffs start
   higher on a laptop screen.
 - The primary rail reads 01 through 07 in display order, every room hero
@@ -28,15 +37,6 @@
 - Session console header shows model, agent, and start date instead of filler
   copy, and the instruments show the model where status was duplicated. While
   a session loads, the title and workspace say so instead of inventing values.
-- File watching uses Node's native recursive `fs.watch` instead of one
-  descriptor per directory, so a large Grok home or repository no longer
-  exhausts file descriptors (`EMFILE`) and crashes the supervisor. A watcher
-  that still fails is closed and reported: the Live monitor falls back to its
-  liveness poll, and Changes shows Manual refresh for that workspace. Only
-  the three most recent workspaces stay watched and common build and cache
-  directories are ignored. `chokidar` is no longer a dependency.
-- An unreachable server shows a Link interrupted screen with Try again
-  instead of the remote access token gate.
 - Live roster titles and workspaces are readable again; the roster grid still
   reserved a column for a removed index.
 - Live's Open agents count matches the roster, which includes managed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and move through your complete local history without leaving the browser.
 </a>
 
 [**Watch the 24-second product tour**](https://github.com/joeynyc/Grok-UI/releases/download/v0.5.1/grok-ui-dashboard-tour-final-white-logo.mp4)
-· [**See what’s new in v0.12.1**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.12.1)
+· [**See what’s new in v0.13.0**](https://github.com/joeynyc/Grok-UI/releases/tag/v0.13.0)
 · [**Quickstart**](#quickstart) · [**What it does**](#what-it-does)
 · [**Architecture**](#architecture) · [**Security**](#privacy-and-security)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grok-ui",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grok-ui",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-ui",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "A local-first command center and live dashboard for Grok Build.",
   "license": "MIT",
   "author": "Grok UI contributors",


### PR DESCRIPTION
Bumps the package to 0.13.0, dates the changelog, and points the README at the new release. Tag v0.13.0 follows the squash commit.

Made with [Cursor](https://cursor.com)