### PR TITLE
Let room headers fold to one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Room headers can fold to one line. Every header carries a toggle at its
+  right edge, and Themes offers the same choice as Full or Compact. Compact
+  keeps the index, kicker, and title on a single 44px row and hides the
+  description, so rosters, tables, and diffs start about 85px higher. The
+  choice is stored on the device like the theme. Changes, Control, Fleet,
+  Usage, and Runs now share the same header component as the other rooms.
 - Room shortcuts (1–9, l, m, t, /) no longer fire while a `<select>` has focus
   or while typing inside a dialog. Picking a model or permission mode with the
   keyboard, or entering a host URL, stayed on the room the user was in only by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,7 @@ a second `ARCHITECTURE.md`; update this map when ownership moves.
 | Routing, data loading, local and fleet SSE lifecycle, keyboard shortcuts | `src/App.tsx` |
 | Browser chrome: sidebar, top bar, mobile nav, command palette, access screens | `src/shell/` |
 | Nav item registry (indices, shortcuts) and theme registry | `src/shell/nav.ts`, `src/shell/themes.ts` |
+| Room header component and Full/Compact density preference | `src/shell/primitives.tsx`, `src/shell/hero.tsx` |
 | Shared number and time formatting | `src/format.ts` |
 | Stylesheet order and per-room CSS files | `src/styles/index.css` |
 | Fleet page coordination, selection, filters, and registry actions | `src/views/FleetView.tsx` |

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -186,6 +186,37 @@ test.describe.serial('public launch path', () => {
     )).toBe(0)
   })
 
