### PR TITLE
Keep room shortcuts quiet while a select or dialog has focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Room shortcuts (1–9, l, m, t, /) no longer fire while a `<select>` has focus
+  or while typing inside a dialog. Picking a model or permission mode with the
+  keyboard, or entering a host URL, stayed on the room the user was in only by
+  luck; in WebKit it jumped rooms mid-entry and closed the host editor.
+
 ## 0.13.0 — 2026-09-12
 
 - File watching uses Node's native recursive `fs.watch` instead of one

--- a/e2e/fleet.spec.ts
+++ b/e2e/fleet.spec.ts
@@ -57,6 +57,8 @@ async function clearFleet(request: APIRequestContext): Promise<void> {
  */
 async function typeInto(field: Locator, value: string): Promise<void> {
   await field.click()
+  await field.focus()
+  await expect(field).toBeFocused()
   await field.fill('')
   await field.pressSequentially(value)
   await expect(field).toHaveValue(value)

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -233,6 +233,15 @@ test.describe.serial('public launch path', () => {
     await expect(page.getByLabel('WORKTREE')).toBeVisible()
     await expect(page.getByRole('button', { name: 'Start session' })).toBeVisible()
     await expect(page).toHaveURL(/#\/live$/)
+
+    // Letters typed into a focused <select> pick options; they must not fire
+    // the single-key room shortcuts (t = Themes, m = Memory, 3 = Changes).
+    const permissions = page.getByLabel('PERMISSIONS')
+    await permissions.focus()
+    await expect(permissions).toBeFocused()
+    await page.keyboard.type('tm3')
+    await expect(page).toHaveURL(/#\/live$/)
+    await expect(page.getByRole('heading', { name: 'Start a session' })).toBeVisible()
     await expect(page.getByRole('navigation', { name: 'Primary navigation' })
       .getByRole('button', { name: /Control/ })).toHaveCount(0)
     await expect(page.getByRole('navigation', { name: 'Primary navigation' })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,8 +424,14 @@ function App() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement
-      const typing = target.matches('input, textarea, [contenteditable="true"]')
+      const target = event.target instanceof HTMLElement ? event.target : null
+      // Single-key room shortcuts must never fire while the user is entering
+      // data. A focused <select> takes letters to pick an option, and a form in
+      // a dialog (host editor, launch form) should not navigate away mid-entry.
+      const typing = target !== null && (
+        target.matches('input, textarea, select, [contenteditable="true"]')
+        || target.closest('[role="dialog"]') !== null
+      )
       if (selectedSession || remoteSession) return
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault()


### PR DESCRIPTION
Root cause of the recurring WebKit fleet e2e failure, found via the CI screenshot: the test typed a host URL and ended up in **Changes**.

The single-key room shortcuts (`1`–`9`, `l`, `m`, `t`, `/`) only treated `input`, `textarea`, and `contenteditable` targets as "typing". A focused `<select>` — which takes letters to pick options — was not excluded, nor was anything inside a dialog. So after `selectOption('direct')` on the transport picker, the URL keystrokes `http://localhost:37833` became `t`→Themes, `l`→Library, `3`→Changes, `7`→Fleet, `8`→Control, `3`→Changes, and the host editor unmounted.

This is a real keyboard bug for users too: choosing a model or permission mode from the keyboard could jump rooms.

- `src/App.tsx`: treat `select` and any target inside `[role="dialog"]` as typing.
- `e2e/launch.spec.ts`: regression check — focus the launch form's `PERMISSIONS` select, type `tm3`, assert we're still on Live. Confirmed this fails on `main` (lands on `#/changes`) and passes with the fix.
- `e2e/fleet.spec.ts`: `typeInto` asserts the field is focused before typing, so a focus problem fails with a clear message instead of navigating away.

`npm run test:e2e`: 26 passed locally.

Made with [Cursor](https://cursor.com)