+  test('folds every room header to one line and remembers the choice', async ({ page }) => {
+    await page.goto('/#/sessions')
+    const hero = page.locator('.page-intro')
+    await expect(hero).toBeVisible()
+    await expect(hero).not.toHaveClass(/is-compact/)
+    const fullHeight = (await hero.boundingBox())!.height
+    expect(fullHeight).toBeGreaterThan(100)
+
+    await page.getByRole('button', { name: 'Compact room headers' }).click()
+    await expect(hero).toHaveClass(/is-compact/)
+    await expect(page.locator('.app-shell')).toHaveAttribute('data-hero', 'compact')
+    await expect(hero.locator('> p')).toBeHidden()
+    const compactHeight = (await hero.boundingBox())!.height
+    expect(compactHeight).toBeLessThan(fullHeight / 2)
+    expect(await page.evaluate(() => localStorage.getItem('grok-ui-hero'))).toBe('compact')
+
+    // Shared by every room, including ones with their own hero styling.
+    await page.getByRole('button', { name: /Changes/ }).click()
+    await expect(page.locator('.page-intro.changes-intro')).toHaveClass(/is-compact/)
+    await page.reload()
+    await expect(page.locator('.page-intro')).toHaveClass(/is-compact/)
+
+    // Themes offers the same preference as a labelled control.
+    await page.getByRole('button', { name: /Themes/ }).click()
+    const density = page.getByRole('group', { name: 'Room header density' })
+    await expect(density.getByRole('button', { name: /Compact/ })).toHaveAttribute('aria-pressed', 'true')
+    await density.getByRole('button', { name: /^Full/ }).click()
+    await expect(page.locator('.page-intro')).not.toHaveClass(/is-compact/)
+    expect(await page.evaluate(() => localStorage.getItem('grok-ui-hero'))).toBe('full')
+  })
+
   test('guides a clean installation through missing CLI and ready states', async ({ page }) => {
     await Promise.all([
       fs.rm(path.join(grokHome, 'e2e-cli-ready'), { force: true }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { reconcileControlSnapshot } from './control-snapshot'
 import { collectAttention, parseHash, writeHash } from './navigation'
 import { PrivacyProvider } from './privacy'
 import { CommandPalette } from './shell/CommandPalette'
+import { HERO_STORAGE_KEY, HeroDensityProvider, storedHeroDensity, type HeroDensity } from './shell/hero'
 import { MobileNav, NeedsYouBar } from './shell/MobileNav'
 import { NAV_ITEMS } from './shell/nav'
 import { AmbientGrid, AuthScreen, BootScreen, ErrorState, LoadingState, UnreachableScreen } from './shell/screens'
@@ -81,6 +82,7 @@ function App() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const [theme, setTheme] = useState<ThemeId>(storedTheme)
   const [privacyMode, setPrivacyMode] = useState(storedPrivacy)
+  const [heroDensity, setHeroDensity] = useState<HeroDensity>(storedHeroDensity)
   const lastAttentionRef = useRef(0)
   const lastInteractionRef = useRef<HTMLElement | null>(null)
   const mobileNavTriggerRef = useRef<HTMLElement | null>(null)
@@ -107,6 +109,14 @@ function App() {
       // Privacy Mode still works when storage is unavailable.
     }
   }, [privacyMode])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(HERO_STORAGE_KEY, heroDensity)
+    } catch {
+      // The hero toggle still works for this visit when storage is unavailable.
+    }
+  }, [heroDensity])
 
   const load = useCallback(async (force = false) => {
     if (force) setRefreshing(true)
@@ -353,10 +363,12 @@ function App() {
 
   return (
     <PrivacyProvider enabled={privacyMode}>
+      <HeroDensityProvider density={heroDensity} onChange={setHeroDensity}>
       <div
         className="app-shell"
         data-theme={theme}
         data-privacy={privacyMode ? 'on' : 'off'}
+        data-hero={heroDensity}
         onClickCapture={(event) => {
           if (!(event.target instanceof Element)) return
           lastInteractionRef.current = event.target.closest<HTMLElement>(
@@ -477,7 +489,14 @@ function App() {
             )}
             {view === 'library' && <LibraryView data={data} query={query} onQuery={setQuery} />}
             {view === 'memory' && <MemoryView data={data} />}
-            {view === 'themes' && <ThemesView active={theme} onSelect={setTheme} />}
+            {view === 'themes' && (
+              <ThemesView
+                active={theme}
+                onSelect={setTheme}
+                heroDensity={heroDensity}
+                onHeroDensity={setHeroDensity}
+              />
+            )}
           </div>
         )}
         </main>
@@ -528,6 +547,7 @@ function App() {
           />
         )}
       </div>
+      </HeroDensityProvider>
     </PrivacyProvider>
   )
 }

--- a/src/shell/hero.tsx
+++ b/src/shell/hero.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext } from 'react'
+
+// Room heroes come in two densities. Full is the editorial header with the
+// large title and description; compact folds it to one line so the roster,
+// tables, and diffs start near the top. The choice is a device preference,
+// like the theme, and every hero carries a toggle for it.
+
+export type HeroDensity = 'full' | 'compact'
+
+export const HERO_STORAGE_KEY = 'grok-ui-hero'
+
+export function storedHeroDensity(): HeroDensity {
+  try {
+    return localStorage.getItem(HERO_STORAGE_KEY) === 'compact' ? 'compact' : 'full'
+  } catch {
+    return 'full'
+  }
+}
+
+interface HeroDensityValue {
+  density: HeroDensity
+  setDensity: (density: HeroDensity) => void
+}
+
+const HeroDensityContext = createContext<HeroDensityValue>({
+  density: 'full',
+  setDensity: () => {},
+})
+
+export function HeroDensityProvider({
+  density,
+  onChange,
+  children,
+}: {
+  density: HeroDensity
+  onChange: (density: HeroDensity) => void
+  children: React.ReactNode
+}) {
+  return (
+    <HeroDensityContext.Provider value={{ density, setDensity: onChange }}>
+      {children}
+    </HeroDensityContext.Provider>
+  )
+}
+
+export function useHeroDensity(): HeroDensityValue & { toggle: () => void } {
+  const value = useContext(HeroDensityContext)
+  return {
+    ...value,
+    toggle: () => value.setDensity(value.density === 'compact' ? 'full' : 'compact'),
+  }
+}

--- a/src/shell/primitives.tsx
+++ b/src/shell/primitives.tsx
@@ -1,26 +1,47 @@
-import { Search, X, type LucideIcon } from 'lucide-react'
+import { ChevronsDownUp, ChevronsUpDown, Search, X, type LucideIcon } from 'lucide-react'
 import type { SessionRow } from '../types'
+import { useHeroDensity } from './hero'
 
-/** Room hero: index badge, kicker, title, and one-line description. */
+/**
+ * Room hero: index badge, kicker, title, and description, with a toggle that
+ * folds every hero to one line. The density is a device preference shared by
+ * all rooms; see ./hero.tsx.
+ */
 export function PageIntro({
   index,
   eyebrow,
+  icon: Icon,
   title,
   description,
+  className = '',
 }: {
   index: string
   eyebrow: string
+  icon?: LucideIcon
   title: React.ReactNode
-  description: string
+  description: React.ReactNode
+  className?: string
 }) {
+  const hero = useHeroDensity()
+  const compact = hero.density === 'compact'
   return (
-    <header className="page-intro">
+    <header className={`page-intro ${compact ? 'is-compact' : ''} ${className}`.trim()}>
       <div className="intro-index">{index}</div>
-      <div>
-        <div className="kicker">{eyebrow}</div>
+      <div className="intro-copy">
+        <div className="kicker">{Icon && <Icon size={14} />}{eyebrow}</div>
         <h1>{title}</h1>
       </div>
       <p>{description}</p>
+      <button
+        type="button"
+        className="intro-density"
+        onClick={hero.toggle}
+        aria-pressed={compact}
+        aria-label={compact ? 'Expand room headers' : 'Compact room headers'}
+        title={compact ? 'Expand room headers' : 'Compact room headers'}
+      >
+        {compact ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
+      </button>
       <div className="intro-rule"><span /></div>
     </header>
   )

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,20 +1,25 @@
-/* Room hero (.page-intro): index badge, kicker, title, rule. */
+/* Room hero (.page-intro): index badge, kicker, title, description, density
+   toggle, rule. `.is-compact` folds the whole thing to one line; the choice
+   is a device preference shared by every room (src/shell/hero.tsx). */
 
 .page-intro {
   position: relative;
   min-height: 126px;
   display: grid;
-  grid-template-columns: 44px minmax(380px, 1fr) minmax(260px, 420px);
+  grid-template-columns: 44px minmax(380px, 1fr) minmax(260px, 420px) auto;
   gap: 22px;
   align-items: end;
   padding-bottom: 22px;
 }
 
-.intro-index,
-.page-intro-index {
+.intro-index {
   align-self: start;
   padding-top: 7px;
   writing-mode: vertical-rl;
+}
+
+.intro-copy {
+  min-width: 0;
 }
 
 .kicker {
@@ -49,6 +54,29 @@
   line-height: 1.8;
 }
 
+.intro-density {
+  grid-row: 1;
+  grid-column: -2 / -1;
+  align-self: start;
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  color: var(--muted-dim);
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: color .18s, border-color .18s, background .18s;
+}
+
+.intro-density:hover,
+.intro-density:focus-visible {
+  color: var(--lime);
+  border-color: var(--line);
+  background: rgba(255, 255, 255, .025);
+}
+
 .intro-rule {
   position: absolute;
   height: 1px;
@@ -63,4 +91,53 @@
   width: 9%;
   height: 1px;
   background: var(--lime);
+}
+
+/* Compact: index, kicker, and title share one row; the description folds away. */
+
+.page-intro.is-compact {
+  min-height: 0;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: center;
+  padding: 4px 0 12px;
+}
+
+.page-intro.is-compact .intro-index {
+  align-self: center;
+  padding-top: 0;
+  writing-mode: horizontal-tb;
+}
+
+.page-intro.is-compact .intro-copy {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 16px;
+  row-gap: 2px;
+}
+
+.page-intro.is-compact h1 {
+  max-width: none;
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+.page-intro.is-compact h1 br {
+  display: none;
+}
+
+.page-intro.is-compact h1 em {
+  margin-left: .3em;
+}
+
+.page-intro.is-compact > p {
+  display: none;
+}
+
+.page-intro.is-compact .intro-density {
+  align-self: center;
+  color: var(--muted);
 }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -73,12 +73,16 @@
   }
 
   .page-intro {
-    grid-template-columns: 32px minmax(0, 1fr);
+    grid-template-columns: 32px minmax(0, 1fr) auto;
   }
 
   .page-intro > p {
     grid-column: 2;
     max-width: 560px;
+  }
+
+  .page-intro.is-compact {
+    grid-template-columns: auto minmax(0, 1fr) auto;
   }
 
   .two-col-grid,
@@ -186,6 +190,16 @@
     gap: 8px;
   }
 
+  .preference-row {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    padding: 18px;
+  }
+
+  .preference-options {
+    grid-template-columns: 1fr;
+  }
+
   .topbar-path,
   .sync-copy,
   .sync-time,
@@ -203,7 +217,7 @@
 
   .page-intro {
     min-height: 132px;
-    grid-template-columns: 20px 1fr;
+    grid-template-columns: 20px 1fr auto;
     gap: 12px;
     padding-bottom: 20px;
   }
@@ -214,6 +228,15 @@
 
   .page-intro > p {
     font-size: var(--type-body);
+  }
+
+  .page-intro.is-compact {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding: 2px 0 10px;
+  }
+
+  .page-intro.is-compact h1 {
+    font-size: 16px;
   }
 
   .overview-grid {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -203,6 +203,128 @@
   background: var(--lime-soft);
 }
 
+/* Room header density preference. */
+
+.preference-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(0, 2fr);
+  gap: 28px;
+  align-items: start;
+  padding: 24px;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 9, .64);
+}
+
+.preference-row h2 {
+  margin: 8px 0 10px;
+  font-family: 'Syne Variable', sans-serif;
+  font-size: clamp(22px, 2vw, 28px);
+  line-height: 1;
+  letter-spacing: -.035em;
+  font-weight: 650;
+}
+
+.preference-row h2 em {
+  color: #767a70;
+  font-weight: 420;
+  font-style: normal;
+}
+
+.preference-row > div > p {
+  margin: 0;
+  color: var(--muted);
+  font-size: var(--type-body);
+  line-height: 1.7;
+}
+
+.preference-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.preference-option {
+  position: relative;
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  color: var(--paper);
+  text-align: left;
+  border: 1px solid var(--line);
+  background: rgba(8, 10, 9, .8);
+  cursor: pointer;
+  transition: border-color .18s, box-shadow .18s;
+}
+
+.preference-option:hover {
+  border-color: var(--line-strong);
+}
+
+.preference-option.is-selected {
+  border-color: var(--lime);
+  box-shadow: inset 0 0 0 1px var(--lime);
+}
+
+.preference-option strong {
+  font-size: var(--type-control);
+  letter-spacing: .04em;
+}
+
+.preference-option small {
+  color: var(--muted);
+  font-size: var(--type-meta);
+  line-height: 1.6;
+}
+
+.preference-preview {
+  display: grid;
+  gap: 5px;
+  height: 52px;
+  margin-bottom: 8px;
+  padding: 8px;
+  align-content: start;
+  border: 1px solid var(--line);
+  background: #090a08;
+}
+
+.preference-preview i {
+  display: block;
+  height: 5px;
+  background: var(--line-strong);
+}
+
+.preference-preview-full i:first-child {
+  height: 16px;
+  background: var(--lime);
+  opacity: .8;
+}
+
+.preference-preview-compact i:first-child {
+  background: var(--lime);
+  opacity: .8;
+}
+
+.preference-preview i:nth-child(2) {
+  width: 70%;
+}
+
+.preference-preview i:nth-child(3) {
+  width: 55%;
+}
+
+.preference-state {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--lime);
+  font-size: var(--type-label);
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
 .theme-note {
   margin-top: 12px;
   padding: 18px 20px;

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -17,6 +17,7 @@ import type {
   WorkspaceSnapshot,
 } from '../types'
 import { usePrivacy } from '../privacy'
+import { PageIntro } from '../shell/primitives'
 
 const REPOSITORY_PROBE_LIMIT = 6
 
@@ -96,14 +97,14 @@ export function ChangesView({ data, live, connected, workspaceChange }: ChangesV
 
   return (
     <>
-      <section className="page-intro changes-intro">
-        <div className="page-intro-index">03</div>
-        <div className="page-intro-copy">
-          <div className="kicker"><Braces size={14} /> Change surface</div>
-          <h1>See the work.<br /><em>Before it lands.</em></h1>
-        </div>
-        <p>A repository-aware view of every staged, unstaged, and untracked file in the workspace Grok is operating on.</p>
-      </section>
+      <PageIntro
+        index="03"
+        className="changes-intro"
+        icon={Braces}
+        eyebrow="Change surface"
+        title={<>See the work.<br /><em>Before it lands.</em></>}
+        description="A repository-aware view of every staged, unstaged, and untracked file in the workspace Grok is operating on."
+      />
 
       <section className="workspace-toolbar">
         <label>

--- a/src/views/ControlView.tsx
+++ b/src/views/ControlView.tsx
@@ -19,6 +19,7 @@ import type {
 } from '../types'
 import { clockTime, compactNumber } from '../format'
 import { usePrivacy } from '../privacy'
+import { PageIntro } from '../shell/primitives'
 import { SessionLaunchForm } from './SessionLaunchForm'
 
 interface ControlViewProps {
@@ -89,14 +90,14 @@ export function ControlView({ data, live, control, onRefresh, onOpenSession }: C
 
   return (
     <>
-      <section className="page-intro command-intro">
-        <div className="page-intro-index">08</div>
-        <div className="page-intro-copy">
-          <div className="kicker"><Command size={14} /> Control</div>
-          <h1>Don’t just watch.<br /><em>Run the room.</em></h1>
-        </div>
-        <p>Launch concurrent Grok agents, resume any conversation, approve sensitive work, and stop a turn without returning to the terminal.</p>
-      </section>
+      <PageIntro
+        index="08"
+        className="command-intro"
+        icon={Command}
+        eyebrow="Control"
+        title={<>Don’t just watch.<br /><em>Run the room.</em></>}
+        description="Launch concurrent Grok agents, resume any conversation, approve sensitive work, and stop a turn without returning to the terminal."
+      />
 
       <section className="control-health-strip">
         <div>

--- a/src/views/FleetView.tsx
+++ b/src/views/FleetView.tsx
@@ -22,6 +22,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { refreshFleetHost } from '../api'
 import { usePrivacy } from '../privacy'
+import { PageIntro } from '../shell/primitives'
 import type { FleetHostView, FleetSnapshot, SessionRow } from '../types'
 import { HostEditor } from './fleet/HostEditor'
 import {
@@ -161,18 +162,14 @@ export function FleetView({
 
   return (
     <>
-      <header className="page-intro fleet-intro">
-        <div className="intro-index">07</div>
-        <div>
-          <div className="kicker"><Network size={14} /> Multi-machine monitoring</div>
-          <h1>Every host.<br /><em>One quiet orbit.</em></h1>
-        </div>
-        <p>
-          Monitor every trusted host, then continue opted-in Grok Build sessions through
-          an authenticated Tailscale or SSH connection.
-        </p>
-        <div className="intro-rule"><span /></div>
-      </header>
+      <PageIntro
+        index="07"
+        className="fleet-intro"
+        icon={Network}
+        eyebrow="Multi-machine monitoring"
+        title={<>Every host.<br /><em>One quiet orbit.</em></>}
+        description="Monitor every trusted host, then continue opted-in Grok Build sessions through an authenticated Tailscale or SSH connection."
+      />
 
       <section className="fleet-constellation" aria-label="Fleet health summary">
         <div className="constellation-field" aria-hidden="true">

--- a/src/views/ThemesView.tsx
+++ b/src/views/ThemesView.tsx
@@ -1,13 +1,23 @@
 import { ArrowRight, Check } from 'lucide-react'
+import type { HeroDensity } from '../shell/hero'
 import { PageIntro } from '../shell/primitives'
 import { THEMES, type ThemeId } from '../shell/themes'
+
+const HERO_DENSITIES: Array<{ id: HeroDensity; name: string; description: string }> = [
+  { id: 'full', name: 'Full', description: 'Large title and description at the top of each room.' },
+  { id: 'compact', name: 'Compact', description: 'One line per room so tables, rosters, and diffs start higher.' },
+]
 
 export function ThemesView({
   active,
   onSelect,
+  heroDensity,
+  onHeroDensity,
 }: {
   active: ThemeId
   onSelect: (theme: ThemeId) => void
+  heroDensity: HeroDensity
+  onHeroDensity: (density: HeroDensity) => void
 }) {
   return (
     <>
@@ -53,9 +63,38 @@ export function ThemesView({
         })}
       </section>
 
+      <section className="preference-row section-gap" aria-labelledby="hero-density-heading">
+        <div>
+          <span className="kicker">Room headers</span>
+          <h2 id="hero-density-heading">How much header<br /><em>each room shows.</em></h2>
+          <p>Every room header carries the same toggle. This choice is stored on this device.</p>
+        </div>
+        <div className="preference-options" role="group" aria-label="Room header density">
+          {HERO_DENSITIES.map((option) => {
+            const selected = option.id === heroDensity
+            return (
+              <button
+                key={option.id}
+                type="button"
+                className={`preference-option ${selected ? 'is-selected' : ''}`}
+                aria-pressed={selected}
+                onClick={() => onHeroDensity(option.id)}
+              >
+                <span className={`preference-preview preference-preview-${option.id}`} aria-hidden="true">
+                  <i /><i /><i />
+                </span>
+                <strong>{option.name}</strong>
+                <small>{option.description}</small>
+                {selected && <span className="preference-state"><Check size={13} /> Active</span>}
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
       <section className="theme-note">
         <span>LOCAL PREFERENCE</span>
-        <p>Themes are presentation-only and are stored in your browser. Grok session data never leaves the local dashboard.</p>
+        <p>Themes and header density are presentation-only and are stored in your browser. Grok session data never leaves the local dashboard.</p>
       </section>
     </>
   )

--- a/src/views/UsageView.tsx
+++ b/src/views/UsageView.tsx
@@ -20,6 +20,7 @@ import {
   saveUsageBudget,
 } from '../api'
 import { usePrivacy } from '../privacy'
+import { PageIntro } from '../shell/primitives'
 import type {
   UsageGroupDimension,
   UsageBudgetDimension,
@@ -146,18 +147,12 @@ export function UsageView() {
 
   return (
     <>
-      <header className="page-intro">
-        <div className="intro-index">06</div>
-        <div>
-          <div className="kicker">Persistent usage ledger</div>
-          <h1>Know what was used,<br /><em>and how we know.</em></h1>
-        </div>
-        <p>
-          Durable token and cost observations across CLI sessions, managed sessions, and workflow agents,
-          with provenance attached to every value.
-        </p>
-        <div className="intro-rule"><span /></div>
-      </header>
+      <PageIntro
+        index="06"
+        eyebrow="Persistent usage ledger"
+        title={<>Know what was used,<br /><em>and how we know.</em></>}
+        description="Durable token and cost observations across CLI sessions, managed sessions, and workflow agents, with provenance attached to every value."
+      />
 
       <section className="usage-toolbar" aria-label="Usage report controls">
         <div>

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -17,6 +17,7 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 import { controlWorkflow, runControlCommand } from '../api'
 import { usePrivacy } from '../privacy'
+import { PageIntro } from '../shell/primitives'
 import type {
   ControlSnapshot,
   WorkflowControlAction,
@@ -170,15 +171,12 @@ export function WorkflowsView({
 
   return (
     <>
-      <header className="page-intro">
-        <div className="intro-index">02</div>
-        <div>
-          <div className="kicker">Cross-session orchestration</div>
-          <h1>Every run.<br /><em>One command field.</em></h1>
-        </div>
-        <p>Track Grok workflow phases, agent allocation, failures, and recoverable controls across every UI-managed session.</p>
-        <div className="intro-rule"><span /></div>
-      </header>
+      <PageIntro
+        index="02"
+        eyebrow="Cross-session orchestration"
+        title={<>Every run.<br /><em>One command field.</em></>}
+        description="Track Grok workflow phases, agent allocation, failures, and recoverable controls across every UI-managed session."
+      />
 
       <section className="live-summary-strip workflow-summary-strip">
         <div className={`live-summary-metric ${active ? 'live-tone-lime' : 'live-tone-paper'}`}>


### PR DESCRIPTION
Closes the last item from the hero work: a compact header option.

**What it does**

- Every room header carries a toggle at its right edge (`Compact room headers` / `Expand room headers`). One click folds *all* headers to one line: index badge, kicker, and title on a single 44px row (down from ~128px), description hidden. Rosters, tables, and diffs start about 85px higher.
- Themes offers the same preference as a labelled **Room headers** control with Full / Compact cards, next to the theme picker.
- Stored on the device (`localStorage: grok-ui-hero`) like the theme, applied as `data-hero` on `.app-shell` and `.is-compact` on each hero.

**Structural**

- `src/shell/hero.tsx`: density type, storage reader, context + `useHeroDensity()`.
- `PageIntro` gains `icon`, `className`, ReactNode `description`, and the toggle.
- Changes, Control, Fleet, Usage, and Runs move from hand-rolled hero markup to the shared `PageIntro`, so all twelve rooms fold together. Their room-specific kicker classes (`changes-intro`, `command-intro`, `fleet-intro`) are preserved via `className`.
- Toggle is pinned to row 1 / last column so it stays top-right at every breakpoint (it previously would have dropped beside the description on phones).

**Verified**

- New e2e test: toggles on Sessions, asserts height < half, checks `changes-intro` folds too, survives reload, and switches back from the Themes control. Full chromium suite: 27 passed locally.
- Screenshots at 1440, 1100, and 390px for both densities.

Made with [Cursor](https://cursor.com)